### PR TITLE
[chore] Update eslint conf to use _ for unused vars

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,6 +26,21 @@ export default tseslint.config(
       // Suppress defaultProps deprecation warnings from Recharts
       "react/no-deprecated": "off",
       "react/default-props-match-prop-types": "off",
+
+      // Mimic Typescripts noUnusedLocals and noUnusedParameters behaviour
+      // https://typescript-eslint.io/rules/no-unused-vars/#what-benefits-does-this-rule-have-over-typescript
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          args: "all",
+          argsIgnorePattern: "^_",
+          caughtErrors: "all",
+          caughtErrorsIgnorePattern: "^_",
+          destructuredArrayIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          ignoreRestSiblings: true,
+        },
+      ],
     },
   },
 );


### PR DESCRIPTION
This change mimics the noUnusedLocals and noUnusedParameters Typescript compiler flags. With this you can use _ to indicate that a local declaration is unused which is very helpful when deconstructing arrays or have to match a certain function signature but don't need all arguments.

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #[issue-number] <!-- or: Related to #[issue-number] -->