### PR TITLE
616 prevent overflow of ranked list on small screens

### DIFF
--- a/src/components/RankedList.tsx
+++ b/src/components/RankedList.tsx
@@ -46,19 +46,19 @@ export function RankedList({
         </div>
       </div>
 
-      <div className="grid gap-y-6 grid-cols-[auto_1fr_auto]">
+      <div className="grid gap-y-4 md:gap-y-6 grid-cols-[auto_1fr_auto]">
         <Text className="col-span-full text-md text-grey">{description}</Text>
         {items.map((item, index) => (
           <a
             key={item.link}
             href={item.link}
-            className="grid grid-cols-subgrid col-span-full items-center gap-4 hover:bg-black-1 transition-colors rounded-lg"
+            className="grid grid-cols-subgrid col-span-full items-center gap-2 md:gap-4 hover:bg-black-1 transition-colors rounded-lg"
           >
             <span className={cn("text-2xl md:text-5xl font-light", rankColor)}>
               {String(index + 1).padStart(2, "0")}
             </span>
             <span className="text-base md:text-lg">{item.name}</span>
-            <div className="flex items-center md:justify-end">
+            <div className="flex flex-wrap justify-end">
               {itemValueRenderer(item)}
             </div>
           </a>


### PR DESCRIPTION
### ✨ What’s Changed?

Adapted ranked list to small screens (<375 px).

### 📸 Screenshots (if applicable)

Before
![434787988-dfce542f-82d7-4b8c-ba57-3f8199028e78](https://github.com/user-attachments/assets/fee31814-aaec-4af9-82a2-a25457640309)


After
<img width="274" alt="Screenshot 2025-05-05 at 13 59 14" src="https://github.com/user-attachments/assets/a20b5ce9-ed17-49b4-831e-d577faca5e5a" />


### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Close #614