### PR TITLE
707 correct company pie chart tooltip location

### DIFF
--- a/src/components/companies/sectors/charts/SectorEmissionsChart.tsx
+++ b/src/components/companies/sectors/charts/SectorEmissionsChart.tsx
@@ -141,8 +141,8 @@ const SectorEmissionsChart: React.FC<EmissionsChartProps> = ({
         <ResponsiveContainer width="100%" height="100%">
           {chartType === "pie" ? (
             totalEmissions > 0 ? (
-              <div className="flex flex-col gap-4 mt-8 md:flex-row md:gap-8">
-                <div className="md:w-2/3 md:h-full w-full">
+              <div className="flex flex-col gap-4 mt-8 lg:flex-row lg:gap-8">
+                <div className="w-full lg:w-1/2 lg:h-full">
                   <PieChartView
                     pieChartData={pieChartDataWithColor}
                     size={size}
@@ -153,7 +153,7 @@ const SectorEmissionsChart: React.FC<EmissionsChartProps> = ({
                     layout={screenSize.isMobile ? "mobile" : "desktop"}
                   />
                 </div>
-                <div className={"w-full md:w-1/3 flex md:items-center"}>
+                <div className={"w-full h-full flex lg:w-1/2 lg:items-center"}>
                   <SectorPieLegend
                     payload={pieChartDataWithColor}
                     selectedLabel={selectedSector}

--- a/src/components/companies/sectors/charts/SectorPieLegend.tsx
+++ b/src/components/companies/sectors/charts/SectorPieLegend.tsx
@@ -44,89 +44,72 @@ const SectorPieLegend: React.FC<PieLegendProps> = ({
   }
 
   const handleItemClick = (entry: PieLegendEntry) => {
-    const isCompanyView = entry.wikidataId || entry.wikidataId;
-
-    if (isCompanyView) {
-      // If we're viewing companies within a sector, navigate to company detail page
-      const wikidataId = entry.wikidataId || entry.wikidataId;
-      if (wikidataId) {
-        navigateToCompany(wikidataId);
-      }
-    } else {
-      // If we're viewing sectors, handle the sector selection
-      const sectorCode = entry.sectorCode || entry.sectorCode;
-      if (sectorCode) {
-        handlePieClick({ sectorCode });
-      }
+    if (entry.wikidataId) {
+      navigateToCompany(entry.wikidataId);
+    } else if (entry.sectorCode) {
+      handlePieClick({ sectorCode: entry.sectorCode });
     }
   };
 
   return (
-    <div className="w-full min-w-0 flex-1">
-      <div className="container-type-inline-size w-full m-w-0 flex-1">
-        <TooltipProvider>
-          <div className="legend-list">
-            {payload.map((entry, index) => {
-              const value = entry.value || entry.value;
-              const total = entry.total || entry.total;
-              const percentage =
-                value / total < 0.001
-                  ? "<0.1%"
-                  : formatPercent(value / total, currentLanguage);
+    <TooltipProvider>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-2 max-h-[300px] lg:max-h-[600px] overflow-y-auto w-full ">
+        {payload.map((entry, index) => {
+          const { sectorCode, value, total } = entry;
+          const percentage =
+            value / total < 0.001
+              ? "<0.1%"
+              : formatPercent(value / total, currentLanguage);
 
-              let color;
-              if (selectedLabel) {
-                color = getCompanyColors(index).base;
-              } else if (entry.sectorCode || entry.sectorCode) {
-                const sectorCode = entry.sectorCode || entry.sectorCode;
-                color =
-                  sectorColors[sectorCode as keyof typeof sectorColors]?.base;
-              } else {
-                color = "var(--grey)";
-              }
+          let color;
+          if (selectedLabel) {
+            color = getCompanyColors(index).base;
+          } else if (sectorCode) {
+            color = sectorColors[sectorCode as keyof typeof sectorColors]?.base;
+          } else {
+            color = "var(--grey)";
+          }
 
-              return (
-                <Tooltip key={`legend-${index}`}>
-                  <TooltipTrigger asChild>
-                    <div
-                      className={`flex items-center gap-2 p-2 rounded bg-black-2 hover:bg-black-1 transition-colors cursor-pointer ${
-                        selectedLabel ? "hover:ring-1 hover:ring-black-1" : ""
-                      }`}
-                      onClick={() => handleItemClick(entry)}
-                    >
-                      <div
-                        className="w-3 h-3 rounded-md flex-shrink-0"
-                        style={{ backgroundColor: color }}
-                      />
-                      <div className="min-w-0 flex-1">
-                        <div className="text-sm text-white truncate">
-                          {entry.name || entry.value}
-                        </div>
-                        <div className="text-xs text-grey flex justify-between">
-                          <span>
-                            {formatEmissionsAbsolute(
-                              Math.round(value),
-                              currentLanguage,
-                            )}{" "}
-                            {t("emissionsUnit")}
-                          </span>
-                          <span>{percentage}</span>
-                        </div>
-                      </div>
+          return (
+            <Tooltip key={`legend-${index}`}>
+              <TooltipTrigger asChild>
+                <div
+                  className={`flex items-center gap-2 p-2 rounded bg-black-2 hover:bg-black-1 transition-colors cursor-pointer ${
+                    selectedLabel ? "hover:ring-1 hover:ring-black-1" : ""
+                  }`}
+                  onClick={() => handleItemClick(entry)}
+                >
+                  <div
+                    className="w-3 h-3 rounded-md flex-shrink-0"
+                    style={{ backgroundColor: color }}
+                  />
+                  <div className="min-w-0 flex-1">
+                    <div className="text-sm text-white truncate">
+                      {entry.name || entry.value}
                     </div>
-                  </TooltipTrigger>
-                  <TooltipContent className="bg-black-1 text-white">
-                    {selectedLabel
-                      ? t("companiesPage.sectorGraphs.pieLegendCompany")
-                      : t("companiesPage.sectorGraphs.pieLegendSector")}
-                  </TooltipContent>
-                </Tooltip>
-              );
-            })}
-          </div>
-        </TooltipProvider>
+                    <div className="text-xs text-grey flex justify-between">
+                      <span>
+                        {formatEmissionsAbsolute(
+                          Math.round(value),
+                          currentLanguage,
+                        )}{" "}
+                        {t("emissionsUnit")}
+                      </span>
+                      <span>{percentage}</span>
+                    </div>
+                  </div>
+                </div>
+              </TooltipTrigger>
+              <TooltipContent className="bg-black-1 text-white">
+                {selectedLabel
+                  ? t("companiesPage.sectorGraphs.pieLegendCompany")
+                  : t("companiesPage.sectorGraphs.pieLegendSector")}
+              </TooltipContent>
+            </Tooltip>
+          );
+        })}
       </div>
-    </div>
+    </TooltipProvider>
   );
 };
 

--- a/src/components/companies/sectors/charts/SectorPieLegend.tsx
+++ b/src/components/companies/sectors/charts/SectorPieLegend.tsx
@@ -13,10 +13,18 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 
+interface PieLegendEntry {
+  name: string;
+  value: number;
+  total: number;
+  sectorCode?: string;
+  wikidataId?: string;
+}
+
 interface PieLegendProps {
-  payload: any[];
+  payload: PieLegendEntry[];
   selectedLabel: string | null;
-  handlePieClick: (data: any) => void;
+  handlePieClick: (data: { sectorCode: string }) => void;
 }
 
 const SectorPieLegend: React.FC<PieLegendProps> = ({
@@ -35,19 +43,18 @@ const SectorPieLegend: React.FC<PieLegendProps> = ({
     return null;
   }
 
-  const handleItemClick = (entry: any) => {
-    const isCompanyView =
-      payload?.[0]?.wikidataId || payload?.[0]?.payload?.wikidataId;
+  const handleItemClick = (entry: PieLegendEntry) => {
+    const isCompanyView = entry.wikidataId || entry.wikidataId;
 
     if (isCompanyView) {
       // If we're viewing companies within a sector, navigate to company detail page
-      const wikidataId = entry.wikidataId || entry.payload?.wikidataId;
+      const wikidataId = entry.wikidataId || entry.wikidataId;
       if (wikidataId) {
         navigateToCompany(wikidataId);
       }
     } else {
       // If we're viewing sectors, handle the sector selection
-      const sectorCode = entry.sectorCode || entry.payload?.sectorCode;
+      const sectorCode = entry.sectorCode || entry.sectorCode;
       if (sectorCode) {
         handlePieClick({ sectorCode });
       }
@@ -60,8 +67,8 @@ const SectorPieLegend: React.FC<PieLegendProps> = ({
         <TooltipProvider>
           <div className="legend-list">
             {payload.map((entry, index) => {
-              const value = entry.payload?.value || entry.value;
-              const total = entry.payload?.total || entry.total;
+              const value = entry.value || entry.value;
+              const total = entry.total || entry.total;
               const percentage =
                 value / total < 0.001
                   ? "<0.1%"
@@ -70,9 +77,8 @@ const SectorPieLegend: React.FC<PieLegendProps> = ({
               let color;
               if (selectedLabel) {
                 color = getCompanyColors(index).base;
-              } else if (entry.payload?.sectorCode || entry.sectorCode) {
-                const sectorCode =
-                  entry.payload?.sectorCode || entry.sectorCode;
+              } else if (entry.sectorCode || entry.sectorCode) {
+                const sectorCode = entry.sectorCode || entry.sectorCode;
                 color =
                   sectorColors[sectorCode as keyof typeof sectorColors]?.base;
               } else {
@@ -89,7 +95,7 @@ const SectorPieLegend: React.FC<PieLegendProps> = ({
                       onClick={() => handleItemClick(entry)}
                     >
                       <div
-                        className="w-3 h-3 rounded flex-shrink-0"
+                        className="w-3 h-3 rounded-md flex-shrink-0"
                         style={{ backgroundColor: color }}
                       />
                       <div className="min-w-0 flex-1">

--- a/src/components/companies/sectors/charts/SectorPieLegend.tsx
+++ b/src/components/companies/sectors/charts/SectorPieLegend.tsx
@@ -4,7 +4,6 @@ import {
   sectorColors,
   getCompanyColors,
 } from "@/hooks/companies/useCompanyFilters";
-import { useScreenSize } from "@/hooks/useScreenSize";
 import { formatEmissionsAbsolute, formatPercent } from "@/utils/localizeUnit";
 import { useLanguage } from "@/components/LanguageProvider";
 import {
@@ -25,7 +24,6 @@ const SectorPieLegend: React.FC<PieLegendProps> = ({
   selectedLabel,
   handlePieClick,
 }) => {
-  const screenSize = useScreenSize();
   const { t } = useTranslation();
   const { currentLanguage } = useLanguage();
 
@@ -57,11 +55,8 @@ const SectorPieLegend: React.FC<PieLegendProps> = ({
   };
 
   return (
-    <div style={{ width: "100%", minWidth: 0, flex: 1 }}>
-      <div
-        className="container-type-inline-size"
-        style={{ width: "100%", minWidth: 0, flex: 1 }}
-      >
+    <div className="w-full min-w-0 flex-1">
+      <div className="container-type-inline-size w-full m-w-0 flex-1">
         <TooltipProvider>
           <div className="legend-list">
             {payload.map((entry, index) => {

--- a/src/index.css
+++ b/src/index.css
@@ -220,37 +220,6 @@ input[type="number"] {
   }
 }
 
-/* Fallback for browsers without container queries */
-@media (min-width: 0px) {
-  .legend-list {
-    grid-template-columns: 1fr;
-    max-height: 500px;
-    overflow-y: auto;
-  }
-}
-
-/* SectorPieLegend responsive grid and scroll with container queries */
-.legend-list {
-  display: grid;
-  gap: 0.5rem;
-  overflow-y: auto;
-  overflow-x: hidden;
-  padding-right: 0.5rem;
-  grid-template-columns: 1fr;
-  max-height: 400px;
-  margin-top: 0.5rem;
-  min-width: 0;
-  width: 100%;
-}
-
-@container (min-width: 400px) {
-  .legend-list {
-    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-    max-height: 600px;
-    margin-top: 1rem;
-  }
-}
-
 .container-type-inline-size {
   container-type: inline-size;
   /* width: 600px;  Remove any fixed width */


### PR DESCRIPTION
### ✨ What’s Changed?

UI wise:
- Sector pie chart legend tooltip is now placed over it's legend item (instead of floating in top left corner)
- Using all space next to sector pie chart for legend, instead of just some

Behind the scenes:
- Cleaning up code, removing unnecessary styling and combining styling where possible

### 📸 Screenshots (if applicable)
Before

<img width="1246" alt="Screenshot 2025-05-13 at 19 54 04" src="https://github.com/user-attachments/assets/7d5567c6-7b30-4f5e-b5ac-c492af3c95f7" />

After

![Uploading Screenshot 2025-05-13 at 19.54.43.png…]()


### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #707 