### PR TITLE
FIX change municipality card KPI colors to match rest of site

### DIFF
--- a/src/components/municipalities/list/MunicipalityCard.tsx
+++ b/src/components/municipalities/list/MunicipalityCard.tsx
@@ -101,14 +101,14 @@ export function MunicipalityCard({ municipality }: MunicipalityCardProps) {
           title={t("municipalities.card.emission", { year: lastYear })}
           tooltip={t("municipalities.card.emissionInfo", { year: lastYear })}
           value={lastYearEmissions}
-          textColor="text-orange-3"
+          textColor="text-orange-2"
           unit={t("emissionsUnit")}
         />
         <CardInfo
           title={t("municipalities.card.changeRate")}
           tooltip={t("municipalities.card.changeRateInfo")}
           value={emissionsChange}
-          textColor={meetsParis ? "text-green-3" : "text-pink-3"}
+          textColor="text-orange-2"
         />
       </div>
       <LinkCard


### PR DESCRIPTION
### ✨ What’s Changed?

Change colors for emissions last year as well as historic change percent to match rest of site.

### 📸 Screenshots (if applicable)

Before
<img width="697" alt="Screenshot 2025-05-13 at 07 51 13" src="https://github.com/user-attachments/assets/a854dea9-458e-414f-a1d2-0337800671e4" />


After
<img width="697" alt="Screenshot 2025-05-13 at 07 51 22" src="https://github.com/user-attachments/assets/1d80d9af-b620-4ad3-9b9d-654f2069fdf4" />


### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)