### PR TITLE
622 make sustainability report link on company card

### DIFF
--- a/src/components/companies/list/CompanyCard.tsx
+++ b/src/components/companies/list/CompanyCard.tsx
@@ -262,7 +262,7 @@ export function CompanyCard({
             </div>
           )}
         </div>
-        {/* Climate Plan */}
+        {/* Sustainability Report */}
         {latestPeriod?.reportURL && (
           <a
             href={latestPeriod.reportURL}

--- a/src/components/companies/list/CompanyCard.tsx
+++ b/src/components/companies/list/CompanyCard.tsx
@@ -30,6 +30,7 @@ import {
   localizeUnit,
   formatPercentChange,
 } from "@/utils/localizeUnit";
+import { LinkCard } from "@/components/ui/link-card";
 
 type CompanyCardProps = Pick<
   RankedCompany,
@@ -264,30 +265,20 @@ export function CompanyCard({
         </div>
         {/* Sustainability Report */}
         {latestPeriod?.reportURL && (
-          <a
-            href={latestPeriod.reportURL}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="block bg-black-1 rounded-level-2 p-4 hover:bg-black-1/80 transition-colors"
-          >
-            <div className="flex items-center justify-between">
-              <div>
-                <Text
-                  variant="h6"
-                  className="flex items-center gap-2 text-white mb-2"
-                >
-                  <FileText className="w-6 h-6 text-white" />
-                  <span>{t("companies.card.companyReport")}</span>
-                </Text>
-                <Text variant="body" className=" text-grey">
-                  {latestPeriod.reportURL === "Saknar report"
-                    ? t("companies.card.missingReport")
-                    : ``}
-                </Text>
-              </div>
-              <ArrowUpRight className="w-6 h-6" />
-            </div>
-          </a>
+          <LinkCard
+            link={latestPeriod.reportURL ? latestPeriod.reportURL : undefined}
+            title={t("companies.card.companyReport")}
+            description={
+              latestPeriod.reportURL === "Saknar report"
+                ? t("companies.card.missingReport")
+                : ``
+            }
+            descriptionColor={
+              latestPeriod.reportURL === "Saknar report"
+                ? "text-pink-3"
+                : "text-green-3"
+            }
+          />
         )}
       </Link>
     </div>

--- a/src/components/municipalities/list/MunicipalityCard.tsx
+++ b/src/components/municipalities/list/MunicipalityCard.tsx
@@ -11,6 +11,7 @@ import {
   localizeUnit,
 } from "@/utils/localizeUnit";
 import { useLanguage } from "@/components/LanguageProvider";
+import { LinkCard } from "@/components/ui/link-card";
 
 interface MunicipalityCardProps {
   municipality: Municipality;
@@ -35,9 +36,7 @@ export function MunicipalityCard({ municipality }: MunicipalityCardProps) {
       )
     : t("municipalities.card.noData");
 
-  const noClimatePlan =
-    municipality.climatePlanLink === "Saknar plan" ||
-    municipality.climatePlanLink === undefined;
+  const noClimatePlan = !municipality.climatePlanLink;
 
   return (
     <Link
@@ -112,44 +111,23 @@ export function MunicipalityCard({ municipality }: MunicipalityCardProps) {
           textColor={meetsParis ? "text-green-3" : "text-pink-3"}
         />
       </div>
-      <a
-        href={
+      <LinkCard
+        link={
           municipality.climatePlanLink &&
           municipality.climatePlanLink !== "Saknar plan"
             ? municipality.climatePlanLink
             : undefined
         }
-        target="_blank"
-        rel="noopener noreferrer"
-        className="block bg-black-1 rounded-level-2 p-6 hover:bg-black-1/80 transition-colors"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex items-center justify-between">
-          <div>
-            <Text
-              variant="h6"
-              className="flex items-center gap-2 text-white mb-2"
-            >
-              <FileText className="w-6 h-6 text-white" />
-              <span>{t("municipalities.card.climatePlan")}</span>
-            </Text>
-            <Text
-              variant="body"
-              className={cn(noClimatePlan ? "text-pink-3" : "text-green-3")}
-            >
-              {noClimatePlan
-                ? t("municipalities.card.noPlan")
-                : t("municipalities.card.adopted", {
-                    year: municipality.climatePlanYear,
-                  })}
-            </Text>
-          </div>
-          {municipality.climatePlanLink &&
-            municipality.climatePlanLink !== "Saknar plan" && (
-              <ArrowUpRight className="w-6 h-6" />
-            )}
-        </div>
-      </a>
+        title={t("municipalities.card.climatePlan")}
+        description={
+          noClimatePlan
+            ? t("municipalities.card.noPlan")
+            : t("municipalities.card.adopted", {
+                year: municipality.climatePlanYear,
+              })
+        }
+        descriptionColor={noClimatePlan ? "text-pink-3" : "text-green-3"}
+      />
     </Link>
   );
 }

--- a/src/components/ui/link-card.tsx
+++ b/src/components/ui/link-card.tsx
@@ -1,0 +1,42 @@
+import { ArrowUpRight, FileText } from "lucide-react";
+import { Text } from "./text";
+
+interface LinkCardProps {
+  link: string | undefined;
+  title: string;
+  description: string;
+  descriptionColor: string;
+}
+
+export const LinkCard = ({
+  link,
+  title,
+  description,
+  descriptionColor,
+}: LinkCardProps) => {
+  return (
+    <a
+      href={link}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="block bg-black-1 rounded-level-2 p-6 hover:bg-black-1/80 transition-colors"
+      onClick={(e) => e.stopPropagation()}
+    >
+      <div className="flex items-center justify-between">
+        <div>
+          <Text
+            variant="h6"
+            className="flex items-center gap-2 text-white mb-2"
+          >
+            <FileText className="w-6 h-6 text-white" />
+            <span>{title}</span>
+          </Text>
+          <Text variant="body" className={descriptionColor}>
+            {description}
+          </Text>
+        </div>
+        {link && <ArrowUpRight className="w-6 h-6" />}
+      </div>
+    </a>
+  );
+};


### PR DESCRIPTION
### ✨ What’s Changed?

Brake out linked card that we use in both companies and municipalities to its own component and apply it on both Company- and MunicipalityCard, thus solving the bug at the same time.

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #622 