### PR TITLE
[544] Added total emissions to Scope 1-3 view on emissions chart

### DIFF
--- a/src/components/companies/detail/CustomTooltip.tsx
+++ b/src/components/companies/detail/CustomTooltip.tsx
@@ -43,9 +43,15 @@ export const CustomTooltip = ({
               : `${localizeUnit(Math.round(entry.value), currentLanguage)} ${t(
                   "companies.tooltip.tonsCO2e"
                 )}`;
-                
+
+          const totalEmissions = entry.payload?.scope1 + entry.payload?.scope2 + entry.payload?.scope3
+          console.log(totalEmissions)
+
+          console.log(totalEmissions)
+          // perhaps adding the scopes together manually. Or pass a custom variable for view scopes 1-3.    
           return (
             <div key={entry.dataKey} className={`${entry.name === 'Total' ? 'my-2' : 'my-0'} text-grey mr-2 text-sm`}>
+              <span>{totalEmissions}</span>
               <span className="text-grey mr-2">{name}:</span>
               <span style={{ color: entry.color }}>{displayValue}</span>
             </div>

--- a/src/components/companies/detail/CustomTooltip.tsx
+++ b/src/components/companies/detail/CustomTooltip.tsx
@@ -34,6 +34,7 @@ export const CustomTooltip = ({
 
           // Extract the original value from payload
           const originalValue = entry.payload?.originalValues?.[entry.dataKey];
+          console.log(entry)
 
           // Correctly display "No Data Available" if original value was null
           const displayValue =
@@ -42,9 +43,9 @@ export const CustomTooltip = ({
               : `${localizeUnit(Math.round(entry.value), currentLanguage)} ${t(
                   "companies.tooltip.tonsCO2e"
                 )}`;
-
+                
           return (
-            <div key={entry.dataKey} className="text-sm">
+            <div key={entry.dataKey} className={`${entry.name === 'Total' ? 'my-2' : 'my-0'} text-grey mr-2 text-sm`}>
               <span className="text-grey mr-2">{name}:</span>
               <span style={{ color: entry.color }}>{displayValue}</span>
             </div>

--- a/src/components/companies/detail/CustomTooltip.tsx
+++ b/src/components/companies/detail/CustomTooltip.tsx
@@ -19,7 +19,22 @@ export const CustomTooltip = ({
   const { currentLanguage} = useLanguage();
 
   if (active && payload && payload.length) {
-  
+    
+    if (payload.length === 3) {
+      const totalEmissions = payload[0]?.payload.total;
+      
+      const companyTotal = {
+        dataKey: 'total',
+        name: 'Total',
+        color: "white",
+        payload: {
+          total: totalEmissions,
+        },
+        value: totalEmissions,
+      }
+      payload = [companyTotal, ...payload]
+    }
+    
     return (
       <div className="bg-black-1 px-4 py-3 rounded-level-2">
         <div className="text-sm font-medium mb-2">{label}</div>
@@ -34,7 +49,6 @@ export const CustomTooltip = ({
 
           // Extract the original value from payload
           const originalValue = entry.payload?.originalValues?.[entry.dataKey];
-          console.log(entry)
 
           // Correctly display "No Data Available" if original value was null
           const displayValue =
@@ -44,14 +58,8 @@ export const CustomTooltip = ({
                   "companies.tooltip.tonsCO2e"
                 )}`;
 
-          const totalEmissions = entry.payload?.scope1 + entry.payload?.scope2 + entry.payload?.scope3
-          console.log(totalEmissions)
-
-          console.log(totalEmissions)
-          // perhaps adding the scopes together manually. Or pass a custom variable for view scopes 1-3.    
           return (
             <div key={entry.dataKey} className={`${entry.name === 'Total' ? 'my-2' : 'my-0'} text-grey mr-2 text-sm`}>
-              <span>{totalEmissions}</span>
               <span className="text-grey mr-2">{name}:</span>
               <span style={{ color: entry.color }}>{displayValue}</span>
             </div>

--- a/src/components/companies/detail/EmissionsHistory.tsx
+++ b/src/components/companies/detail/EmissionsHistory.tsx
@@ -187,9 +187,11 @@ export function EmissionsHistory({
               </>
             )}
 
+
+            
             {dataView === "scopes" && (
               <>
-              {!hiddenScopes.includes("scope3") && (
+{/*               {!hiddenScopes.includes("scope3") && (
                 <Line
                   type="monotone"
                   dataKey="total"
@@ -199,7 +201,7 @@ export function EmissionsHistory({
                   activeDot={{ r: 6, fill: "white", cursor: "pointer" }}
                   name="Total"
                 />
-              )}
+              )} */}
                 {!hiddenScopes.includes("scope1") && (
                   <Line
                     type="monotone"

--- a/src/components/companies/detail/EmissionsHistory.tsx
+++ b/src/components/companies/detail/EmissionsHistory.tsx
@@ -189,6 +189,17 @@ export function EmissionsHistory({
 
             {dataView === "scopes" && (
               <>
+              {!hiddenScopes.includes("scope3") && (
+                <Line
+                  type="monotone"
+                  dataKey="total"
+                  stroke="white"
+                  strokeWidth={2}
+                  dot={{ r: 4, fill: "white", cursor: "pointer"}}
+                  activeDot={{ r: 6, fill: "white", cursor: "pointer" }}
+                  name="Total"
+                />
+              )}
                 {!hiddenScopes.includes("scope1") && (
                   <Line
                     type="monotone"


### PR DESCRIPTION
Added total emissions to Scope 1-3 view on emissions history chart and is only shown when all three categories are viewed. Couldn't figure about a better way to do it without having to draw another line on the chart. Feedback much appreciated! 

