### PR TITLE
[569] Added a marquee for partners in footer

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -53,8 +53,8 @@ export function Footer() {
   const navigate = useNavigate();
 
   return (
-    <footer className="relative z-20 bg-black-2 py-4 md:py-8">
-      <div className="container mx-auto px-4 space-y-4 md:space-y-8 flex flex-col items-center text-center">
+    <footer className="relative w-full z-20 bg-black-2 py-4 md:py-8">
+      <div className="container mx-auto px-4 space-y-4 md:space-y-8 flex flex-col w-screen items-center text-center">
         {/* Contact Section */}
         <div className="space-y-2 md:space-y-4">
           <Text variant="h6" className="text-grey md:text-base">

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -4,6 +4,7 @@ import { Text } from "@/components/ui/text";
 import { Trans, useTranslation } from "react-i18next";
 import { Avatar, AvatarFallback, AvatarImage } from "@radix-ui/react-avatar";
 import { useNavigate } from "react-router-dom";
+import { Marquee } from "@/components/magicui/marquee.tsx";
 
 function SocialLinks() {
   return (
@@ -30,13 +31,19 @@ function SocialLinks() {
 
 function PartnerLogos() {
   return (
-    <div className="flex flex-wrap justify-center items-center gap-4 px-2 md:px-6">
+    <Marquee reverse={false} pauseOnHover={false} className="[--duration:60s]">
       {partners.map(({ href, src, alt }) => (
-        <a key={alt} href={href} target="_blank" rel="noreferrer">
+        <a
+          key={alt}
+          href={href}
+          target="_blank"
+          rel="noreferrer"
+          className="flex items-center"
+        >
           <img className="w-28 max-h-12 object-contain" src={src} alt={alt} />
         </a>
       ))}
-    </div>
+    </Marquee>
   );
 }
 
@@ -71,11 +78,13 @@ export function Footer() {
         </div>
 
         {/* Partners Section */}
-        <div className="space-y-2">
+        <div className="space-y-2 relative">
           <Text variant="h6" className="text-blue-3">
             {t("footer.supporters")}
           </Text>
+          <div className="absolute left-0 top-0 bottom-0 w-16 bg-gradient-to-r from-[var(--black-2)] to-transparent pointer-events-none z-10" />
           <PartnerLogos />
+          <div className="absolute right-0 top-0 bottom-0 w-16 bg-gradient-to-l from-[var(--black-2)] to-transparent pointer-events-none z-10" />
         </div>
 
         {/* Footer Links */}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -31,16 +31,16 @@ function SocialLinks() {
 
 function PartnerLogos() {
   return (
-    <Marquee reverse={false} pauseOnHover={false} className="[--duration:60s]">
+    <Marquee reverse={false} pauseOnHover={false} className="[--duration:80s]">
       {partners.map(({ href, src, alt }) => (
         <a
           key={alt}
           href={href}
           target="_blank"
           rel="noreferrer"
-          className="flex items-center"
+          className="flex items-center justify-center"
         >
-          <img className="w-28 max-h-12 object-contain" src={src} alt={alt} />
+          <img className="w-28 h-12 p-0 object-contain" src={src} alt={alt} />
         </a>
       ))}
     </Marquee>
@@ -82,9 +82,9 @@ export function Footer() {
           <Text variant="h6" className="text-blue-3">
             {t("footer.supporters")}
           </Text>
-          <div className="absolute left-0 top-0 bottom-0 w-16 bg-gradient-to-r from-[var(--black-2)] to-transparent pointer-events-none z-10" />
+          <div className="absolute left-20 md:left-0 top-0 bottom-0 w-24 md:w-16 bg-gradient-to-r from-[var(--black-2)] to-transparent pointer-events-none z-10" />
           <PartnerLogos />
-          <div className="absolute right-0 top-0 bottom-0 w-16 bg-gradient-to-l from-[var(--black-2)] to-transparent pointer-events-none z-10" />
+          <div className="absolute right-20 md:right-0 top-0 bottom-0 w-24 md:w-16 bg-gradient-to-l from-[var(--black-2)] to-transparent pointer-events-none z-10" />
         </div>
 
         {/* Footer Links */}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -5,6 +5,7 @@ import { Trans, useTranslation } from "react-i18next";
 import { Avatar, AvatarFallback, AvatarImage } from "@radix-ui/react-avatar";
 import { useNavigate } from "react-router-dom";
 import { Marquee } from "@/components/magicui/marquee.tsx";
+import { useReducedMotion } from "framer-motion";
 
 function SocialLinks() {
   return (
@@ -29,9 +30,21 @@ function SocialLinks() {
   );
 }
 
-function PartnerLogos() {
+interface PartnerLogoProps {
+  prefersReducedMotion: boolean | null;
+}
+
+function PartnerLogos({ prefersReducedMotion }: PartnerLogoProps) {
+  const Wrapper = prefersReducedMotion ? "div" : Marquee;
+  const wrapperProps = prefersReducedMotion
+    ? {
+        className:
+          "flex flex-wrap justify-center items-center gap-4 px-2 md:px-6",
+      }
+    : { className: "[--duration:80s]", reverse: false, pauseOnHover: false };
+
   return (
-    <Marquee reverse={false} pauseOnHover={false} className="[--duration:80s]">
+    <Wrapper {...wrapperProps}>
       {partners.map(({ href, src, alt }) => (
         <a
           key={alt}
@@ -40,16 +53,17 @@ function PartnerLogos() {
           rel="noreferrer"
           className="flex items-center justify-center"
         >
-          <img className="w-28 h-12 p-0 object-contain" src={src} alt={alt} />
+          <img className="w-28 h-12 object-contain" src={src} alt={alt} />
         </a>
       ))}
-    </Marquee>
+    </Wrapper>
   );
 }
 
 export function Footer() {
   const { t } = useTranslation();
   const { login, logout, token, user } = useAuth();
+  const prefersReducedMotion = useReducedMotion();
   const navigate = useNavigate();
 
   return (
@@ -82,9 +96,13 @@ export function Footer() {
           <Text variant="h6" className="text-blue-3">
             {t("footer.supporters")}
           </Text>
-          <div className="absolute left-20 md:left-0 top-0 bottom-0 w-24 md:w-16 bg-gradient-to-r from-[var(--black-2)] to-transparent pointer-events-none z-10" />
-          <PartnerLogos />
-          <div className="absolute right-20 md:right-0 top-0 bottom-0 w-24 md:w-16 bg-gradient-to-l from-[var(--black-2)] to-transparent pointer-events-none z-10" />
+          {prefersReducedMotion || (
+            <div className="absolute left-20 md:left-0 top-0 bottom-0 w-24 md:w-16 bg-gradient-to-r from-[var(--black-2)] to-transparent pointer-events-none z-10" />
+          )}
+          <PartnerLogos prefersReducedMotion={prefersReducedMotion} />
+          {prefersReducedMotion || (
+            <div className="absolute right-20 md:right-0 top-0 bottom-0 w-24 md:w-16 bg-gradient-to-l from-[var(--black-2)] to-transparent pointer-events-none z-10" />
+          )}
         </div>
 
         {/* Footer Links */}

--- a/src/components/magicui/marquee.tsx
+++ b/src/components/magicui/marquee.tsx
@@ -1,0 +1,73 @@
+import { cn } from "@/lib/utils";
+import { ComponentPropsWithoutRef } from "react";
+
+interface MarqueeProps extends ComponentPropsWithoutRef<"div"> {
+  /**
+   * Optional CSS class name to apply custom styles
+   */
+  className?: string;
+  /**
+   * Whether to reverse the animation direction
+   * @default false
+   */
+  reverse?: boolean;
+  /**
+   * Whether to pause the animation on hover
+   * @default false
+   */
+  pauseOnHover?: boolean;
+  /**
+   * Content to be displayed in the marquee
+   */
+  children: React.ReactNode;
+  /**
+   * Whether to animate vertically instead of horizontally
+   * @default false
+   */
+  vertical?: boolean;
+  /**
+   * Number of times to repeat the content
+   * @default 4
+   */
+  repeat?: number;
+}
+
+export function Marquee({
+  className,
+  reverse = false,
+  pauseOnHover = false,
+  children,
+  vertical = false,
+  repeat = 4,
+  ...props
+}: MarqueeProps) {
+  return (
+    <div
+      {...props}
+      className={cn(
+        "group flex overflow-hidden p-2 [--duration:40s] [--gap:1rem] [gap:var(--gap)]",
+        {
+          "flex-row": !vertical,
+          "flex-col": vertical,
+        },
+        className,
+      )}
+    >
+      {Array(repeat)
+        .fill(0)
+        .map((_, i) => (
+          <div
+            key={i}
+            className={cn("flex shrink-0 justify-around [gap:var(--gap)]", {
+              "animate-marquee flex-row": !vertical,
+              "animate-marquee-vertical flex-col": vertical,
+              "group-hover:[animation-play-state:paused]": pauseOnHover,
+              "[animation-direction:reverse]": reverse,
+            })}
+          >
+            {children}
+          </div>
+        ))}
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -65,6 +65,12 @@
   h6 {
     @apply font-light tracking-tight;
   }
+  .theme {
+    --animate-marquee:
+    marquee var(--duration) infinite linear;
+    --animate-marquee-vertical:
+    marquee-vertical var(--duration) linear infinite;
+  }
 }
 
 @layer components {
@@ -182,3 +188,34 @@ input[type='number'] {
   -moz-appearance: textfield;
 }
 
+@layer base {
+  * {
+    @apply border-border;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}
+
+@theme inline {
+  @keyframes marquee {
+  from {
+    transform:
+    translateX(0);
+    }
+  to {
+    transform:
+    translateX(calc(-100% - var(--gap)));
+    }
+  }
+  @keyframes marquee-vertical {
+  from {
+    transform:
+    translateY(0);
+    }
+  to {
+    transform:
+    translateY(calc(-100% - var(--gap)));
+    }
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -122,10 +122,15 @@ export default {
           from: { height: "var(--radix-accordion-content-height)" },
           to: { height: "0" },
         },
+        marquee: {
+          from: { transform: "translateX(0%)" },
+          to: { transform: "translateX(-100%)" },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
+        marquee: "marquee var(--duration, 20s) linear infinite",
       },
     },
   },


### PR DESCRIPTION
### ✨ What’s Changed?

Switched up the footer partners to a marquee instead per idea of @klimatkollsfrida. Would still need to look at the different sizes for the individual logos to make it look crisp. Falling back to the previous partners display if reduced motion setting is active. 

### 📸 Screenshots (if applicable)

# Desktop
[marquee-desktop.webm](https://github.com/user-attachments/assets/b854b383-2cf2-422b-80ba-0384be4a4507)

# Mobile
[marquee-mobile.webm](https://github.com/user-attachments/assets/151079a3-e911-4d63-9f34-ba3fb1f62e65)



### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [ ] I've set the labels, issue, and milestone for the PR
- [ ] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #[[569](https://github.com/Klimatbyran/frontend/issues/569)] 