### PR TITLE
[#521] Support setting the development backend URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,6 @@
 # Client ID for GitHub OAuth app
 VITE_GITHUB_CLIENT_ID=
+
+# Backend endpoint for local development
+VITE_API_PROXY=https://klimatkollen.se/
+

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ pnpm-debug.log*
 # environment variables
 .env
 .env.production
+.env.development
 
 # macOS-specific files
 .DS_Store
@@ -25,3 +26,4 @@ pnpm-debug.log*
 
 .vscode/settings.json
 .aider*
+

--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ Klimatkollen is an open-source, citizen-driven platform designed to visualize cl
 - **`src/components/`**: Houses reusable React components utilized throughout the application.
 - **`public/`**: Stores static assets such as images.
 
+## 🗄️ Deciding on backend to run development client against
+
+To run the local development client, you must run our API locally or connect to our production API. For information on setting up the API locally, see the [README](https://github.com/Klimatbyran/garbo) in our data pipeline repository.
+
+If you instead want to run the local development client against production,
+setup the local `.env` file for development by running the following command in
+the root directory of the frontend code.
+
+```
+cp .env.example .env.development
+```
+
 ## 🧞 Building and Running Locally
 
 To run the project locally, execute the following commands from the root of the project in your terminal:
@@ -17,11 +29,12 @@ To run the project locally, execute the following commands from the root of the 
 | Command           | Action                                        |
 | :---------------- | :-------------------------------------------- |
 | `npm install`     | Installs dependencies                         |
-| `npm run dev`     | Starts local dev server at `localhost:5173`   |
+| `npm run dev`     | Starts local dev server at `localhost:5173` or
+VITE_API_PROXY   |
+| `npm run dev-gen` | Starts local dev server at `localhost:5173` and generate api
+keys | 
 | `npm run build`   | Builds your production site to `./dist/`      |
 | `npm run preview` | Previews your build locally, before deploying |
-
-To see data in your local development server, you must run our API locally or connect to our production API. More information on how to do that can be found [here](https://github.com/Klimatbyran/garbo) in our data pipeline repository.
 
 ## 👩‍💻 Contributing
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "4.0.1-rc.10",
   "type": "module",
   "scripts": {
-    "dev": "npm run generate-api && vite",
+    "dev": "vite",
+    "dev-gen": "npm run generate-api && vite",
     "build": "tsc && vite build",
     "postbuild": "npm run generate-sitemap || echo 'Sitemap generation failed, but build completed'",
     "lint": "eslint .",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,35 +1,38 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv, ConfigEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import { plugin as markdown } from "vite-plugin-markdown";
 import { Mode } from "vite-plugin-markdown";
-import { IncomingMessage } from "http";
 
-export default defineConfig({
-  plugins: [
-    react({
-      babel: {
-        plugins: [
-          ["@babel/plugin-transform-react-jsx", { runtime: "automatic" }],
-          ["@babel/plugin-proposal-class-properties", { loose: true }],
-        ],
-      },
-    }),
-    markdown({ mode: ["html", "toc", "meta", "react"] as Mode[] }),
-  ],
-  resolve: {
-    alias: {
-      "@": new URL("./src", import.meta.url).pathname,
-      "@lib": new URL("./src/lib", import.meta.url).pathname, // Fixes your import issue
-    },
-  },
-  server: {
-    proxy: {
-      "/api": {
-        target: "http://localhost:3000/", // Default to local, override in CI/CD
-        changeOrigin: true,
-        secure: false,
+export default ({ mode }: ConfigEnv) => {
+  const env = loadEnv(mode, process.cwd());
+
+  return defineConfig({
+    plugins: [
+      react({
+        babel: {
+          plugins: [
+            ["@babel/plugin-transform-react-jsx", { runtime: "automatic" }],
+            ["@babel/plugin-proposal-class-properties", { loose: true }],
+          ],
+        },
+      }),
+      markdown({ mode: ["html", "toc", "meta", "react"] as Mode[] }),
+    ],
+    resolve: {
+      alias: {
+        "@": new URL("./src", import.meta.url).pathname,
+        "@lib": new URL("./src/lib", import.meta.url).pathname, // Fixes your import issue
       },
     },
-  },
-  base: "/",
-});
+    server: {
+      proxy: {
+        "/api": {
+          target: env.VITE_API_PROXY ?? "http://localhost:3000/", // Default to local, override in CI/CD
+          changeOrigin: true,
+          secure: false,
+        },
+      },
+    },
+    base: "/",
+  });
+};


### PR DESCRIPTION
This allows running the client against the production backend for local development and reduce the friction for someone to start contributing.

### ✨ What’s Changed?

Add support for setting the proxy URL through a `.env.development` file which allows a contributor to run only the frontend locally while connecting to the production backend.

**Note:** One thing that was changed in this PR is the generation of client side API types which is no longer tied to `npm run dev` but instead a separate step. We might reconsider this if it turns out we forget to update the types when making changes to the API. One alternative we can explore is to run the type generation in CI and fail a build if the generated types doesn't match the checked in version.

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [ ] I've verified the change runs locally
- [x] I've set the labels, issue, and milestone for the PR
- [ ] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #[521] <!-- or: Related to #[issue-number] -->