### PR TITLE
[609] Reduced width on baseYear tooltip on mobile devices

### DIFF
--- a/src/components/companies/detail/CustomTooltip.tsx
+++ b/src/components/companies/detail/CustomTooltip.tsx
@@ -43,7 +43,7 @@ export const CustomTooltip = ({
 
     return (
       <div
-        className={`${isMobile ? "w-[280px]" : "w-[400px]"} bg-black-1 px-4 py-3 rounded-level-2 `}
+        className={`${isMobile ? "max-w-[280px]" : "max-w-[400px]"} bg-black-1 px-4 py-3 rounded-level-2 `}
       >
         <div className="text-sm font-medium mb-2">
           {label}

--- a/src/components/companies/detail/CustomTooltip.tsx
+++ b/src/components/companies/detail/CustomTooltip.tsx
@@ -2,6 +2,7 @@ import { useCategoryMetadata } from "@/hooks/companies/useCategories";
 import { useTranslation } from "react-i18next";
 import { formatEmissionsAbsolute, localizeUnit } from "@/utils/localizeUnit";
 import { useLanguage } from "@/components/LanguageProvider";
+import { useScreenSize } from "@/hooks/useScreenSize";
 
 interface CustomTooltipProps {
   active?: boolean;
@@ -18,7 +19,8 @@ export const CustomTooltip = ({
 }: CustomTooltipProps) => {
   const { t } = useTranslation();
   const { getCategoryName } = useCategoryMetadata();
-  const { currentLanguage} = useLanguage();
+  const { currentLanguage } = useLanguage();
+  const { isMobile } = useScreenSize();
 
   if (active && payload && payload.length) {
     if (payload.length === 3) {
@@ -36,12 +38,17 @@ export const CustomTooltip = ({
       };
       payload = [companyTotal, ...payload];
     }
-    
+
     const isBaseYear = companyBaseYear === payload[0].payload.year;
-    
+
     return (
-      <div className="bg-black-1 px-4 py-3 rounded-level-2 max-w-[525px] ">
-        <div className="text-sm font-medium mb-2">{label}{isBaseYear ? '*' : ''}</div>
+      <div
+        className={`${isMobile ? "w-[280px]" : "w-[400px]"} bg-black-1 px-4 py-3 rounded-level-2 `}
+      >
+        <div className="text-sm font-medium mb-2">
+          {label}
+          {isBaseYear ? "*" : ""}
+        </div>
         {payload.map((entry: any) => {
           if (entry.dataKey === "gap") return null;
 
@@ -74,17 +81,12 @@ export const CustomTooltip = ({
               <span style={{ color: entry.color }}>{displayValue}</span>
             </div>
           );
-          
         })}
-            {
-                isBaseYear
-                ? 
-                  <span className="text-grey mr-2 text-sm">
-                    <br></br>
-                    *{t('companies.emissionsHistory.baseYearInfo')}
-                  </span>
-                : null                
-              }
+        {isBaseYear ? (
+          <span className="text-grey mr-2 text-sm">
+            <br></br>*{t("companies.emissionsHistory.baseYearInfo")}
+          </span>
+        ) : null}
       </div>
     );
   }


### PR DESCRIPTION
### ✨ What’s Changed?

Reduced width on baseYear tooltip on mobile devices since the tooltip containing the baseYear info would clip out of frame on smaller devices.

### 📸 Screenshots (if applicable)
After:
![image](https://github.com/user-attachments/assets/7c2700e6-b6f6-4865-9a67-0ab799d10626)




### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [ ] I've set the labels, issue, and milestone for the PR
- [ ] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #[[609](https://github.com/Klimatbyran/frontend/issues/609)] 