### PR TITLE
FIX remove percent calculation of EV growth from frontend

### DIFF
--- a/src/pages/MunicipalityDetailPage.tsx
+++ b/src/pages/MunicipalityDetailPage.tsx
@@ -122,7 +122,7 @@ export function MunicipalityDetailPage() {
           {t("municipalityDetailPage.seoText.transportText", {
             municipality: municipality.name,
             bikeMeters: municipality.bicycleMetrePerCapita.toFixed(1),
-            evGrowth: (municipality.electricCarChangePercent * 100).toFixed(1),
+            evGrowth: municipality.electricCarChangePercent.toFixed(1),
           })}
         </p>
       </PageSEO>


### PR DESCRIPTION
### ✨ What’s Changed?

Calculation of EV growth to percent is now moved to backend thus removed from frontend.

See related PRs
https://github.com/Klimatbyran/klimatkollen-deprecated/pull/755
https://github.com/Klimatbyran/garbo/pull/752

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [x] I've set the labels, issue, and milestone for the PR
- [ ] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)
