### PR TITLE
FIX correct percent formatting

### DIFF
--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -88,7 +88,7 @@ export function LandingPage() {
 
   const renderMunicipalityChangeRate = (item: RankedListItem) => (
     <span className="text-base md:text-lg md:text-right text-green-3">
-      {formatPercentChange(item.value, currentLanguage)}
+      {formatPercentChange(item.value, currentLanguage, true)}
     </span>
   );
 


### PR DESCRIPTION
### ✨ What’s Changed?

Correct formatting of municipality ranked list on landing page.

### 📸 Screenshots (if applicable)

Before
<img width="640" alt="Screenshot 2025-05-07 at 16 53 34" src="https://github.com/user-attachments/assets/00903b4f-31a5-432b-98eb-1622741bd7b0" />

After
<img width="640" alt="Screenshot 2025-05-07 at 16 53 41" src="https://github.com/user-attachments/assets/9bc9a51d-ef2b-4d33-bfa7-a5e32294468e" />


### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)