### PR TITLE
FIX update color use so increases in emissions are marked red

### DIFF
--- a/src/components/municipalities/list/MunicipalityCard.tsx
+++ b/src/components/municipalities/list/MunicipalityCard.tsx
@@ -104,7 +104,9 @@ export function MunicipalityCard({ municipality }: MunicipalityCardProps) {
           title={t("municipalities.card.changeRate")}
           tooltip={t("municipalities.card.changeRateInfo")}
           value={emissionsChange}
-          textColor="text-orange-2"
+          textColor={cn(
+            emissionsChangeExists > 0 ? "text-pink-3" : "text-orange-2",
+          )}
         />
       </div>
       <LinkCard

--- a/src/pages/MunicipalityDetailPage.tsx
+++ b/src/pages/MunicipalityDetailPage.tsx
@@ -201,7 +201,11 @@ export function MunicipalityDetailPage() {
                 municipality.historicalEmissionChangePercent,
                 currentLanguage,
               )}`,
-              valueClassName: "text-orange-2",
+              valueClassName: cn(
+                municipality.historicalEmissionChangePercent > 0
+                  ? "text-pink-3"
+                  : "text-orange-2",
+              ),
             },
             {
               title: t("municipalityDetailPage.reductionToMeetParis"),


### PR DESCRIPTION
### ✨ What’s Changed?

Follow up PR to #703 , where colors now align with decision to have increases in emissions as red and decreases as orange. Here also at municipality card and detailed page.

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)