### PR TITLE
[#696] Fix company card layout through container queries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@radix-ui/react-toggle": "^1.1.0",
         "@radix-ui/react-toggle-group": "^1.1.0",
         "@radix-ui/react-tooltip": "^1.1.2",
+        "@tailwindcss/container-queries": "^0.1.1",
         "@tanstack/react-query": "^5.28.4",
         "@types/papaparse": "^5.3.15",
         "class-variance-authority": "^0.7.0",
@@ -3443,6 +3444,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tailwindcss/container-queries": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/container-queries/-/container-queries-0.1.1.tgz",
+      "integrity": "sha512-p18dswChx6WnTSaJCSGx6lTmrGzNNvm2FtXmiO6AuA1V4U5REyoqwmT6kgAsIMdjo07QdAfYXHJ4hnMtfHzWgA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "tailwindcss": ">=3.2.0"
       }
     },
     "node_modules/@tanstack/query-core": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@radix-ui/react-toggle": "^1.1.0",
     "@radix-ui/react-toggle-group": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.1.2",
+    "@tailwindcss/container-queries": "^0.1.1",
     "@tanstack/react-query": "^5.28.4",
     "@types/papaparse": "^5.3.15",
     "class-variance-authority": "^0.7.0",

--- a/src/components/companies/list/CompanyCard.tsx
+++ b/src/components/companies/list/CompanyCard.tsx
@@ -12,7 +12,6 @@ import {
 } from "@/hooks/companies/useCompanyFilters";
 import type { RankedCompany } from "@/types/company";
 import { Text } from "@/components/ui/text";
-import { useScreenSize } from "@/hooks/useScreenSize";
 import { useTranslation } from "react-i18next";
 import { useCategoryMetadata } from "@/hooks/companies/useCategories";
 import { useLanguage } from "@/components/LanguageProvider";
@@ -42,8 +41,6 @@ export function CompanyCard({
   industry,
   reportingPeriods,
 }: CompanyCardProps) {
-  const { isMobile } = useScreenSize();
-
   const { t } = useTranslation();
   const { getCategoryColor } = useCategoryMetadata();
   const sectorNames = useSectorNames();
@@ -85,7 +82,7 @@ export function CompanyCard({
     : "var(--blue-2)";
 
   return (
-    <div className="relative rounded-level-2">
+    <div className="relative rounded-level-2 @container">
       <Link
         to={`/companies/${wikidataId}`}
         className="block bg-black-2 rounded-level-2 p-8 space-y-8 transition-all duration-300 hover:shadow-[0_0_10px_rgba(153,207,255,0.15)] hover:bg-[#1a1a1a]"
@@ -141,11 +138,7 @@ export function CompanyCard({
             <Building2 className="w-6 h-6" />
           </div>
         </div>
-        <div
-          className={
-            isMobile ? "flex flex-col gap-4" : "grid grid-cols-2 gap-4"
-          }
-        >
+        <div className="flex flex-col gap-4 @xl:grid grid-cols-2">
           <div className="space-y-2">
             <div className="flex items-center gap-2 text-grey mb-2 text-lg">
               <TrendingDown className="w-4 h-4" />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -129,5 +129,8 @@ export default {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [
+    require("tailwindcss-animate"),
+    require("@tailwindcss/container-queries"),
+  ],
 };


### PR DESCRIPTION
### ✨ What’s Changed?

Use container queries to better control the company card. Container queries are still somewhat new but the fallback will be for users with older browsers to always see the layout where emissions and change rates are stacked.

### 📸 Screenshots (if applicable)

Before:
<img width="1009" alt="image" src="https://github.com/user-attachments/assets/cd4b4d00-43f1-42a3-91c7-5788b0c16b30" />

After
<img width="1008" alt="image" src="https://github.com/user-attachments/assets/e7b99e52-f10b-4716-9536-f025bc953a57" />

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [ ] I've set the labels, issue, and milestone for the PR
- [ ] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #[696] <!-- or: Related to #[issue-number] -->