### PR TITLE
[504] Tooltip clipping on company cards & card hover effects

### DIFF
--- a/src/components/companies/list/CompanyCard.tsx
+++ b/src/components/companies/list/CompanyCard.tsx
@@ -80,7 +80,7 @@ export function CompanyCard({
     <div className="relative rounded-level-2">
       <Link
         to={`/companies/${wikidataId}`}
-        className="block bg-black-2 rounded-level-2 p-8 space-y-8 transition-all duration-300 hover:shadow-[0_0_30px_rgba(153,207,255,0.15)] hover:bg-[#1a1a1a]"
+        className="block bg-black-2 rounded-level-2 p-8 space-y-8 transition-all duration-300 hover:shadow-[0_0_10px_rgba(153,207,255,0.15)] hover:bg-[#1a1a1a]"
       >
         <div className="flex items-start justify-between rounded-level-2">
           <div className="space-y-2">

--- a/src/components/companies/list/SectionedCompanyList.tsx
+++ b/src/components/companies/list/SectionedCompanyList.tsx
@@ -98,9 +98,9 @@ export function SectionedCompanyList({
                   {sectorCompanies.map((company) => (
                     <div
                       key={company.wikidataId}
-                      className="group overflow-hidden rounded-level-2"
+                      className="block rounded-level-2"
                     >
-                      <div className="transition-all duration-300 group-hover:scale-[1.02] group-hover:shadow-[0_0_30px_rgba(153,207,255,0.15)]">
+                      <div>
                         <CompanyCard {...company} />
                       </div>
                     </div>

--- a/src/components/municipalities/list/MunicipalityCard.tsx
+++ b/src/components/municipalities/list/MunicipalityCard.tsx
@@ -35,7 +35,7 @@ export function MunicipalityCard({ municipality }: MunicipalityCardProps) {
   return (
     <Link
       to={`/municipalities/${municipality.name}`}
-      className="block bg-black-2 rounded-level-2 p-8 space-y-8 hover:bg-black-1/80 transition-colors"
+      className="block bg-black-2 rounded-level-2 p-8 space-y-8 transition-all duration-300 hover:shadow-[0_0_10px_rgba(153,207,255,0.15)] hover:bg-[#1a1a1a]"
     >
       <div className="space-y-6">
         <h2 className="text-3xl font-light">{municipality.name}</h2>

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import * as TooltipPrimitive from '@radix-ui/react-tooltip';
-
 import { cn } from '@/lib/utils';
 
 const TooltipProvider = TooltipPrimitive.Provider;


### PR DESCRIPTION
Tooltip no longer clips on compant cards on hover on desktop. Also added so that municipality and company cards have the same on hover effects. Hade to remove scaling on hover to be able to remove overflow-hidden for now.