### PR TITLE
Fix municipality change percent formatting

### DIFF
--- a/src/components/municipalities/list/MunicipalityCard.tsx
+++ b/src/components/municipalities/list/MunicipalityCard.tsx
@@ -30,10 +30,7 @@ export function MunicipalityCard({ municipality }: MunicipalityCardProps) {
 
   const emissionsChangeExists = municipality.historicalEmissionChangePercent;
   const emissionsChange = emissionsChangeExists
-    ? formatPercentChange(
-        Math.ceil(emissionsChangeExists) / 100,
-        currentLanguage,
-      )
+    ? formatPercentChange(Math.ceil(emissionsChangeExists), currentLanguage)
     : t("municipalities.card.noData");
 
   const noClimatePlan = !municipality.climatePlanLink;

--- a/src/components/municipalities/list/MunicipalityCard.tsx
+++ b/src/components/municipalities/list/MunicipalityCard.tsx
@@ -1,5 +1,4 @@
 import { Link } from "react-router-dom";
-import { ArrowUpRight, FileText } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { Text } from "@/components/ui/text";
 import { cn } from "@/lib/utils";
@@ -30,7 +29,7 @@ export function MunicipalityCard({ municipality }: MunicipalityCardProps) {
 
   const emissionsChangeExists = municipality.historicalEmissionChangePercent;
   const emissionsChange = emissionsChangeExists
-    ? formatPercentChange(Math.ceil(emissionsChangeExists), currentLanguage)
+    ? formatPercentChange(emissionsChangeExists, currentLanguage)
     : t("municipalities.card.noData");
 
   const noClimatePlan = !municipality.climatePlanLink;


### PR DESCRIPTION
### ✨ What’s Changed?

Remove division by 100 of municipality historical change percent on compare view to align with the API.
The issue was caused by inconsistencies in backend data presentation, which has been fixed in seperate PR in the municipality data pipeline.

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)