### PR TITLE
FIX for content of site being wider than screen

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -8,7 +8,7 @@ interface LayoutProps {
 
 export function Layout({ children }: LayoutProps) {
   return (
-    <div className="min-h-screen w-screen overflow-x-hidden bg-black-3 flex flex-col">
+    <div className="min-h-screen w-full overflow-x-hidden bg-black-3 flex flex-col">
       <Header />
       <main className="grow container mx-auto px-4 pt-24 pb-12">
         {children}


### PR DESCRIPTION
### ✨ What’s Changed?

Changed w-screen to w-full in Layout component since it was causing content of site to be wider than the screen on all pages.

### 📸 Screenshots (if applicable)

Before
<img width="537" alt="Screenshot 2025-05-05 at 16 28 39" src="https://github.com/user-attachments/assets/808e3c8b-3ea0-46af-b16e-0ca74e89ea07" />


After
<img width="537" alt="Screenshot 2025-05-05 at 16 28 33" src="https://github.com/user-attachments/assets/2b6ae4ad-20ec-47f9-b8a9-7684f9ff8493" />


### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)
