### PR TITLE
[feat] Added base year and base year info to emissions history and tooltip

### DIFF
--- a/src/components/companies/detail/CompanyHistory.tsx
+++ b/src/components/companies/detail/CompanyHistory.tsx
@@ -8,7 +8,7 @@ interface CompanyHistoryProps {
 export function CompanyHistory({ company }: CompanyHistoryProps) {
   return (
     <>
-      <EmissionsHistory reportingPeriods={company.reportingPeriods} />
+      <EmissionsHistory reportingPeriods={company.reportingPeriods} baseYear={company.baseYear} />
     </>
   );
 }

--- a/src/components/companies/detail/CompanyOverview.tsx
+++ b/src/components/companies/detail/CompanyOverview.tsx
@@ -42,7 +42,6 @@ export function CompanyOverview({
   const navigate = useNavigate();
   const sectorNames = useSectorNames();
   const { currentLanguage } = useLanguage();
-  
   const periodYear = new Date(selectedPeriod.endDate).getFullYear();
 
   // Get the translated sector name using the sector code

--- a/src/components/companies/detail/CustomTooltip.tsx
+++ b/src/components/companies/detail/CustomTooltip.tsx
@@ -7,19 +7,21 @@ interface CustomTooltipProps {
   active?: boolean;
   payload?: any[];
   label?: string;
+  companyBaseYear: number;
 }
 
 export const CustomTooltip = ({
   active,
   payload,
   label,
+  companyBaseYear,
 }: CustomTooltipProps) => {
   const { t } = useTranslation();
   const { getCategoryName } = useCategoryMetadata();
   const { currentLanguage} = useLanguage();
 
   if (active && payload && payload.length) {
-  
+    console.log(payload)
     return (
       <div className="bg-black-1 px-4 py-3 rounded-level-2">
         <div className="text-sm font-medium mb-2">{label}</div>
@@ -44,9 +46,19 @@ export const CustomTooltip = ({
                 )}`;
 
           return (
-            <div key={entry.dataKey} className="text-sm">
+            <div key={entry.dataKey} className="text-sm max-w-[320px]">
               <span className="text-grey mr-2">{name}:</span>
               <span style={{ color: entry.color }}>{displayValue}</span>
+              {
+                entry.payload.year === companyBaseYear
+                ? 
+                  <span className="text-grey mr-2">
+                    <br></br><br></br>
+                    The base year refers to a specific year chosen as a reference point against which future emissions are compared.
+                  </span>
+                : null
+                
+              }
             </div>
           );
         })}

--- a/src/components/companies/detail/CustomTooltip.tsx
+++ b/src/components/companies/detail/CustomTooltip.tsx
@@ -7,7 +7,7 @@ interface CustomTooltipProps {
   active?: boolean;
   payload?: any[];
   label?: string;
-  companyBaseYear: number;
+  companyBaseYear: number | undefined;
 }
 
 export const CustomTooltip = ({

--- a/src/components/companies/detail/EmissionsHistory.tsx
+++ b/src/components/companies/detail/EmissionsHistory.tsx
@@ -184,7 +184,8 @@ export function EmissionsHistory({
                     fontWeight={`${isBaseYear ? 'bold' : 'normal' }`}
                   >
                     {payload.value}
-                  </text>     
+                  </text>
+                  
                 )
               }}
               padding={{ left: 0, right: 0 }}
@@ -199,7 +200,7 @@ export function EmissionsHistory({
               padding={{ top: 0, bottom: 0 }}
               tickFormatter={(value) => new Intl.NumberFormat(currentLanguage === 'sv' ? 'sv-SE' : 'en-US').format(value)}
             />
-            <Tooltip content={<CustomTooltip />} />
+            <Tooltip content={<CustomTooltip companyBaseYear={companyBaseYear} />} />
 
             {dataView === "overview" && (
               <>

--- a/src/components/companies/detail/EmissionsHistory.tsx
+++ b/src/components/companies/detail/EmissionsHistory.tsx
@@ -6,6 +6,7 @@ import {
   XAxis,
   YAxis,
   Tooltip,
+  ReferenceLine
 } from "recharts";
 import { Info, X } from "lucide-react";
 import {
@@ -31,6 +32,7 @@ export function EmissionsHistory({
   reportingPeriods,
   onYearSelect,
   className,
+  baseYear,
   features = {
     interpolateScope3: true,
     guessBaseYear: true,
@@ -52,7 +54,6 @@ export function EmissionsHistory({
     );
   }
   const isMobile = useScreenSize();
-
   const { currentLanguage } = useLanguage();
 
   const hasScope3Categories = useMemo(
@@ -69,6 +70,8 @@ export function EmissionsHistory({
     }
     return "overview";
   });
+
+  const companyBaseYear = baseYear?.year;
 
   // Only interpolate if the feature is enabled
   const processedPeriods = useMemo(
@@ -116,6 +119,7 @@ export function EmissionsHistory({
     });
   };
 
+
   return (
     <div
       className={cn("bg-black-2 rounded-level-1 px-4 md:px-16 py-8", className)}
@@ -152,12 +156,31 @@ export function EmissionsHistory({
             margin={{ top: 10, right: 10, left: 0, bottom: 10 }}
             onClick={handleClick}
           >
+            <ReferenceLine 
+              x={companyBaseYear} 
+              stroke="#878787" 
+              strokeDasharray="5 5" 
+            />
             <XAxis
               dataKey="year"
               stroke="#878787"
               tickLine={false}
               axisLine={true}
-              tick={{ fontSize: 12 }}
+              tick={({ x, y, payload }) => {
+                const isBaseYear = payload.value === companyBaseYear;
+                return (
+                  <text
+                    x={x - 15}
+                    y={y + 10}
+                    fontSize={12}
+                    fill={`${isBaseYear ? 'white' : '#878787' }`}
+                    fontWeight={`${isBaseYear ? 'bold' : 'normal' }`}
+                  >
+                    {payload.value}
+                  </text>
+                  
+                )
+              }}
               padding={{ left: 0, right: 0 }}
             />
             <YAxis

--- a/src/components/companies/detail/EmissionsHistory.tsx
+++ b/src/components/companies/detail/EmissionsHistory.tsx
@@ -153,13 +153,20 @@ export function EmissionsHistory({
         <ResponsiveContainer width="100%" height="100%" className="w-full">
           <LineChart
             data={chartData}
-            margin={{ top: 10, right: 10, left: 0, bottom: 10 }}
+            margin={{ top: 20, right: 20, left: 10, bottom: 10 }}
             onClick={handleClick}
           >
             <ReferenceLine 
+              label={{
+                value: 'Base year',
+                position: "top",
+                fill: "white",
+                fontSize: 12,
+                fontWeight: "normal",
+              }}
               x={companyBaseYear} 
               stroke="#878787" 
-              strokeDasharray="5 5" 
+              strokeDasharray="4 4" 
             />
             <XAxis
               dataKey="year"
@@ -177,8 +184,7 @@ export function EmissionsHistory({
                     fontWeight={`${isBaseYear ? 'bold' : 'normal' }`}
                   >
                     {payload.value}
-                  </text>
-                  
+                  </text>     
                 )
               }}
               padding={{ left: 0, right: 0 }}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -562,7 +562,9 @@
       "title": "Historical Emissions",
       "tooltip": "Historical emissions; click on a point to remove the line from the graph. Hover over a point to see the values for the reporting period.",
       "unit": "Tons CO₂e per year",
-      "totalEmissions": "Total Emissions"
+      "totalEmissions": "Total Emissions",
+      "baseYear": "Base year",
+      "baseYearInfo": "The base year refers to a specific year chosen as a reference point against which future emissions are compared."
     },
     "list": {
       "error": {

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -570,7 +570,9 @@
       "title": "Historiska utsläpp",
       "tooltip": "Historiska utsläpp och trend mot 2030. Klicka på en punkt för att ta bort linjen från grafen. Hovra över punkten för att se värdena för rapporteringsperioden.",
       "unit": "Ton CO₂e per år",
-      "totalEmissions": "Totala utsläpp"
+      "totalEmissions": "Totala utsläpp",
+      "baseYear": "Basår",
+      "baseYearInfo": "Basår syftar på ett specifikt år som väljs som referenspunkt för att jämföra framtida utsläpp mot."
     },
     "list": {
       "error": {

--- a/src/types/emissions.ts
+++ b/src/types/emissions.ts
@@ -22,6 +22,7 @@ export interface EmissionsHistoryProps {
   onYearSelect?: (year: string) => void;
   className?: string;
   features?: EmissionsFeatures;
+  baseYear?: { id: string; year: number; metadata: { id: string; comment: string | null; source: string | null; updatedAt: string; user: { name: string; }; verifiedBy: { name: string; } | null; }; } | null
 }
 
 export type DataView = "overview" | "scopes" | "categories";


### PR DESCRIPTION
### ✨ What’s Changed?

This PR adds the company baseyear to the emissions history chart as well as an explanation for what a base year is in both Swedish and English. baseYear is passed as props to emissionsHistory and from there to customTooltip. Right now passing the entire object, but perhaps only neccesary to pass the year itself?

### 📸 Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/91557264-cf1a-438a-9481-82650706fd3b)

### 📋 Checklist

- [x] PR title starts with [#issue-number], [fix], or [feat]
- [x] I've verified the change runs locally
- [ ] I've created sub-tasks or follow-up issues for anything not included in this PR but are necessary for the change as a whole
- [ ] I've set the labels, issue, and milestone for the PR

### 🛠 Related Issue

Closes #[407](https://github.com/Klimatbyran/frontend/issues/407) 