### PR TITLE
Fix copy update for municipalities without CO2 budget

### DIFF
--- a/src/components/municipalities/MunicipalityEmissionsGraph.tsx
+++ b/src/components/municipalities/MunicipalityEmissionsGraph.tsx
@@ -77,7 +77,7 @@ export const MunicipalityEmissionsGraph: FC<
       <ResponsiveContainer width="100%" height="100%">
         <LineChart data={projectedData}>
           <Legend
-            verticalAlign="top"
+            verticalAlign="bottom"
             align="right"
             height={36}
             iconType="line"

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -555,6 +555,7 @@
     },
     "totalEmissions": "Total emissions {{year}}",
     "budgetRunsOut": "Carbon budget expected to run out by",
+    "budgetRanOut": "Carbon budget ran out",
     "budgetKept": "Carbon budget expected to",
     "budgetHolds": "Stay within limits",
     "hitNetZero": "Predicted to hit net zero",

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -556,6 +556,7 @@
     },
     "totalEmissions": "Totala utsläpp {{year}}",
     "budgetRunsOut": "Koldioxidbudgeten tar slut",
+    "budgetRanOut": "Koldioxidbudgeten tog slut",
     "budgetKept": "Koldioxidbudgeten tar slut",
     "budgetHolds": "Håller budget",
     "hitNetZero": "Når nettonoll",

--- a/src/pages/MunicipalityDetailPage.tsx
+++ b/src/pages/MunicipalityDetailPage.tsx
@@ -141,8 +141,10 @@ export function MunicipalityDetailPage() {
             <MunicipalityStatCard
               title={
                 !municipality.budgetRunsOut
-                  ? t("municipalityDetailPage.budgetRunsOut")
-                  : t("municipalityDetailPage.budgetKept")
+                  ? t("municipalityDetailPage.budgetKept")
+                  : new Date(municipality.budgetRunsOut) > new Date()
+                    ? t("municipalityDetailPage.budgetRunsOut")
+                    : t("municipalityDetailPage.budgetRanOut")
               }
               value={
                 !municipality.budgetRunsOut

--- a/src/pages/MunicipalityDetailPage.tsx
+++ b/src/pages/MunicipalityDetailPage.tsx
@@ -182,10 +182,7 @@ export function MunicipalityDetailPage() {
               {t("municipalityDetailPage.inTons")}
             </Text>
             {!municipality.neededEmissionChangePercent && (
-              <p className="my-4">
-                Kommunens koldioxidbudget är slut och det finns därför ingen
-                linje för Parisavtalet ovan.
-              </p>
+              <p className="my-4">{t("municipalityDetailPage.noParisPath")}</p>
             )}
           </div>
           <div className="mt-8 mr-8">


### PR DESCRIPTION
### ✨ What’s Changed?

New SMHI emissions data for 2023 means 110 municipalities have ran out of their carbon budgets, so copy have been updated to clarify if budget is already blown.

### 📸 Screenshots (if applicable)

Before
<img width="853" alt="Screenshot 2025-05-06 at 16 05 50" src="https://github.com/user-attachments/assets/a585f0e2-9f09-4a69-9341-89ceec6209eb" />

After
<img width="853" alt="Screenshot 2025-05-06 at 16 05 37" src="https://github.com/user-attachments/assets/64347c5c-0766-416c-867d-1b7509d6993b" />

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)