### PR TITLE
[UI] Change to landing page visuals

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -106,7 +106,7 @@ export function Header() {
   ];
 
   return (
-    <header className="fixed w-screen overflow-x-hidden overflow-y-hidden top-0 left-0 right-0 z-50 bg-black-2 h-10 lg:h-12">
+    <header className="w-screen overflow-x-hidden absolute overflow-y-hidden top-0 left-0 right-0 z-50 bg-black-2 h-10 lg:h-12">
       <div className="container mx-auto px-4 flex items-center justify-between pt-2 lg:pt-0">
         <Link to="/" className="flex items-center gap-2 text-base font-medium">
           Klimatkollen

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -8,9 +8,9 @@ interface LayoutProps {
 
 export function Layout({ children }: LayoutProps) {
   return (
-    <div className="min-h-screen w-full overflow-x-hidden bg-black-3 flex flex-col">
+    <div className="min-h-screen w-screen overflow-x-hidden bg-black-3 flex flex-col">
       <Header />
-      <main className="grow container mx-auto px-4 pt-24 pb-12">
+      <main className="grow w-screen p-0">
         {children}
       </main>
       <Footer />

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -15,6 +15,7 @@ import {
   formatEmissionsAbsolute,
   formatPercentChange,
 } from "@/utils/localizeUnit";
+import { useScreenSize } from "@/hooks/useScreenSize";
 
 export function LandingPage() {
   const { t } = useTranslation();
@@ -22,6 +23,7 @@ export function LandingPage() {
   const { companies } = useCompanies();
   const { getTopMunicipalities } = useMunicipalities();
   const { currentLanguage } = useLanguage();
+  const { isMobile } = useScreenSize();
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -111,68 +113,81 @@ export function LandingPage() {
         canonicalUrl={canonicalUrl}
         structuredData={structuredData}
       />
-      <div className="min-h-screen flex flex-col">
-        <div className="flex-1 flex flex-col items-center justify-center text-center px-4 py-16 md:py-24">
-          <div className="mb-8 md:mb-12">
-            <Tabs
-              defaultValue="companies"
-              value={selectedTab}
-              onValueChange={setSelectedTab}
-              className="w-full max-w-xs md:max-w-md"
-            >
-              <TabsList className="grid w-full grid-cols-2 bg-black-1">
-                <TabsTrigger
-                  value="companies"
-                  className="data-[state=active]:bg-black-2"
-                >
-                  {t("landingPage.tabs.companies")}
-                </TabsTrigger>
-                <TabsTrigger
-                  value="municipalities"
-                  className="data-[state=active]:bg-black-2"
-                >
-                  {t("landingPage.tabs.municipalities")}
-                </TabsTrigger>
-              </TabsList>
-            </Tabs>
-          </div>
-
-          <div className="max-w-lg md:max-w-4xl mx-auto space-y-4">
-            <h1 className="text-4xl md:text-7xl font-light tracking-tight">
-              {t("landingPage.title", {
-                tabName: t(`landingPage.tabName.${selectedTab}`),
-              })}
-            </h1>
-
-            <div className="h-[80px] md:h-[120px] flex items-center justify-center text-4xl md:text-7xl font-light">
-              <Typewriter
-                text={
-                  selectedTab === "companies"
-                    ? companyTypewriterTexts
-                    : municipalityTypewriterTexts
-                }
-                speed={70}
-                className="text-[#E2FF8D]"
-                waitTime={2000}
-                deleteSpeed={40}
-                cursorChar="_"
-              />
-            </div>
-          </div>
-
-          <Button
-            className="mt-8 md:mt-12 rounded-full px-6 md:px-8 py-4 md:py-6 text-base md:text-lg bg-white text-black hover:bg-white/90"
-            asChild
+      <div className="min-h-screen w-screen flex flex-col">
+        <div className="flex w-screen min-h-screen flex-col items-center justify-center text-center relative  ">
+          <video
+            className="w-screen h-screen z-1 object-cover opacity-75"
+            autoPlay
+            loop
+            muted
+            aria-label="Panning video of mountains"
           >
-            <a
-              href={
-                selectedTab === "companies" ? "/companies" : "/municipalities"
-              }
+            <source src="./videos/mountain-optimized.mp4" type="video/mp4" />
+          </video>
+          <div className="absolute">
+            {/* <div className="mb-8 md:mb-12">
+              <Tabs
+                defaultValue="companies"
+                value={selectedTab}
+                onValueChange={setSelectedTab}
+                className="w-full max-w-xs md:max-w-md"
+              >
+                <TabsList className="grid w-full grid-cols-2 bg-black-1">
+                  <TabsTrigger
+                    value="companies"
+                    className="data-[state=active]:bg-black-2"
+                  >
+                    {t("landingPage.tabs.companies")}
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="municipalities"
+                    className="data-[state=active]:bg-black-2"
+                  >
+                    {t("landingPage.tabs.municipalities")}
+                  </TabsTrigger>
+                </TabsList>
+              </Tabs>
+            </div> */}
+
+            <div className="max-w-lg md:max-w-4xl mx-auto space-y-4">
+              <h1 className="text-4xl md:text-7xl font-light tracking-tight">
+                {t("landingPage.title", {
+                  tabName: t(`landingPage.tabName.${selectedTab}`),
+                })}
+              </h1>
+
+              <div className="h-[80px] md:h-[120px] flex items-center justify-center text-4xl md:text-7xl font-light">
+                <Typewriter
+                  text={
+                    selectedTab === "companies"
+                      ? companyTypewriterTexts
+                      : municipalityTypewriterTexts
+                  }
+                  speed={70}
+                  className="text-[#E2FF8D]"
+                  waitTime={2000}
+                  deleteSpeed={40}
+                  cursorChar="_"
+                />
+              </div>
+            </div>
+            <Button
+              className="mt-8 md:mt-12 rounded-full px-6 md:px-8 py-4 md:py-6 text-base md:text-lg bg-white text-black hover:bg-white/90"
+              asChild
             >
-              {t("landingPage.seeResults")}
-              <ArrowRight className="ml-2 h-5 w-5" />
-            </a>
-          </Button>
+              <a
+                href={
+                  selectedTab === "companies" ? "/companies" : "/municipalities"
+                }
+              >
+                {t("landingPage.seeResults")}
+                <ArrowRight className="ml-2 h-5 w-5" />
+              </a>
+            </Button>
+          </div>
+          <div
+            className={`${isMobile ? "h-[100px]" : "h-[200px]"} absolute  -bottom-2 w-full bg-gradient-to-b from-transparent to-black`}
+          ></div>
         </div>
 
         {/* FIXME reintroduce at a later stage
@@ -193,7 +208,7 @@ export function LandingPage() {
         </div>
       )} */}
 
-        <div className="py-8 md:py-24">
+        <div className="py-8 md:py-18">
           <div className="container mx-auto">
             <h2 className="text-4xl md:text-5xl font-light text-center mb-8 md:mb-16">
               {t("landingPage.bestPerformers")}
@@ -220,7 +235,7 @@ export function LandingPage() {
           </div>
         </div>
 
-        <div className="pb-8 md:pb-16">
+        <div className="mb-16 md:mt-12 md:mb-24">
           <div className="container mx-auto">
             <ContentBlock
               title={t("landingPage.aboutUsTitle")}


### PR DESCRIPTION
### ✨ What’s Changed?

This PR introduces a more defined hero-section to the landing page aswell as running a video of a panning landscape shot to try a make a connection of what it is Klimatkollen is working for/towards for a user just landing on the site. Would love feedback and thoughts on this. There's plenty of video assets to choose from aswell if you'd fancy a different one.

This PR does not contain logic for a fallback to a static img if a user has reduced-motion setting turned on. But will be added if we go forward with this idea. Also removed the "municipalities / companies tab for now.

### 📸 Screenshots (if applicable)

# Desktop
[landing-desktop.webm](https://github.com/user-attachments/assets/1332970e-02e8-4ee3-8a9c-ce1dc3a88652)

# Mobile
[landing-mobile.webm](https://github.com/user-attachments/assets/8a8d5a42-f949-4f10-9672-abedf22ac4f3)


### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [ ] I've set the labels, issue, and milestone for the PR
- [ ] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #[issue-number] <!-- or: Related to #[issue-number] -->