### PR TITLE
[535] Switched category "Årsrapport" to "Rapport" and changed title of article per request

### DIFF
--- a/src/lib/constants/reports.ts
+++ b/src/lib/constants/reports.ts
@@ -1,12 +1,12 @@
 export const reports = [
   {
     id: 1,
-    title: "Storföretagens Historiska Utsläpp",
+    title: "Storföretagens historiska utsläpp",
     slug: "storföretagens-historiska-utsläpp",
     date: "2025-03-11",
     excerpt: "En analys av 150 bolags klimatredovisningar",
     readTime: "15 min",
-    category: "Årsrapport",
+    category: "Rapport",
     author: {
       name: "Alexandra Palmquist",
       avatar: "/people/alex.jpg",


### PR DESCRIPTION
Switched category "Årsrapport" to "Rapport" and changed title of the article "Storföretagens historiska utsläpp" per request.