### PR TITLE
Feat/redirect 302s

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -21,34 +21,31 @@ server {
 
     # 302 Redirects for old URLs
     location /foretag/utslappen/lista {
-        return 302 https://klimatkollen.se/companies;
+        return 301 https://klimatkollen.se/companies;
     }
     location ~^/foretag/[^-]+-(Q\d+)$ {
-        return 302 https://klimatkollen.se/companies/$1;
+        return 301 https://klimatkollen.se/companies/$1;
     }
     location ~^/geografiskt/(koldioxidbudgetarna|klimatplanerna|konsumtionen|elbilarna|laddarna|cyklarna|upphandlingarna|utslappen)/(karta|lista)$ {
-        return 302 https://klimatkollen.se/municipalities;
+        return 301 https://klimatkollen.se/municipalities;
     }
     location ~^/kommun/([^/]+)/framtida-prognos$ {
-        return 302 https://klimatkollen.se/municipalities/$1;
+        return 301 https://klimatkollen.se/municipalities/$1;
     }
     location /om-oss {
-        return 302 https://klimatkollen.se/about;
+        return 301 https://klimatkollen.se/about;
     }
     location /kallor-och-metod {
-        return 302 https://klimatkollen.se/methodology;
+        return 301 https://klimatkollen.se/methodology;
     }
     location /blog {
-        return 302 https://klimatkollen.se/insights;
-    }
-    location /blog {
-        return 302 https://klimatkollen.se/insights;
+        return 301 https://klimatkollen.se/insights;
     }
     location /utslappsberakningar {
-        return 302 https://klimatkollen.se/insights/utslappsberakning;
+        return 301 https://klimatkollen.se/insights/utslappsberakning;
     }
     location /partierna {
-        return 302 https://klimatkollen.se/insights/klimatmal;
+        return 301 https://klimatkollen.se/insights/klimatmal;
     }
     
     # API proxy


### PR DESCRIPTION
### Background
Before we can change the live code to reference the new code, we need to set up 302 redirects from previous url paths, to the new paths to ensure we don't break links.

### What's Changed
Updated [nginx.conf](https://github.com/Klimatbyran/beta/pull/369/files#diff-1f91f64bfa3fb0a1ece881887af0a2356b8c529a96fb91c1894745b2a1a009aa) to set up previous location paths to the new versions. No UX changes as part of this.