### PR TITLE
[532] Added extended information on emissionsChange tooltip when faced with very high or low numbers

### DIFF
--- a/src/components/companies/detail/CompanyOverview.tsx
+++ b/src/components/companies/detail/CompanyOverview.tsx
@@ -22,6 +22,13 @@ import {
 import { useLanguage } from "@/components/LanguageProvider";
 import { localizeUnit } from "@/utils/localizeUnit";
 import { cn } from "@/lib/utils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Info } from "lucide-react";
 
 interface CompanyOverviewProps {
   company: CompanyDetails;
@@ -193,9 +200,34 @@ export function CompanyOverview({
         </div>
 
         <div>
-          <Text className="mb-2 lg:text-lg md:text-base sm:text-sm">
-            {t("companies.overview.changeSinceLastYear")}
-          </Text>
+          <div className="flex items-center gap-2">
+            <Text className="mb-2 lg:text-lg md:text-base sm:text-sm">
+              {t("companies.overview.changeSinceLastYear")}
+            </Text>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger>
+                  <Info className="w-4 h-4 mb-2" />
+                </TooltipTrigger>
+                <TooltipContent className="max-w-80">
+                  {yearOverYearChange !== null ? (
+                    yearOverYearChange <= -80 || yearOverYearChange >= 80 ? (
+                      <>
+                        <p>{t("companies.card.emissionsChangeRateInfo")}</p>
+                        <p className="my-2">
+                          {t("companies.card.emissionsChangeRateInfoExtended")}
+                        </p>
+                      </>
+                    ) : (
+                      <p>{t("companies.card.emissionsChangeRateInfo")}</p>
+                    )
+                  ) : (
+                    <p>{t("companies.card.noData")}</p>
+                  )}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </div>
           <Text className="text-3xl lg:text-6xl md:text-4xl sm:text-3xl font-light tracking-tighter leading-none">
             {yearOverYearChange !== null ? (
               <span

--- a/src/components/companies/list/CompanyCard.tsx
+++ b/src/components/companies/list/CompanyCard.tsx
@@ -82,8 +82,6 @@ export function CompanyCard({
     ? getCategoryColor(largestCategory.category)
     : "var(--blue-2)";
 
-  console.log(emissionsChange);
-
   return (
     <div className="relative rounded-level-2">
       <Link

--- a/src/components/companies/list/CompanyCard.tsx
+++ b/src/components/companies/list/CompanyCard.tsx
@@ -82,6 +82,8 @@ export function CompanyCard({
     ? getCategoryColor(largestCategory.category)
     : "var(--blue-2)";
 
+  console.log(emissionsChange);
+
   return (
     <div className="relative rounded-level-2">
       <Link
@@ -179,8 +181,23 @@ export function CompanyCard({
                   <TooltipTrigger>
                     <Info className="w-4 h-4" />
                   </TooltipTrigger>
-                  <TooltipContent>
-                    <p>{t("companies.card.emissionsChangeRateInfo")}</p>
+                  <TooltipContent className="max-w-80">
+                    {emissionsChange !== null ? (
+                      emissionsChange <= -80 || emissionsChange >= 80 ? (
+                        <>
+                          <p>{t("companies.card.emissionsChangeRateInfo")}</p>
+                          <p className="my-2">
+                            {t(
+                              "companies.card.emissionsChangeRateInfoExtended",
+                            )}
+                          </p>
+                        </>
+                      ) : (
+                        <p>{t("companies.card.emissionsChangeRateInfo")}</p>
+                      )
+                    ) : (
+                      <p>{t("companies.card.noData")}</p>
+                    )}
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -546,6 +546,7 @@
       "totalEmissionsInfo": "Total Emissions (Scope 1 & 2)",
       "emissionsChangeRate": "Change Rate",
       "emissionsChangeRateInfo": "Change rate of emissions compared to the previous reporting period.",
+      "emissionsChangeRateInfoExtended": "This value is so large due to inconsistencies in reported data, thus the change in percentages is not representative of actual changes.",
       "turnover": "Turnover",
       "employees": "Employees",
       "companyReport": "Sustainability Report",

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -554,6 +554,7 @@
       "totalEmissionsInfo": "Totala utsläpp (Scope 1 & 2)",
       "emissionsChangeRate": "Förändringstakt",
       "emissionsChangeRateInfo": "Förändringstakt för utsläpp jämfört med föregående rapporteringsperiod.",
+      "emissionsChangeRateInfoExtended": "Det här värdet är så högt på grund av inkonsekvent rapporterad data, vilket gör att procentförändringen inte speglar verkliga förändringar.",
       "turnover": "Omsättning",
       "employees": "Anställda",
       "companyReport": "Hållbarhetsrapport",


### PR DESCRIPTION
### ✨ What’s Changed?

Added an extension to the information on emissions change tooltip when the values are higher than 80% or lower than -80% in English and Swedish. Also added the tooltip to the company details page.

See images below for added info in Eng and Swe.

### 📸 Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/dfd8624f-b05d-4c74-9f63-de2933942154)
![image](https://github.com/user-attachments/assets/02555ac8-88e3-468f-acb3-98c01c6b19b5)


### 📋 Checklist

- [x] PR title starts with [#issue-number], [fix], or [feat]
- [x] I've verified the change runs locally
- [ ] I've created sub-tasks or follow-up issues for anything not included in this PR but are necessary for the change as a whole
- [ ] I've set the labels, issue, and milestone for the PR

### 🛠 Related Issue

Closes #[[532] <!-- or: Related to #[issue-number] -->](https://github.com/Klimatbyran/frontend/issues/532)