### PR TITLE
FIX change company card emissions and change rate colors

### DIFF
--- a/src/components/companies/list/CompanyCard.tsx
+++ b/src/components/companies/list/CompanyCard.tsx
@@ -156,7 +156,7 @@ export function CompanyCard({
             </div>
             <div className="text-3xl font-light">
               {currentEmissions ? (
-                <span className="text-orange-3">
+                <span className="text-orange-2">
                   {formatEmissionsAbsolute(currentEmissions, currentLanguage)}
                   <span className="text-lg text-grey ml-1">
                     {t("emissionsUnit")}
@@ -199,11 +199,7 @@ export function CompanyCard({
             </div>
             <div className="text-3xl font-light">
               {emissionsChange !== null ? (
-                <span
-                  className={
-                    emissionsChange < 0 ? "text-green-3" : "text-pink-3"
-                  }
-                >
+                <span className="text-orange-2">
                   {formatPercentChange(
                     Math.ceil(emissionsChange) / 100,
                     currentLanguage,


### PR DESCRIPTION
### ✨ What’s Changed?

Change company card change rate and total emissions colors to match rest of site, from pink/green and deeper orange to a lighter orange shade we use for "neutral" values.

### 📸 Screenshots (if applicable)

Before
<img width="697" alt="Screenshot 2025-05-13 at 08 41 00" src="https://github.com/user-attachments/assets/61be6f6f-fdb0-43da-b0a0-8141e05cca86" />


After
<img width="697" alt="Screenshot 2025-05-13 at 08 40 56" src="https://github.com/user-attachments/assets/269e8c5b-3bda-40d3-9eee-7604b39f28d2" />



### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)