### PR TITLE
Feat remove municipality ranking needed emissions percent

### DIFF
--- a/src/hooks/useMunicipalityKPIs.ts
+++ b/src/hooks/useMunicipalityKPIs.ts
@@ -22,26 +22,6 @@ export const useMunicipalityKPIs = (): KPIValue[] => {
       higherIsBetter: false,
     },
     {
-      label: t("municipalities.list.kpis.neededEmissionChangePercent.label"),
-      key: "neededEmissionChangePercent",
-      unit: "%",
-      source: "municipalities.list.neededEmissionChangePercent.source",
-      sourceUrls: [
-        "https://nationellaemissionsdatabasen.smhi.se/",
-        "http://www.cemus.uu.se/wp-content/uploads/2023/12/Paris-compliant-carbon-budgets-for-Swedens-counties-.pdf",
-      ],
-      description: t(
-        "municipalities.list.kpis.neededEmissionChangePercent.description",
-      ),
-      detailedDescription: t(
-        "municipalities.list.kpis.neededEmissionChangePercent.detailedDescription",
-      ),
-      nullValues: t(
-        "municipalities.list.kpis.neededEmissionChangePercent.nullValues",
-      ),
-      higherIsBetter: false,
-    },
-    {
       label: t("municipalities.list.kpis.electricCarChangePercent.label"),
       key: "electricCarChangePercent",
       unit: "%",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -888,13 +888,6 @@
           "detailedDescription": "Average annual change in carbon dioxide emissions in Swedish municipalities since the Paris Agreement in 2015",
           "source": "<0>National Emissions Database</0>"
         },
-        "neededEmissionChangePercent": {
-          "label": "Required Emission Change",
-          "description": "Required change in emissions to meet climate goals",
-          "detailedDescription": "The emission reduction required to meet the Paris Agreement. Lower values are better",
-          "source": "<0>National Emissions Database</0>, <1>Uppsala University</1>",
-          "nullValues": "cannot reach Paris Agreement"
-        },
         "electricCarChangePercent": {
           "label": "Electric Car Growth",
           "description": "Change in electric car adoption",

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -889,13 +889,6 @@
           "detailedDescription": "Genomsnittlig årlig förändring av koldioxidutsläppen i Sveriges kommuner sedan Parisavtalet 2015",
           "source": "<0>Nationella emissionsdatabasen</0>"
         },
-        "neededEmissionChangePercent": {
-          "label": "Nödvändig utsläppsminskning",
-          "description": "Nödvändig minskning av utsläpp för att nå klimatmålen",
-          "detailedDescription": "Den utsläppsminskning som krävs för att nå Parisavtalet. Ju lägre desto bättre",
-          "source": "<0>Nationella emissionsdatabasen</0>, <1>Uppsala universitet</1>",
-          "nullValues": "kan inte nå Parisavtalet"
-        },
         "electricCarChangePercent": {
           "label": "Tillväxt av elbilar",
           "description": "Förändring i andel elbilar",


### PR DESCRIPTION
### ✨ What’s Changed?

Neeeded emissions change percent is removed from municipality ranking page in preparation for new emissions data, since roughly 110 municipalities have exhausted their carbon budgets making it impossible to rank bottom 5.

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)