### PR TITLE
Fix remove empty years from pie chart overview

### DIFF
--- a/src/components/companies/sectors/charts/SectorEmissionsChart.tsx
+++ b/src/components/companies/sectors/charts/SectorEmissionsChart.tsx
@@ -125,28 +125,34 @@ const SectorEmissionsChart: React.FC<EmissionsChartProps> = ({
       <div>
         <ResponsiveContainer width="100%" height="100%">
           {chartType === "pie" ? (
-            screenSize.isMobile ? (
-              <MobilePieChartView
-                pieChartData={pieChartData}
-                selectedSector={selectedSector}
-                size={{
-                  innerRadius: size.innerRadius,
-                  outerRadius: size.outerRadius,
-                }}
-                handlePieMouseEnter={handlePieMouseEnter}
-                handlePieClick={handlePieClick}
-              />
+            totalEmissions > 0 ? (
+              screenSize.isMobile ? (
+                <MobilePieChartView
+                  pieChartData={pieChartData}
+                  selectedSector={selectedSector}
+                  size={{
+                    innerRadius: size.innerRadius,
+                    outerRadius: size.outerRadius,
+                  }}
+                  handlePieMouseEnter={handlePieMouseEnter}
+                  handlePieClick={handlePieClick}
+                />
+              ) : (
+                <DesktopPieChartView
+                  pieChartData={pieChartData}
+                  selectedSector={selectedSector}
+                  size={{
+                    innerRadius: size.innerRadius,
+                    outerRadius: size.outerRadius,
+                  }}
+                  handlePieMouseEnter={handlePieMouseEnter}
+                  handlePieClick={handlePieClick}
+                />
+              )
             ) : (
-              <DesktopPieChartView
-                pieChartData={pieChartData}
-                selectedSector={selectedSector}
-                size={{
-                  innerRadius: size.innerRadius,
-                  outerRadius: size.outerRadius,
-                }}
-                handlePieMouseEnter={handlePieMouseEnter}
-                handlePieClick={handlePieClick}
-              />
+              <div className="flex justify-center items-center h-full">
+                <p className="text-grey">{t("noDataAvailable")}</p>
+              </div>
             )
           ) : (
             <BarChart

--- a/src/components/companies/sectors/charts/SectorEmissionsChart.tsx
+++ b/src/components/companies/sectors/charts/SectorEmissionsChart.tsx
@@ -151,7 +151,9 @@ const SectorEmissionsChart: React.FC<EmissionsChartProps> = ({
               )
             ) : (
               <div className="flex justify-center items-center h-full">
-                <p className="text-grey">{t("noDataAvailable")}</p>
+                <p className="text-grey">
+                  {t("companiesPage.sectorGraphs.noDataAvailablePieChart")}
+                </p>
               </div>
             )
           ) : (

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -2,7 +2,6 @@
   "yes": "Yes",
   "no": "No",
   "emissionsUnit": "tCO₂e",
-  "noDataAvailable": "No data available",
   "header": {
     "companies": "Companies",
     "municipalities": "Municipalities",
@@ -275,6 +274,7 @@
       "back": "Back",
       "sectorTotal": "Sector Total Emissions",
       "total": "Total Emissions",
+      "noDataAvailablePieChart": "No data available for this year",
       "pieLegendCompany": "View company details",
       "pieLegendSector": "View sector details",
       "unknownCompany": "Unknown Company",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -2,6 +2,7 @@
   "yes": "Yes",
   "no": "No",
   "emissionsUnit": "tCO₂e",
+  "noDataAvailable": "No data available",
   "header": {
     "companies": "Companies",
     "municipalities": "Municipalities",

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -2,6 +2,7 @@
   "yes": "Ja",
   "no": "Nej",
   "emissionsUnit": "tCO₂e",
+  "noDataAvailable": "Inga data tillgänglig",
   "header": {
     "companies": "Företag",
     "municipalities": "Kommuner",

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -2,7 +2,6 @@
   "yes": "Ja",
   "no": "Nej",
   "emissionsUnit": "tCO₂e",
-  "noDataAvailable": "Inga data tillgänglig",
   "header": {
     "companies": "Företag",
     "municipalities": "Kommuner",
@@ -275,6 +274,7 @@
       "back": "Tillbaka",
       "sectorTotal": "Totala utsläpp i sektorn",
       "total": "Totala utsläpp",
+      "noDataAvailablePieChart": "Det finns inga data för detta år",
       "yearTotal": "Årlig total",
       "unknownCompany": "Okänt företag",
       "pieLegendCompany": "Visa företagsdetaljer",


### PR DESCRIPTION
### ✨ What’s Changed?

Added string to catch years of company sector pie chart without data.

### 📸 Screenshots (if applicable)

Before
<img width="853" alt="Screenshot 2025-05-05 at 18 57 27" src="https://github.com/user-attachments/assets/6aec0332-fe38-4236-9203-d4922b56dd27" />

After
<img width="853" alt="Screenshot 2025-05-05 at 18 57 18" src="https://github.com/user-attachments/assets/6b90c3eb-4a7d-4c51-acc3-ad5469cbf390" />


### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)