### PR TITLE
[598] Added unique path for companies graph & list views

### DIFF
--- a/src/components/companies/sectors/charts/PieLegend.tsx
+++ b/src/components/companies/sectors/charts/PieLegend.tsx
@@ -52,7 +52,6 @@ const PieLegend: React.FC<PieLegendProps> = ({
       }`}
     >
       {payload.map((entry, index) => {
-        console.log("Entry in map:", entry);
         const percentage = formatPercent(
           entry.payload.value / entry.payload.total,
           currentLanguage,

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -235,7 +235,8 @@
     "errorTitle": "Unable to retrieve company information",
     "errorDescription": "Please try again later",
     "notFoundTitle": "Company not found",
-    "notFoundDescription": "Check if the company ID is correct"
+    "notFoundDescription": "Check if the company ID is correct",
+    "back": "Back"
   },
   "methodsPage": {
     "header": {

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -233,7 +233,8 @@
     "errorTitle": "Det gick inte att hämta företagsinformation",
     "errorDescription": "Försök igen senare",
     "notFoundTitle": "Företaget kunde inte hittas",
-    "notFoundDescription": "Kontrollera att företags-ID:t är korrekt"
+    "notFoundDescription": "Kontrollera att företags-ID:t är korrekt",
+    "back": "Tillbaka"
   },
   "methodsPage": {
     "header": {

--- a/src/pages/CompaniesPage.tsx
+++ b/src/pages/CompaniesPage.tsx
@@ -35,6 +35,7 @@ import { useTranslation } from "react-i18next";
 import { useScreenSize } from "@/hooks/useScreenSize";
 import { cn } from "@/lib/utils";
 import SectorGraphs from "@/components/companies/sectors/SectorGraphs";
+import { useNavigate, useLocation } from "react-router-dom";
 
 type FilterBadge = {
   type: "filter" | "sort";
@@ -237,6 +238,8 @@ export function CompaniesPage() {
   const sectorNames = useSectorNames();
   const [viewMode, setViewMode] = useState<"graphs" | "list">("list");
   const [isDevEnvironment, setIsDevEnvironment] = useState(false);
+  const location = useLocation();
+  const navigate = useNavigate();
 
   const {
     searchQuery,

--- a/src/pages/CompaniesPage.tsx
+++ b/src/pages/CompaniesPage.tsx
@@ -236,10 +236,11 @@ export function CompaniesPage() {
   const [filterOpen, setFilterOpen] = useState(false);
   const sortOptions = useSortOptions();
   const sectorNames = useSectorNames();
-  const [viewMode, setViewMode] = useState<"graphs" | "list">("list");
   const [isDevEnvironment, setIsDevEnvironment] = useState(false);
   const location = useLocation();
   const navigate = useNavigate();
+  const params = new URLSearchParams(location.search);
+  const view = params.get("view");
 
   const {
     searchQuery,
@@ -257,12 +258,20 @@ export function CompaniesPage() {
     const isDev = hostname.includes("stage.") || hostname.includes("localhost");
 
     setIsDevEnvironment(isDev);
-
-    // If in dev environment, we can default to graphs view
-    if (isDev) {
-      setViewMode("graphs");
-    }
   }, []);
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const view = params.get("view");
+
+    if (!view || (view !== "graphs" && view !== "list")) {
+      navigate({ search: "view=graphs" });
+    }
+  }, [location.search]);
+
+  const setQueryParam = (URLparam: string) => {
+    navigate({ search: `view=${URLparam}` });
+  };
 
   const activeFilters: FilterBadge[] = [
     ...sectors.map((sec) => ({
@@ -273,7 +282,7 @@ export function CompaniesPage() {
           : sectorNames[sec as SectorCode] || sec,
       onRemove: () => setSectors((prev) => prev.filter((s) => s !== sec)),
     })),
-    ...(viewMode === "list"
+    ...(view === "list"
       ? [
           {
             type: "sort" as const,
@@ -332,11 +341,9 @@ export function CompaniesPage() {
                 size="sm"
                 className={cn(
                   "h-8 px-3 rounded-none",
-                  viewMode === "graphs"
-                    ? "bg-blue-5/30 text-blue-2"
-                    : "text-grey",
+                  view === "graphs" ? "bg-blue-5/30 text-blue-2" : "text-grey",
                 )}
-                onClick={() => setViewMode("graphs")}
+                onClick={() => setQueryParam("graphs")}
                 title={t("companiesPage.viewModes.graphs")}
               >
                 <BarChart className="w-4 h-4" />
@@ -346,11 +353,9 @@ export function CompaniesPage() {
                 size="sm"
                 className={cn(
                   "h-8 px-3 rounded-none",
-                  viewMode === "list"
-                    ? "bg-blue-5/30 text-blue-2"
-                    : "text-grey",
+                  view === "list" ? "bg-blue-5/30 text-blue-2" : "text-grey",
                 )}
-                onClick={() => setViewMode("list")}
+                onClick={() => setQueryParam("list")}
                 title={t("companiesPage.viewModes.list")}
               >
                 <List className="w-4 h-4" />
@@ -359,7 +364,7 @@ export function CompaniesPage() {
           )}
 
           {/* Search Input - Always show in production, only in list view for dev */}
-          {(!isDevEnvironment || viewMode === "list") && (
+          {(!isDevEnvironment || view === "list") && (
             <Input
               type="text"
               placeholder={t("companiesPage.searchPlaceholder")}
@@ -377,7 +382,7 @@ export function CompaniesPage() {
             setSectors={setSectors}
             sortBy={sortBy}
             setSortBy={setSortBy}
-            viewMode={isDevEnvironment ? viewMode : "list"}
+            viewMode={isDevEnvironment ? view : "list"}
           />
 
           {/* Badges */}
@@ -403,7 +408,7 @@ export function CompaniesPage() {
             {t("companiesPage.tryDifferentCriteria")}
           </p>
         </div>
-      ) : isDevEnvironment && viewMode === "graphs" ? (
+      ) : isDevEnvironment && view === "graphs" ? (
         <SectorGraphs
           companies={companies}
           selectedSectors={

--- a/src/pages/CompanyDetailPage.tsx
+++ b/src/pages/CompanyDetailPage.tsx
@@ -168,7 +168,7 @@ export function CompanyDetailPage() {
         )}
       </PageSEO>
 
-      <div className="space-y-16 max-w-[1400px] mx-auto">
+      <div className="space-y-4 max-w-[1400px] mx-auto">
         <Button
           variant="ghost"
           size="sm"

--- a/src/pages/CompanyDetailPage.tsx
+++ b/src/pages/CompanyDetailPage.tsx
@@ -172,7 +172,7 @@ export function CompanyDetailPage() {
         <Button
           variant="ghost"
           size="sm"
-          className="gap-2"
+          className="gap-2 px-4"
           onClick={() => navigate(-1)}
         >
           <ArrowLeft className="w-4 h-4" />

--- a/src/pages/CompanyDetailPage.tsx
+++ b/src/pages/CompanyDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { useState, useEffect } from "react";
 import { useCompanyDetails } from "@/hooks/companies/useCompanyDetails";
 import { CompanyOverview } from "@/components/companies/detail/CompanyOverview";
@@ -8,6 +8,8 @@ import { useTranslation } from "react-i18next";
 import { PageSEO } from "@/components/SEO/PageSEO";
 import { createSlug } from "@/lib/utils";
 import { CompanyScope3 } from "@/components/companies/detail/CompanyScope3";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft } from "lucide-react";
 
 export function CompanyDetailPage() {
   const { t } = useTranslation();
@@ -16,6 +18,7 @@ export function CompanyDetailPage() {
   // It's either directly from /companies/:id or extracted from /foretag/:slug-:id
   const { company, loading, error } = useCompanyDetails(id!);
   const [selectedYear, setSelectedYear] = useState<string>("latest");
+  const navigate = useNavigate();
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -166,6 +169,15 @@ export function CompanyDetailPage() {
       </PageSEO>
 
       <div className="space-y-16 max-w-[1400px] mx-auto">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="gap-2"
+          onClick={() => navigate(-1)}
+        >
+          <ArrowLeft className="w-4 h-4" />
+          {t("companyDetailPage.back")}
+        </Button>
         <CompanyOverview
           company={company}
           selectedPeriod={selectedPeriod}


### PR DESCRIPTION
### ✨ What’s Changed?

Added unique paths for company graphs and list views with the ability to go back to the correct view. Removed viewMode state and display the correct view depending on the queryparam instead. Added a "go back" button to companyDetailPage. It's not quite in the same position as the back button when viewing articles, but we're using different paddings there, and I kept it like that for now. 

### 📸 Screenshots (if applicable)
Back buttons:
![image](https://github.com/user-attachments/assets/86dc76e4-b2e1-4599-af95-8ac4b0160e01)
![image](https://github.com/user-attachments/assets/61cb2af0-7977-4ee0-bacd-b2e55d747187)

URLS:
![image](https://github.com/user-attachments/assets/5a32a897-97da-46d5-9b60-bb540c95f4a5)
![image](https://github.com/user-attachments/assets/a6324210-9060-43f0-bade-f47f97d38f86)




### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [ ] I've set the labels, issue, and milestone for the PR
- [ ] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #[598](https://github.com/Klimatbyran/frontend/issues/598)] 