### PR TITLE
Fix adapt company detailed page overview to mobile

### DIFF
--- a/src/components/companies/detail/overview/CompanyDescription.tsx
+++ b/src/components/companies/detail/overview/CompanyDescription.tsx
@@ -1,0 +1,43 @@
+import { Text } from "@/components/ui/text";
+import { useTranslation } from "react-i18next";
+import { useScreenSize } from "@/hooks/useScreenSize";
+import { useState } from "react";
+
+interface CompanyDescriptionProps {
+  description: string | null;
+}
+
+export function CompanyDescription({ description }: CompanyDescriptionProps) {
+  const { t } = useTranslation();
+  const { isMobile } = useScreenSize();
+  const [showMore, setShowMore] = useState(false);
+
+  if (isMobile) {
+    return (
+      <div>
+        <button
+          className="bg-black-1 text-white px-3 py-1 rounded-md mt-1 text-sm"
+          onClick={() => setShowMore(!showMore)}
+        >
+          {showMore
+            ? t("companies.overview.readLess")
+            : t("companies.overview.readMore")}
+        </button>
+        {showMore && (
+          <Text
+            variant="body"
+            className="text-sm md:text-base lg:text-lg max-w-3xl mt-2"
+          >
+            {description}
+          </Text>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <Text variant="body" className="text-sm md:text-base lg:text-lg max-w-3xl">
+      {description}
+    </Text>
+  );
+}

--- a/src/components/companies/detail/overview/CompanyOverview.tsx
+++ b/src/components/companies/detail/overview/CompanyOverview.tsx
@@ -1,4 +1,4 @@
-import { Building2, ArrowUpRight } from "lucide-react";
+import { Building2 } from "lucide-react";
 import {
   Select,
   SelectContent,
@@ -24,7 +24,6 @@ import {
   formatEmissionsAbsolute,
   formatEmployeeCount,
   formatPercentChange,
-  localizeUnit,
 } from "@/utils/localizeUnit";
 import { cn } from "@/lib/utils";
 import { OverviewStatistics } from "./OverviewStatistics";
@@ -89,7 +88,7 @@ export function CompanyOverview({
       <div className="flex items-start justify-between mb-12">
         <div className="space-y-4">
           <div className="flex items-center gap-4">
-            <Text className=" text-4xl lg:text-6xl">{company.name}</Text>
+            <Text className="text-4xl lg:text-6xl">{company.name}</Text>
             <div className="flex flex-col h-full justify-around">
               {token && (
                 <Button
@@ -119,7 +118,7 @@ export function CompanyOverview({
               {showMore && (
                 <Text
                   variant="body"
-                  className="text-lg md:text-base sm:text-sm max-w-3xl mt-2"
+                  className="text-sm md:text-base lg:text-lg max-w-3xl mt-2"
                 >
                   {company.description}
                 </Text>
@@ -128,15 +127,15 @@ export function CompanyOverview({
           ) : (
             <Text
               variant="body"
-              className="text-lg md:text-base sm:text-sm max-w-3xl"
+              className="text-sm md:text-base lg:text-lg max-w-3xl"
             >
               {company.description}
             </Text>
           )}
-          <div className="flex flex-col sm:flex-row sm:items-center gap-2 mt-4">
+          <div className="flex flex-row items-center gap-2 mt-4">
             <Text
               variant="body"
-              className="text-grey text-lg md:text-base sm:text-sm"
+              className="text-grey text-sm md:text-base lg:text-lg"
             >
               {t("companies.overview.sector")}:
             </Text>
@@ -168,22 +167,19 @@ export function CompanyOverview({
           </div>
         </div>
         <div className="hidden md:flex w-16 h-16 rounded-full bg-blue-5/30 items-center justify-center">
-          <Building2 className="w-8 h-8 sm:w-6 sm:h-6 text-blue-2" />
+          <Building2 className="w-8 h-8 text-blue-2" />
         </div>
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-8 md:gap-16">
         <div>
-          <Text
-            variant="body"
-            className="mb-2 lg:text-lg md:text-base sm:text-sm"
-          >
+          <Text variant="body" className="mb-2 lg:text-lg md:text-base text-sm">
             {t("companies.overview.totalEmissions")} {periodYear}
           </Text>
           <div className="flex items-baseline gap-4">
             <Text
               className={cn(
-                "text-3xl lg:text-6xl md:text-4xl sm:text-3xl font-light tracking-tighter leading-none",
+                "text-3xl md:text-4xl lg:text-6xl font-light tracking-tighter leading-none",
                 selectedPeriod.emissions?.calculatedTotalEmissions === 0
                   ? "text-grey"
                   : "text-orange-2",
@@ -196,7 +192,7 @@ export function CompanyOverview({
                     selectedPeriod.emissions.calculatedTotalEmissions,
                     currentLanguage,
                   )}
-              <span className="text-lg lg:text-2xl md:text-lg sm:text-sm ml-2 text-grey">
+              <span className="text-sm md:text-lg lg:text-2xl ml-2 text-grey">
                 {t(
                   selectedPeriod.emissions?.calculatedTotalEmissions === 0
                     ? " "
@@ -214,7 +210,7 @@ export function CompanyOverview({
             </Text>
             <CompanyOverviewTooltip yearOverYearChange={yearOverYearChange} />
           </div>
-          <Text className="text-3xl lg:text-6xl md:text-4xl sm:text-3xl font-light tracking-tighter leading-none">
+          <Text className="text-3xl md:text-4xl lg:text-6xl font-light tracking-tighter leading-none">
             {yearOverYearChange !== null ? (
               <span
                 className={

--- a/src/components/companies/detail/overview/CompanyOverview.tsx
+++ b/src/components/companies/detail/overview/CompanyOverview.tsx
@@ -27,13 +27,8 @@ import {
   localizeUnit,
 } from "@/utils/localizeUnit";
 import { cn } from "@/lib/utils";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import { Info } from "lucide-react";
+import { OverviewStatistics } from "./OverviewStatistics";
+import { CompanyOverviewTooltip } from "./CompanyOverviewTooltip";
 
 interface CompanyOverviewProps {
   company: CompanyDetails;
@@ -90,7 +85,7 @@ export function CompanyOverview({
     : t("companies.overview.notReported");
 
   return (
-    <div className="bg-black-2 rounded-level-1 p-16">
+    <div className="bg-black-2 rounded-level-1 p-8 md:p-16">
       <div className="flex items-start justify-between mb-12">
         <div className="space-y-4">
           <div className="flex items-center gap-4">
@@ -217,29 +212,7 @@ export function CompanyOverview({
             <Text className="mb-2 lg:text-lg md:text-base sm:text-sm">
               {t("companies.overview.changeSinceLastYear")}
             </Text>
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger>
-                  <Info className="w-4 h-4 mb-2" />
-                </TooltipTrigger>
-                <TooltipContent className="max-w-80">
-                  {yearOverYearChange !== null ? (
-                    yearOverYearChange <= -80 || yearOverYearChange >= 80 ? (
-                      <>
-                        <p>{t("companies.card.emissionsChangeRateInfo")}</p>
-                        <p className="my-2">
-                          {t("companies.card.emissionsChangeRateInfoExtended")}
-                        </p>
-                      </>
-                    ) : (
-                      <p>{t("companies.card.emissionsChangeRateInfo")}</p>
-                    )
-                  ) : (
-                    <p>{t("companies.card.noData")}</p>
-                  )}
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
+            <CompanyOverviewTooltip yearOverYearChange={yearOverYearChange} />
           </div>
           <Text className="text-3xl lg:text-6xl md:text-4xl sm:text-3xl font-light tracking-tighter leading-none">
             {yearOverYearChange !== null ? (
@@ -262,46 +235,11 @@ export function CompanyOverview({
         </div>
       </div>
 
-      <div className="mt-12 bg-black-1 rounded-level-2 p-8 md:p-6 sm:p-4">
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-          <div>
-            <Text className="mb-2 text-base md:text-base sm:text-sm">
-              {t("companies.overview.turnover")} ({periodYear})
-            </Text>
-            <Text className="text-base md:text-base sm:text-sm">
-              {selectedPeriod.economy?.turnover?.value
-                ? `${localizeUnit(
-                    selectedPeriod.economy.turnover.value / 1e9,
-                    currentLanguage,
-                  )} mdr ${selectedPeriod.economy.turnover.currency}`
-                : t("companies.overview.notReported")}
-            </Text>
-          </div>
-
-          <div>
-            <Text className="text-base md:text-base sm:text-sm mb-2">
-              {t("companies.overview.employees")} ({periodYear})
-            </Text>
-            <Text className="text-base md:text-base sm:text-sm">
-              {formattedEmployeeCount}
-            </Text>
-          </div>
-
-          {selectedPeriod?.reportURL && (
-            <div className="flex items-end">
-              <a
-                href={selectedPeriod.reportURL}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 text-blue-2 hover:text-blue-1 transition-colors"
-              >
-                {t("companies.overview.readAnnualReport")}
-                <ArrowUpRight className="w-4 h-4 sm:w-3 sm:h-3" />
-              </a>
-            </div>
-          )}
-        </div>
-      </div>
+      <OverviewStatistics
+        selectedPeriod={selectedPeriod}
+        currentLanguage={currentLanguage}
+        formattedEmployeeCount={formattedEmployeeCount}
+      />
     </div>
   );
 }

--- a/src/components/companies/detail/overview/CompanyOverview.tsx
+++ b/src/components/companies/detail/overview/CompanyOverview.tsx
@@ -9,8 +9,6 @@ import {
 import { Text } from "@/components/ui/text";
 import type { CompanyDetails, ReportingPeriod } from "@/types/company";
 import { useTranslation } from "react-i18next";
-import { useScreenSize } from "@/hooks/useScreenSize";
-import { useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { Button } from "@/components/ui/button";
 import { useNavigate } from "react-router-dom";
@@ -84,7 +82,7 @@ export function CompanyOverview({
 
   return (
     <div className="bg-black-2 rounded-level-1 p-8 md:p-16">
-      <div className="flex items-start justify-between mb-12">
+      <div className="flex items-start justify-between mb-4 md:mb-12">
         <div className="space-y-4">
           <div className="flex items-center gap-4">
             <Text className="text-4xl lg:text-6xl">{company.name}</Text>
@@ -105,18 +103,18 @@ export function CompanyOverview({
             </div>
           </div>
           <CompanyDescription description={company.description} />
-          <div className="flex flex-row items-center gap-2 mt-4">
+          <div className="flex flex-row items-center gap-2 my-4">
             <Text
               variant="body"
               className="text-grey text-sm md:text-base lg:text-lg"
             >
               {t("companies.overview.sector")}:
             </Text>
-            <Text variant="body" className="text-lg md:text-base sm:text-sm">
+            <Text variant="body" className="text-sm md:text-base lg:text-lg">
               {sectorName}
             </Text>
           </div>
-          <div className="mt-4 w-full max-w-[180px]">
+          <div className="my-4 w-full max-w-[180px]">
             <Select value={selectedYear} onValueChange={onYearSelect}>
               <SelectTrigger className="w-full bg-black-1 text-white px-3 py-2 rounded-md">
                 <SelectValue placeholder={t("companies.overview.selectYear")} />
@@ -144,7 +142,7 @@ export function CompanyOverview({
         </div>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-8 md:gap-16">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-16">
         <div>
           <Text variant="body" className="mb-2 lg:text-lg md:text-base text-sm">
             {t("companies.overview.totalEmissions")} {periodYear}

--- a/src/components/companies/detail/overview/CompanyOverview.tsx
+++ b/src/components/companies/detail/overview/CompanyOverview.tsx
@@ -28,6 +28,7 @@ import {
 import { cn } from "@/lib/utils";
 import { OverviewStatistics } from "./OverviewStatistics";
 import { CompanyOverviewTooltip } from "./CompanyOverviewTooltip";
+import { CompanyDescription } from "./CompanyDescription";
 
 interface CompanyOverviewProps {
   company: CompanyDetails;
@@ -45,8 +46,6 @@ export function CompanyOverview({
   selectedYear,
 }: CompanyOverviewProps) {
   const { t } = useTranslation();
-  const { isMobile } = useScreenSize();
-  const [showMore, setShowMore] = useState(false);
   const { token } = useAuth();
   const navigate = useNavigate();
   const sectorNames = useSectorNames();
@@ -105,33 +104,7 @@ export function CompanyOverview({
               )}
             </div>
           </div>
-          {isMobile ? (
-            <div>
-              <button
-                className="bg-black-1 text-white px-3 py-1 rounded-md mt-1 text-sm"
-                onClick={() => setShowMore(!showMore)}
-              >
-                {showMore
-                  ? t("companies.overview.readLess")
-                  : t("companies.overview.readMore")}
-              </button>
-              {showMore && (
-                <Text
-                  variant="body"
-                  className="text-sm md:text-base lg:text-lg max-w-3xl mt-2"
-                >
-                  {company.description}
-                </Text>
-              )}
-            </div>
-          ) : (
-            <Text
-              variant="body"
-              className="text-sm md:text-base lg:text-lg max-w-3xl"
-            >
-              {company.description}
-            </Text>
-          )}
+          <CompanyDescription description={company.description} />
           <div className="flex flex-row items-center gap-2 mt-4">
             <Text
               variant="body"

--- a/src/components/companies/detail/overview/CompanyOverviewTooltip.tsx
+++ b/src/components/companies/detail/overview/CompanyOverviewTooltip.tsx
@@ -1,0 +1,44 @@
+import { Info } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useTranslation } from "react-i18next";
+
+interface CompanyOverviewTooltipProps {
+  yearOverYearChange: number | null;
+}
+
+export function CompanyOverviewTooltip({
+  yearOverYearChange,
+}: CompanyOverviewTooltipProps) {
+  const { t } = useTranslation();
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger>
+          <Info className="w-4 h-4 mb-2" />
+        </TooltipTrigger>
+        <TooltipContent className="max-w-80">
+          {yearOverYearChange !== null ? (
+            yearOverYearChange <= -80 || yearOverYearChange >= 80 ? (
+              <>
+                <p>{t("companies.card.emissionsChangeRateInfo")}</p>
+                <p className="my-2">
+                  {t("companies.card.emissionsChangeRateInfoExtended")}
+                </p>
+              </>
+            ) : (
+              <p>{t("companies.card.emissionsChangeRateInfo")}</p>
+            )
+          ) : (
+            <p>{t("companies.card.noData")}</p>
+          )}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/src/components/companies/detail/overview/OverviewStatistics.tsx
+++ b/src/components/companies/detail/overview/OverviewStatistics.tsx
@@ -1,0 +1,58 @@
+import { Text } from "@/components/ui/text";
+import { ReportingPeriod } from "@/types/company";
+import { localizeUnit } from "@/utils/localizeUnit";
+import { t } from "i18next";
+import { ArrowUpRight } from "lucide-react";
+
+interface OverviewStatisticProps {
+  selectedPeriod: ReportingPeriod;
+  currentLanguage: "sv" | "en";
+  formattedEmployeeCount: string;
+}
+
+export function OverviewStatistics({
+  selectedPeriod,
+  currentLanguage,
+  formattedEmployeeCount,
+}: OverviewStatisticProps) {
+  return (
+    <div className="mt-8 md:mt-12 bg-black-1 rounded-level-2 p-6 md:p-8">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 md:gap-8">
+        <div>
+          <Text className="md:mb-2 font-bold">
+            {t("companies.overview.turnover")}
+          </Text>
+          <Text>
+            {selectedPeriod.economy?.turnover?.value
+              ? `${localizeUnit(
+                  selectedPeriod.economy.turnover.value / 1e9,
+                  currentLanguage,
+                )} mdr ${selectedPeriod.economy.turnover.currency}`
+              : t("companies.overview.notReported")}
+          </Text>
+        </div>
+
+        <div>
+          <Text className="md:mb-2 font-bold">
+            {t("companies.overview.employees")}
+          </Text>
+          <Text>{formattedEmployeeCount}</Text>
+        </div>
+
+        {selectedPeriod?.reportURL && (
+          <div className="flex items-end">
+            <a
+              href={selectedPeriod.reportURL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 text-blue-2 hover:text-blue-1 transition-colors"
+            >
+              {t("companies.overview.readAnnualReport")}
+              <ArrowUpRight className="w-4 h-4 sm:w-3 sm:h-3" />
+            </a>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/CompanyDetailPage.tsx
+++ b/src/pages/CompanyDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useParams } from "react-router-dom";
 import { useState, useEffect } from "react";
 import { useCompanyDetails } from "@/hooks/companies/useCompanyDetails";
-import { CompanyOverview } from "@/components/companies/detail/CompanyOverview";
+import { CompanyOverview } from "@/components/companies/detail/overview/CompanyOverview";
 import { CompanyHistory } from "@/components/companies/detail/CompanyHistory";
 import { Text } from "@/components/ui/text";
 import { useTranslation } from "react-i18next";
@@ -11,7 +11,7 @@ import { CompanyScope3 } from "@/components/companies/detail/CompanyScope3";
 
 export function CompanyDetailPage() {
   const { t } = useTranslation();
-  const { id, slug } = useParams<{ id: string; slug?: string }>();
+  const { id } = useParams<{ id: string; slug?: string }>();
   // The id parameter is always the Wikidata ID (Q-number)
   // It's either directly from /companies/:id or extracted from /foretag/:slug-:id
   const { company, loading, error } = useCompanyDetails(id!);
@@ -165,7 +165,7 @@ export function CompanyDetailPage() {
         )}
       </PageSEO>
 
-      <div className="space-y-16 max-w-[1400px] mx-auto">
+      <div className="space-y-8 md:space-y-16 max-w-[1400px] mx-auto">
         <CompanyOverview
           company={company}
           selectedPeriod={selectedPeriod}


### PR DESCRIPTION
### ✨ What’s Changed?

Decreased margins, paddings and gaps of company overview to make it better suited to mobile screens. Also broke out compontents to make it simpler to read and maintained (more work can be done here tho).

### 📸 Screenshots (if applicable)

Before
<img width="408" alt="Screenshot 2025-05-10 at 18 30 17" src="https://github.com/user-attachments/assets/48aa19c4-a0b9-450a-b84c-c748128fa2a1" />


After
<img width="408" alt="Screenshot 2025-05-10 at 18 30 13" src="https://github.com/user-attachments/assets/3c7c58f2-bcdd-4603-af63-1a3f77e7f1d9" />


### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)