### PR TITLE
FIX correct value for bike lane meters on detailed municipality page

### DIFF
--- a/src/pages/MunicipalityDetailPage.tsx
+++ b/src/pages/MunicipalityDetailPage.tsx
@@ -270,7 +270,7 @@ export function MunicipalityDetailPage() {
             {
               title: t("municipalityDetailPage.bicycleMetrePerCapita"),
               value: localizeUnit(
-                municipality.electricVehiclePerChargePoints,
+                municipality.bicycleMetrePerCapita,
                 currentLanguage,
               ),
               valueClassName: "text-orange-2",


### PR DESCRIPTION
### ✨ What’s Changed?

Changed value on municipality detailed pages so bike lanes are displayed correctly (instead of showing value for electricVehiclePerChargePoints). 
