### PR TITLE
[558] Changed copy on paragraph on About us page

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -76,7 +76,7 @@
     },
     "mainContent": {
       "title": "What is Klimatkollen?",
-      "paragraph1": "Klimatkollen is a citizen platform that helps individuals, businesses, and organisations track the climate transition by collecting and visualising key climate data.",
+      "paragraph1": "Klimatkollen (eng, Climate Checker) is an open-source citizen platform that helps individuals, businesses and organisations track the climate transition by using Al to collect, analyze and spread key climate data.",
       "paragraph2": "We provide a clear picture of how emissions are progressing compared to where they need to be. By making this information accessible, we empower the public, contribute to fact-based discussions, and strengthen support for climate action.",
       "paragraph3": "Our vision is for decision-makers in politics and business to be guided by an informed and engaged public, leading to actions that reduce emissions in line with the Paris Agreement.",
       "paragraph4": "Launched in March 2022, Klimatkollen is operated by the non-profit association Klimatbyrån. It was founded by Ola Spännar and Frida Berry Eklund. Initially focused on local climate data for Swedish municipalities, the platform expanded in 2024 to include corporate climate data."

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -76,7 +76,7 @@
     },
     "mainContent": {
       "title": "Vad är Klimatkollen?",
-      "paragraph1": "Klimatkollen är en medborgarplattform som hjälper medborgare, företag och organisationer att få koll på klimatomställningen, genom att samla in och visualisera klimatdata.",
+      "paragraph1": "Klimatkollen är en öppen och medborgardriven plattform som hjälper individer, företag och organisationer att följa klimatomställningen genom att använda AI för att samla in, analysera och sprida viktig klimatdata.",
       "paragraph2": "Vi visar hur det går med utsläppen, jämfört med hur det borde gå, så att det blir begripligt för allmänheten, bidrar till en faktabaserad debatt och stärker opinionen för klimatåtgärder.",
       "paragraph3": "Vår vision är att beslutsfattare i politik och näringsliv ska påverkas av en välinformerad och växande opinion till att genomföra åtgärder som sänker utsläppen i linje med Parisavtalet.",
       "paragraph4": "Klimatkollen lanserades i mars 2022 och drivs av den ideella föreningen Klimatbyrån. Initiativtagare är Ola Spännar och Frida Berry Eklund. Vi började med lokal klimatdata för Sveriges kommuner. Från 2024 visas klimatdata även för företag."


### PR DESCRIPTION
### ✨ What’s Changed?

Change in copy on about us page where paragraph was "Klimatkollen is a citizen platform that helps individuals, businesses, and organisations track the climate transition by collecting and visualising key climate data." and was to be changed to "Klimatkollen (eng, Climate Checker) is an open-source citizen platform that helps individuals, businesses and organisations track the climate transition by using Al to collect, analyze and spread key climate data.".

Added Swedish translation as well.



### 📸 Screenshots (if applicable)
Swe
![image](https://github.com/user-attachments/assets/7885df01-9c8d-499e-8566-d00891fa85a3)

Eng
![image](https://github.com/user-attachments/assets/cd055190-6caf-41a3-8cf2-dbbf32416d82)



### 📋 Checklist

- [x] PR title starts with [#issue-number], [fix], or [feat]
- [x] I've verified the change runs locally
- [ ] I've created sub-tasks or follow-up issues for anything not included in this PR but are necessary for the change as a whole
- [ ] I've set the labels, issue, and milestone for the PR

### 🛠 Related Issue

Closes #[[558](https://github.com/Klimatbyran/frontend/issues/558)] 