### PR TITLE
[Feat] Add verify badge to total emissions

### DIFF
--- a/src/components/company/CompanyEmissions.astro
+++ b/src/components/company/CompanyEmissions.astro
@@ -2,6 +2,7 @@
 import {
   getFormattedReportingPeriod,
   getLatestReportingPeriodWithEmissions,
+  hasVerifiedScope3,
   type CompanyData,
   type Scope3,
 } from '@/data/companyData'
@@ -27,6 +28,7 @@ const scope1And2 = emissions?.scope1And2
 const hasVerifiedScope1 = !!scope1?.metadata?.verifiedBy
 const hasVerifiedScope2 = !!scope2?.metadata?.verifiedBy
 const hasVerifiedScope1And2 = !!scope1And2?.metadata?.verifiedBy
+const verifiedScope3 = hasVerifiedScope3(emissions)
 
 const hasScope1 = !!scope1?.total
 const scope2Emissions = scope2?.mb ?? scope2?.lb ?? scope2?.unknown
@@ -84,9 +86,7 @@ const scopeEmissionsList = [
     title: 'Värdekedjan (scope 3)',
     description: 'Indirekta utsläpp från organisationens värdekedja.',
     value: scope3 ? getScope3Total(scope3) : null,
-    // verified: Boolean(
-    //   emissions.scope3?.calculatedTotalEmissions?.metadata?.verifiedBy,
-    // ),
+    verified: verifiedScope3
   },
 ].flat()
 

--- a/src/components/company/CompanyFacts.astro
+++ b/src/components/company/CompanyFacts.astro
@@ -3,11 +3,13 @@ import {
   getLatestReportingPeriodWithEmissions,
   getLatestReportingPeriodWithEconomy,
   getFormattedReportingPeriod,
+  hasVerifiedScope3,
   type CompanyData,
   type Emissions,
 } from '@/data/companyData'
 import { Card } from '../ui/card'
 import { cn, isNumber } from '@/lib/utils'
+import VerifiedBadge from '../VerifiedBadge.astro'
 
 interface Props {
   company: CompanyData
@@ -49,6 +51,10 @@ function getTotalEmissions(emissions: Emissions) {
 const totalEmissions = latestEmissions?.emissions
   ? getTotalEmissions(latestEmissions.emissions)
   : null
+
+const hasVerifiedAllScopes =
+  !!latestEmissions?.emissions?.scope1And2?.metadata?.verifiedBy &&
+  hasVerifiedScope3(latestEmissions?.emissions)
 ---
 
 <Card class="text-sm" level={1}>
@@ -127,10 +133,7 @@ const totalEmissions = latestEmissions?.emissions
               {latestEmissions
                 ? getFormattedReportingPeriod(latestEmissions)
                 : 'saknas'}
-              {/* {Boolean(
-                latestEmissions.emissions.calculatedTotalEmissions.metadata
-                  .verifiedBy,
-              ) && <VerifiedBadge />} */}
+              {Boolean(hasVerifiedAllScopes) && <VerifiedBadge />}
             </h3>
             <span class="text-muted">(ton CO₂e)</span>
           </div>


### PR DESCRIPTION
## What's Changed
On the company details page, now if all scope 3 categories (that have data) have been verified, then the scope 3 has the verified badge as well. Additionally, if scopes 1, 2 and 3 are all verified, then the total emissions will have a verified badge. 

[Linked Issue](https://github.com/Klimatbyran/beta/issues/238)

### Long Term
This is not the best long term solution, next step would be to move some of this logic on the BE side. There is already an issue set up [here](https://github.com/Klimatbyran/garbo/issues/457) for that change. 

### Impact
Scope 3 and total emissions can now have the verified badge where applicable. Note: if there are no reported scope 3 data points, then neither will have the badge. See examples below: 

#### Scenario 1: 
Scope 1 verified, scope 2 verified and **all reported scope 3 categories have been verified**

![Screenshot 2025-01-13 at 14 20 09](https://github.com/user-attachments/assets/66515b42-a94d-4c0d-b9c4-dece153de6dc)


#### Scenario 2:
Scope 1 verified, scope 2 verified and **no reported scope 3 data** but stated total emissions **are verified**

![Screenshot 2025-01-13 at 14 19 15](https://github.com/user-attachments/assets/1ea61ad1-be75-48ba-b177-b8a780a27738)


#### Scenario 3: 
Scope 1  **not** verified, scope 2 verified and **not all reported scope 3 data has been verified**

![Screenshot 2025-01-13 at 14 20 53](https://github.com/user-attachments/assets/c8ef9811-d2f4-48c3-8aed-32477ffebcd8)

#### Scenario 4: 
Scope 1 verified, scope 2 verified and **no reported scope 3 data** and stated total emissions are **not verified**

![Screenshot 2025-01-13 at 14 22 41](https://github.com/user-attachments/assets/a0845b69-8aba-47ec-847f-0dbba07793b3)
