### PR TITLE
[fix] Align history scope tabs with rest of page

### DIFF
--- a/src/components/companies/detail/history/DataViewSelector.tsx
+++ b/src/components/companies/detail/history/DataViewSelector.tsx
@@ -24,7 +24,7 @@ export function DataViewSelector({
   const screenSize = useScreenSize();
 
   return (
-    <div className="w-full max-w-xs">
+    <>
       {!screenSize.isMobile ? (
         <Tabs
           value={dataView}
@@ -63,6 +63,6 @@ export function DataViewSelector({
           </SelectContent>
         </Select>
       )}
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
### ✨ What’s Changed?

The scopes in the history section were drawing in the margin which caused them to not be aligned with the details section.

### 📸 Screenshots (if applicable)

Before:
![image](https://github.com/user-attachments/assets/e8d6ec2f-ff95-4cb7-bcee-6cb1f221adec)

After:
![image](https://github.com/user-attachments/assets/5edd788a-3a3d-4154-91a8-f78bec21ef04)

### 📋 Checklist

- [x ] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [] I've set the labels, issue, and milestone for the PR
- [ ] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #[issue-number] <!-- or: Related to #[issue-number] -->