### PR TITLE
[503] Localized units on municipalities across page

### DIFF
--- a/src/components/RankedList.tsx
+++ b/src/components/RankedList.tsx
@@ -1,6 +1,7 @@
 import { Building2, TreePine } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Text } from "@/components/ui/text";
+import { localizeUnit } from "@/utils/localizeUnit";
 
 interface RankedListProps {
   title: string;
@@ -69,7 +70,7 @@ export function RankedList({
                     textColor
                   )}
                 >
-                  {item.displayValue || item.value.toFixed(1)}
+                  {localizeUnit(item.value) || item.value.toFixed(1)}
                 </span>
                 <span className={cn("text-grey", unit !== "%" && "ml-2")}>
                   {unit}

--- a/src/components/municipalities/MunicipalityStatCard.tsx
+++ b/src/components/municipalities/MunicipalityStatCard.tsx
@@ -1,6 +1,7 @@
 import { Text } from "@/components/ui/text";
 import { cn } from "@/lib/utils";
 
+
 interface StatCardProps {
   title: string;
   value: string | number;

--- a/src/components/municipalities/list/MunicipalityCard.tsx
+++ b/src/components/municipalities/list/MunicipalityCard.tsx
@@ -5,18 +5,21 @@ import { Text } from "@/components/ui/text";
 import { cn } from "@/lib/utils";
 import type { Municipality } from "@/types/municipality";
 import { CardInfo } from "./MunicipalityCardInfo";
+import { localizeUnit } from "@/utils/localizeUnit";
+
 
 interface MunicipalityCardProps {
   municipality: Municipality;
 }
 
+
 export function MunicipalityCard({ municipality }: MunicipalityCardProps) {
   const { t } = useTranslation();
   const meetsParis = municipality.budgetRunsOut === "Håller budget";
-
+  
   const lastYearEmission = municipality.approximatedHistoricalEmission.at(-1);
   const lastYearEmissionsKtons = lastYearEmission
-    ? (lastYearEmission.value / 1000).toFixed(1)
+    ? localizeUnit(lastYearEmission.value / 1000)
     : t("municipalities.card.noData");
   const lastYear = lastYearEmission?.year.toString();
 

--- a/src/pages/MunicipalityDetailPage.tsx
+++ b/src/pages/MunicipalityDetailPage.tsx
@@ -10,6 +10,7 @@ import { MunicipalityLinkCard } from "@/components/municipalities/MunicipalityLi
 import { useTranslation } from "react-i18next";
 import { PageSEO } from "@/components/SEO/PageSEO";
 import { useEffect } from "react";
+import { localizeUnit } from "@/utils/localizeUnit";
 
 export function MunicipalityDetailPage() {
   const { t } = useTranslation();
@@ -36,7 +37,7 @@ export function MunicipalityDetailPage() {
   const lastYearEmissions = municipality.approximatedHistoricalEmission.at(-1);
   const lastYear = lastYearEmissions?.year;
   const lastYearEmissionsKTon = lastYearEmissions
-    ? (lastYearEmissions.value / 1000).toFixed(1)
+    ? localizeUnit(lastYearEmissions.value / 1000)
     : "N/A";
 
   // Prepare SEO data
@@ -184,9 +185,7 @@ export function MunicipalityDetailPage() {
           items={[
             {
               title: t("municipalityDetailPage.annualChangeSince2015"),
-              value: `${municipality.historicalEmissionChangePercent.toFixed(
-                1
-              )}%`,
+              value: `${localizeUnit(municipality.historicalEmissionChangePercent)}%`,
               valueClassName: cn(
                 Math.abs(municipality.historicalEmissionChangePercent) >=
                   municipality.neededEmissionChangePercent
@@ -196,12 +195,12 @@ export function MunicipalityDetailPage() {
             },
             {
               title: t("municipalityDetailPage.reductionToMeetParis"),
-              value: `-${municipality.neededEmissionChangePercent.toFixed(1)}%`,
+              value: `-${localizeUnit(municipality.neededEmissionChangePercent)}%`,
               valueClassName: "text-green-3",
             },
             {
               title: t("municipalityDetailPage.consumptionEmissionsPerCapita"),
-              value: (municipality.totalConsumptionEmission / 1000).toFixed(1),
+              value: (localizeUnit(municipality.totalConsumptionEmission / 1000)),
               valueClassName: "text-orange-2",
             },
           ]}
@@ -245,15 +244,13 @@ export function MunicipalityDetailPage() {
           items={[
             {
               title: t("municipalityDetailPage.electricCarChange"),
-              value: `${(municipality.electricCarChangePercent * 100).toFixed(
-                1
-              )}%`,
+              value: `${localizeUnit(municipality.electricCarChangePercent * 100)}%`,
               valueClassName: "text-orange-2",
             },
             {
               title: t("municipalityDetailPage.electricCarsPerChargePoint"),
               value: municipality.electricVehiclePerChargePoints
-                ? municipality.electricVehiclePerChargePoints.toFixed(1)
+                ? localizeUnit(municipality.electricVehiclePerChargePoints)
                 : t("municipalityDetailPage.noChargePoints"),
               valueClassName: municipality.electricVehiclePerChargePoints
                 ? "text-green-3"
@@ -261,7 +258,7 @@ export function MunicipalityDetailPage() {
             },
             {
               title: t("municipalityDetailPage.bicycleMetrePerCapita"),
-              value: municipality.bicycleMetrePerCapita.toFixed(1),
+              value: localizeUnit(municipality.electricVehiclePerChargePoints),
               valueClassName: "text-orange-2",
             },
           ]}

--- a/src/utils/localizeUnit.ts
+++ b/src/utils/localizeUnit.ts
@@ -1,0 +1,12 @@
+import { useLanguage } from "@/components/LanguageProvider";
+
+export const localizeUnit = (unit: number) => {
+    const { currentLanguage } = useLanguage();
+
+    return unit.toLocaleString(
+        currentLanguage === 'sv'
+        ? 'sv-SE'
+        : 'en-US',
+        { minimumFractionDigits: 1, maximumFractionDigits: 1 }
+    )
+}


### PR DESCRIPTION
Have localized units (commas & dots) depending on language. Haven't been able to do the same on the companies yet as my local environment won't load the companies for some reason. Feedback much appreciated! 