### PR TITLE
[fix] Display employees without fractions

### DIFF
--- a/src/components/companies/detail/CompanyOverview.tsx
+++ b/src/components/companies/detail/CompanyOverview.tsx
@@ -17,7 +17,7 @@ import { useNavigate } from "react-router-dom";
 import { Pen } from "lucide-react";
 import { useSectorNames, SectorCode } from "@/hooks/companies/useCompanyFilters";
 import { useLanguage } from "@/components/LanguageProvider";
-import { localizeUnit } from "@/utils/localizeUnit";
+import { localizeNumber, localizeUnit } from "@/utils/localizeUnit";
 import { cn } from "@/lib/utils";
 
 interface CompanyOverviewProps {
@@ -66,6 +66,11 @@ export function CompanyOverview({
   const sortedPeriods = [...company.reportingPeriods].sort(
     (a, b) => new Date(b.endDate).getTime() - new Date(a.endDate).getTime()
   );
+
+  const formattedEmployeeCount = selectedPeriod.economy?.employees?.value
+    ? localizeNumber(selectedPeriod.economy.employees.value, currentLanguage, { maximumFractionDigits: 0 })
+    : t("companies.overview.notReported")
+
 
   return (
     <div className="bg-black-2 rounded-level-1 p-16">
@@ -222,11 +227,7 @@ export function CompanyOverview({
             <Text className="text-base md:text-base sm:text-sm mb-2">
               {t("companies.overview.employees")} ({periodYear})
             </Text>
-            <Text className="text-base md:text-base sm:text-sm">
-              {selectedPeriod.economy?.employees?.value
-                ? localizeUnit(selectedPeriod.economy.employees.value, currentLanguage)
-                : t("companies.overview.notReported")}
-            </Text>
+            <Text className="text-base md:text-base sm:text-sm">{formattedEmployeeCount}</Text>
           </div>
 
           {selectedPeriod?.reportURL && (

--- a/src/components/companies/detail/CompanyOverview.tsx
+++ b/src/components/companies/detail/CompanyOverview.tsx
@@ -17,7 +17,7 @@ import { useNavigate } from "react-router-dom";
 import { Pen } from "lucide-react";
 import { useSectorNames, SectorCode } from "@/hooks/companies/useCompanyFilters";
 import { useLanguage } from "@/components/LanguageProvider";
-import { localizeNumber, localizeUnit } from "@/utils/localizeUnit";
+import { localizeEmployeeCount, localizeUnit } from "@/utils/localizeUnit";
 import { cn } from "@/lib/utils";
 
 interface CompanyOverviewProps {
@@ -68,7 +68,7 @@ export function CompanyOverview({
   );
 
   const formattedEmployeeCount = selectedPeriod.economy?.employees?.value
-    ? localizeNumber(selectedPeriod.economy.employees.value, currentLanguage, { maximumFractionDigits: 0 })
+    ? localizeEmployeeCount(selectedPeriod.economy.employees.value, currentLanguage)
     : t("companies.overview.notReported")
 
 

--- a/src/components/companies/list/CompanyCard.tsx
+++ b/src/components/companies/list/CompanyCard.tsx
@@ -24,7 +24,7 @@ import { useScreenSize } from "@/hooks/useScreenSize";
 import { useTranslation } from "react-i18next";
 import { useCategoryMetadata } from "@/hooks/companies/useCategories";
 import { useLanguage } from "@/components/LanguageProvider";
-import { localizeUnit } from "@/utils/localizeUnit";
+import { localizeNumber, localizeUnit } from "@/utils/localizeUnit";
 
 type CompanyCardProps = Pick<
   RankedCompany,
@@ -63,7 +63,7 @@ export function CompanyCard({
 
   const employeeCount = latestPeriod?.economy?.employees?.value;
   const formattedEmployeeCount = employeeCount
-    ? localizeUnit(employeeCount, currentLanguage)
+    ? localizeNumber(employeeCount, currentLanguage, { maximumFractionDigits: 0 })
     : t("companies.card.noData");
 
   const sectorName = industry?.industryGics?.sectorCode

--- a/src/components/companies/list/CompanyCard.tsx
+++ b/src/components/companies/list/CompanyCard.tsx
@@ -24,7 +24,7 @@ import { useScreenSize } from "@/hooks/useScreenSize";
 import { useTranslation } from "react-i18next";
 import { useCategoryMetadata } from "@/hooks/companies/useCategories";
 import { useLanguage } from "@/components/LanguageProvider";
-import { localizeNumber, localizeUnit } from "@/utils/localizeUnit";
+import { localizeEmployeeCount, localizeUnit } from "@/utils/localizeUnit";
 
 type CompanyCardProps = Pick<
   RankedCompany,
@@ -63,7 +63,7 @@ export function CompanyCard({
 
   const employeeCount = latestPeriod?.economy?.employees?.value;
   const formattedEmployeeCount = employeeCount
-    ? localizeNumber(employeeCount, currentLanguage, { maximumFractionDigits: 0 })
+    ? localizeEmployeeCount(employeeCount, currentLanguage)
     : t("companies.card.noData");
 
   const sectorName = industry?.industryGics?.sectorCode

--- a/src/components/companies/list/CompanyList.tsx
+++ b/src/components/companies/list/CompanyList.tsx
@@ -11,7 +11,7 @@ import {
 import { useTranslation } from "react-i18next";
 import { useCategoryMetadata } from "@/hooks/companies/useCategories";
 import { useLanguage } from "@/components/LanguageProvider";
-import { localizeUnit } from "@/utils/localizeUnit";
+import { localizeNumber, localizeUnit } from "@/utils/localizeUnit";
 
 type SortOption = "emissions" | "turnover" | "employees" | "name";
 
@@ -178,7 +178,7 @@ export function CompanyList() {
                       </span>
                     </div>
                     <div className="text-lg font-light">
-                      {localizeUnit(employees.value, currentLanguage)}
+                      {localizeNumber(employees.value, currentLanguage, { maximumFractionDigits: 0 })}
                     </div>
                   </div>
                 )}

--- a/src/components/companies/list/CompanyList.tsx
+++ b/src/components/companies/list/CompanyList.tsx
@@ -11,7 +11,7 @@ import {
 import { useTranslation } from "react-i18next";
 import { useCategoryMetadata } from "@/hooks/companies/useCategories";
 import { useLanguage } from "@/components/LanguageProvider";
-import { localizeNumber, localizeUnit } from "@/utils/localizeUnit";
+import { localizeEmployeeCount, localizeUnit } from "@/utils/localizeUnit";
 
 type SortOption = "emissions" | "turnover" | "employees" | "name";
 
@@ -178,7 +178,7 @@ export function CompanyList() {
                       </span>
                     </div>
                     <div className="text-lg font-light">
-                      {localizeNumber(employees.value, currentLanguage, { maximumFractionDigits: 0 })}
+                      {localizeEmployeeCount(employees.value, currentLanguage)}
                     </div>
                   </div>
                 )}

--- a/src/utils/localizeUnit.ts
+++ b/src/utils/localizeUnit.ts
@@ -18,9 +18,13 @@ const defaultNumberFormatOptions = {
   maximumFractionDigits: 1
 }
 
-export const localizeNumber = (nr: number,
+const localizeNumber = (nr: number,
   currentLanguage: SupportedLanguage,
   options: Intl.NumberFormatOptions = defaultNumberFormatOptions) => {
 
   return new Intl.NumberFormat(currentLanguage === 'sv' ? 'sv-SE' : 'en-US', options).format(nr)
 }
+
+export const localizeEmployeeCount = (count: number, currentLanguage: SupportedLanguage) =>
+  localizeNumber(count, currentLanguage, { maximumFractionDigits: 0 })
+

--- a/src/utils/localizeUnit.ts
+++ b/src/utils/localizeUnit.ts
@@ -1,21 +1,26 @@
-export const localizeUnit = (unit: number | Date, currentLanguage: string) => {
-    
-    const formatNumber = (num: number) => num.toLocaleString(
-      currentLanguage === 'sv' 
-      ? 'sv-SE' 
-      : 'en-US',
-      { minimumFractionDigits: 1, maximumFractionDigits: 1 }
-    );
-  
-    if (typeof unit === 'number') {
-      return formatNumber(unit);
-    }
+import { SupportedLanguage } from "@/lib/languageDetection";
 
-    if (unit instanceof Date) {
-      return new Intl.DateTimeFormat(
-        currentLanguage === 'sv' ? 'sv-SE' : 'en-US',
-        { dateStyle: 'short' }
-      ).format(unit);
-    }
+export const localizeUnit = (unit: number | Date, currentLanguage: SupportedLanguage) => {
+  if (typeof unit === 'number') {
+    return localizeNumber(unit, currentLanguage)
   }
-  
+
+  if (unit instanceof Date) {
+    return new Intl.DateTimeFormat(
+      currentLanguage === 'sv' ? 'sv-SE' : 'en-US',
+      { dateStyle: 'short' }
+    ).format(unit);
+  }
+}
+
+const defaultNumberFormatOptions = {
+  minimumFractionDigits: 1,
+  maximumFractionDigits: 1
+}
+
+export const localizeNumber = (nr: number,
+  currentLanguage: SupportedLanguage,
+  options: Intl.NumberFormatOptions = defaultNumberFormatOptions) => {
+
+  return new Intl.NumberFormat(currentLanguage === 'sv' ? 'sv-SE' : 'en-US', options).format(nr)
+}


### PR DESCRIPTION
### ✨ What’s Changed?
Extracted a localizeNumber function from localizeUnit to allow for better control of the formatter options. In this case to render employees without fractions.

### 📸 Screenshots (if applicable)

Before:
<img width="509" alt="image" src="https://github.com/user-attachments/assets/050d8abb-8d11-4bfe-963c-9c757476596d" />

After:
<img width="509" alt="image" src="https://github.com/user-attachments/assets/ef9a5971-5446-454b-bf12-cef6ff30c837" />

<img width="238" alt="image" src="https://github.com/user-attachments/assets/a85c7ba1-0898-4f02-98df-5791626d719b" />

### 📋 Checklist

- [x] PR title starts with [#issue-number], [fix], or [feat]
- [x] I've verified the change runs locally
- [ ] I've created sub-tasks or follow-up issues for anything not included in this PR but are necessary for the change as a whole
- [ ] I've set the labels, issue, and milestone for the PR

### 🛠 Related Issue

Closes #[issue-number] <!-- or: Related to #[issue-number] -->