### PR TITLE
#689 Use compact numbers in historical emissions charts Y axis

### DIFF
--- a/src/components/companies/detail/history/EmissionsLineChart.tsx
+++ b/src/components/companies/detail/history/EmissionsLineChart.tsx
@@ -10,7 +10,7 @@ import {
 import { CustomTooltip } from "../CustomTooltip";
 import { ChartData } from "@/types/emissions";
 import { t } from "i18next";
-import { formatEmissionsAbsolute } from "@/utils/localizeUnit";
+import { formatEmissionsAbsoluteCompact } from "@/utils/localizeUnit";
 
 interface EmissionsLineChartProps {
   data: ChartData[];
@@ -91,11 +91,11 @@ export default function EmissionsLineChart({
           tickLine={false}
           axisLine={true}
           tick={{ fontSize: 12 }}
-          width={80}
+          width={40}
           domain={[0, "auto"]}
           padding={{ top: 0, bottom: 0 }}
           tickFormatter={(value) =>
-            formatEmissionsAbsolute(value, currentLanguage)
+            formatEmissionsAbsoluteCompact(value, currentLanguage)
           }
         />
         <Tooltip

--- a/src/components/municipalities/MunicipalityEmissionsGraph.tsx
+++ b/src/components/municipalities/MunicipalityEmissionsGraph.tsx
@@ -13,7 +13,10 @@ import {
 } from "recharts";
 import { useTranslation } from "react-i18next";
 import { useLanguage } from "../LanguageProvider";
-import { formatEmissionsAbsolute } from "@/utils/localizeUnit";
+import {
+  formatEmissionsAbsolute,
+  formatEmissionsAbsoluteCompact,
+} from "@/utils/localizeUnit";
 
 interface DataPoint {
   year: number;
@@ -101,7 +104,7 @@ export const MunicipalityEmissionsGraph: FC<
             axisLine={false}
             tick={{ fontSize: 12 }}
             tickFormatter={(value) =>
-              formatEmissionsAbsolute(value, currentLanguage)
+              formatEmissionsAbsoluteCompact(value, currentLanguage)
             }
             width={80}
             domain={[0, "auto"]}

--- a/src/utils/localizeUnit.ts
+++ b/src/utils/localizeUnit.ts
@@ -42,6 +42,16 @@ export function formatEmissionsAbsolute(
   return localizeNumber(count, currentLanguage, { maximumFractionDigits: 0 });
 }
 
+export function formatEmissionsAbsoluteCompact(
+  count: number,
+  currentLanguage: SupportedLanguage,
+) {
+  return localizeNumber(count, currentLanguage, {
+    notation: "compact",
+    maximumFractionDigits: 0,
+  });
+}
+
 export function formatPercentChange(
   value: number,
   currentLanguage: SupportedLanguage,


### PR DESCRIPTION
> ### ✨ What’s Changed?

Introduced a new compact version number formatting for the emissions so that the Y axis labels take less space, and thus the graph can take more estate on mobile screen sizes.

### 📸 Screenshots (if applicable)
Before: 
![image](https://github.com/user-attachments/assets/82e56ff5-bfac-43c2-b4f8-c8a4690516b1)

![image](https://github.com/user-attachments/assets/034ce509-2de1-4601-80d3-43b29e88c33a)


After:
![image](https://github.com/user-attachments/assets/cccd91f0-a885-4086-802b-172028b8a4b5)
![Screenshot 2025-05-11 at 14 42 11](https://github.com/user-attachments/assets/411d12e1-81e9-480b-9d6d-30275ad7620a)

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [ ] I've set the labels, issue, and milestone for the PR
- [ ] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #689