### PR TITLE
[fix] Don't shrink the width of category icons

### DIFF
--- a/src/components/companies/list/CompanyCard.tsx
+++ b/src/components/companies/list/CompanyCard.tsx
@@ -130,7 +130,7 @@ export function CompanyCard({
             <p className="text-grey text-sm line-clamp-2">{description}</p>
           </div>
           <div
-            className="w-12 h-12 rounded-full flex items-center justify-center"
+            className="w-12 h-12 rounded-full flex shrink-0 items-center justify-center"
             style={{
               backgroundColor: `color-mix(in srgb, ${categoryColor} 30%, transparent)`,
               color: categoryColor,


### PR DESCRIPTION
### ✨ What’s Changed?

Minor UI fix to avoid the category icon shrinking.

### 📸 Screenshots (if applicable)

Before:
<img width="528" alt="image" src="https://github.com/user-attachments/assets/32af0dea-a332-4c0d-a8a7-94b2e2ee4cf4" />

After:
<img width="528" alt="image" src="https://github.com/user-attachments/assets/825cc0f3-687b-4a19-9da1-2b5491b80597" />

<!-- Add before/after images or UI previews -->


### 📋 Checklist

- [x] PR title starts with [#issue-number], [fix], or [feat]
- [x] I've verified the change runs locally
- [ ] I've created sub-tasks or follow-up issues for anything not included in this PR but are necessary for the change as a whole
- [ ] I've set the labels, issue, and milestone for the PR

### 🛠 Related Issue

Closes #[issue-number] <!-- or: Related to #[issue-number] -->