### PR TITLE
[fix] Align columns in RankedList

### DIFF
--- a/src/components/RankedList.tsx
+++ b/src/components/RankedList.tsx
@@ -49,12 +49,12 @@ export function RankedList({
         </div>
       </div>
 
-      <div className="space-y-6">
-        <Text className="text-md text-grey">{description}</Text>
+      <div className="grid gap-y-6 grid-cols-[auto_1fr_auto]">
+        <Text className="col-span-full text-md text-grey">{description}</Text>
         {initialItems.map((item, index) => (
           <a
             key={item.id || index}
-            className="grid grid-cols-[auto_1fr] items-center gap-4 hover:bg-black-1 transition-colors rounded-lg"
+            className="grid grid-cols-subgrid col-span-full items-center gap-4 hover:bg-black-1 transition-colors rounded-lg"
             href={
               (type === "municipality" ? "/municipalities/" : "/companies/") +
               (item.id || item.name)
@@ -68,21 +68,19 @@ export function RankedList({
             >
               {String(index + 1).padStart(2, "0")}
             </span>
-            <div className="grid grid-cols-1 md:grid-cols-2 items-center md:gap-4">
-              <span className="text-base md:text-lg">{item.name}</span>
-              <div className="flex items-center md:justify-end">
-                <span
-                  className={cn(
-                    "text-base md:text-lg md:text-right",
-                    textColor
-                  )}
-                >
-                  {localizeUnit(item.value, currentLanguage) || item.value.toFixed(1)}
-                </span>
-                <span className={cn("text-grey", unit !== " %" && "ml-2")}>
-                  {unit.padStart(1, " ")}
-                </span>
-              </div>
+            <span className="text-base md:text-lg">{item.name}</span>
+            <div className="flex items-center md:justify-end">
+              <span
+                className={cn(
+                  "text-base md:text-lg md:text-right",
+                  textColor
+                )}
+              >
+                {localizeUnit(item.value, currentLanguage) || item.value.toFixed(1)}
+              </span>
+              <span className={cn("text-grey", unit !== " %" && "ml-2")}>
+                {unit.padStart(1, " ")}
+              </span>
             </div>
           </a>
         ))}


### PR DESCRIPTION
### ✨ What’s Changed?
Since 01 is narrower than 02 using a non-fixed font the columns were misaligned. This changes to use a CSS subgrid to ensure alignment between the rows.

Subgrid is fairly new (implemented in major browsers 2023, https://caniuse.com/?search=subgrid), I'm unsure if this is a problem or not.

### 📸 Screenshots (if applicable)
Before:
<img width="476" alt="misaligned" src="https://github.com/user-attachments/assets/d1bbfc3e-8b26-4f78-a0cb-783252ae481c" />

After:
<img width="476" alt="image" src="https://github.com/user-attachments/assets/2616411f-4716-42a8-9429-2be96b33a44b" />


### 📋 Checklist

- [x] PR title starts with [#issue-number], [fix], or [feat]
- [x] I've verified the change runs locally
- [ ] I've created sub-tasks or follow-up issues for anything not included in this PR but are necessary for the change as a whole
- [ ] I've set the labels, issue, and milestone for the PR

### 🛠 Related Issue

Closes #[issue-number] <!-- or: Related to #[issue-number] -->