### PR TITLE
[591] Fixed layout shift when toggling filters on municipalities page

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -82,7 +82,7 @@ export function Header() {
   ];
 
   return (
-    <header className="fixed top-0 left-0 right-0 z-50 bg-black-2 h-10 lg:h-12">
+    <header className="fixed w-screen overflow-x-hidden overflow-y-hidden top-0 left-0 right-0 z-50 bg-black-2 h-10 lg:h-12">
       <div className="container mx-auto px-4 flex items-center justify-between pt-2 lg:pt-0">
         <Link to="/" className="flex items-center gap-2 text-base font-medium">
           Klimatkollen

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -8,7 +8,7 @@ interface LayoutProps {
 
 export function Layout({ children }: LayoutProps) {
   return (
-    <div className="min-h-screen bg-black-3 flex flex-col">
+    <div className="min-h-screen w-screen overflow-x-hidden bg-black-3 flex flex-col">
       <Header />
       <main className="grow container mx-auto px-4 pt-24 pb-12">
         {children}


### PR DESCRIPTION
### ✨ What’s Changed?
Added hidden overflow aswell as adjusted width on layout and header


### 📸 Screenshots (if applicable)

Before:

https://github.com/user-attachments/assets/1983fa68-f0d2-466e-b5d8-802b85637bba



After:

[klimatkollenLayout.webm](https://github.com/user-attachments/assets/9e224d51-bb6f-4007-802e-64ca7820ebc2)



### 📋 Checklist

- [x] PR title starts with [#issue-number], [fix], or [feat]
- [x] I've verified the change runs locally
- [ ] I've created sub-tasks or follow-up issues for anything not included in this PR but are necessary for the change as a whole
- [ ] I've set the labels, issue, and milestone for the PR

### 🛠 Related Issue

Closes #[[591](https://github.com/Klimatbyran/frontend/issues/591)] <!-- or: Related to #[issue-number] -->