### PR TITLE
FIX support for consumption emissions in tons

### DIFF
--- a/src/pages/MunicipalityDetailPage.tsx
+++ b/src/pages/MunicipalityDetailPage.tsx
@@ -112,9 +112,7 @@ export function MunicipalityDetailPage() {
         <p>
           {t("municipalityDetailPage.seoText.consumptionText", {
             municipality: municipality.name,
-            consumption: (municipality.totalConsumptionEmission / 1000).toFixed(
-              1,
-            ),
+            consumption: municipality.totalConsumptionEmission.toFixed(1),
           })}
         </p>
         <h2>{t("municipalityDetailPage.seoText.transportHeading")}</h2>
@@ -221,7 +219,7 @@ export function MunicipalityDetailPage() {
             {
               title: t("municipalityDetailPage.consumptionEmissionsPerCapita"),
               value: localizeUnit(
-                municipality.totalConsumptionEmission / 1000,
+                municipality.totalConsumptionEmission,
                 currentLanguage,
               ),
               valueClassName: "text-orange-2",


### PR DESCRIPTION
### ✨ What’s Changed?

Removed division with 1000 from consumption emissions since they will be sent in tons from the backend.

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)