### PR TITLE
[Fix] Adjust Municipalitity Detail Page Tooltips

### DIFF
--- a/src/components/municipalities/MunicipalityEmissionsGraph.tsx
+++ b/src/components/municipalities/MunicipalityEmissionsGraph.tsx
@@ -58,10 +58,14 @@ export const MunicipalityEmissionsGraph: FC<
       const isApproximated = filteredPayload.some(
         (entry) => entry.dataKey === "approximated" && entry.value != null,
       );
+      // If approximated is present, only show that value (hide trend and paris)
+      const displayPayload = isApproximated
+        ? filteredPayload.filter((entry) => entry.dataKey === "approximated")
+        : filteredPayload;
       return (
         <div className="bg-black-1 px-4 py-3 rounded-level-2">
           <div className="text-sm font-medium mb-2">{label}</div>
-          {filteredPayload.map((entry) => {
+          {displayPayload.map((entry) => {
             if (entry.dataKey === "gap") {
               return null;
             }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -703,7 +703,7 @@
       "low": "No"
     },
     "totalEmissions": "Total emissions {{year}}",
-    "totalEmissionsTooltip": "This is the latest reported emissions. For calculated estimates on the current year, please see the Historical Emissions graph below.",
+    "totalEmissionsTooltip": "This is the latest reported emissions. For calculated estimates on the current year, please see the emissions development graph below.",
     "budgetRunsOut": "Carbon budget expected to run out by",
     "budgetRanOut": "Carbon budget ran out",
     "budgetKept": "Carbon budget expected to",

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -703,7 +703,7 @@
       "low": "Nej"
     },
     "totalEmissions": "Totala utsläpp {{year}}",
-    "totalEmissionsTooltip": "Detta är de senast rapporterade utsläppen. För beräknade uppskattningar för innevarande år, se grafen Historiska utsläpp nedan.",
+    "totalEmissionsTooltip": "Detta är de senast rapporterade utsläppen. För beräknade uppskattningar för innevarande år, se grafen Utsläppsutveckling nedan.",
     "budgetRunsOut": "Koldioxidbudgeten tar slut",
     "budgetRanOut": "Koldioxidbudgeten tog slut",
     "budgetKept": "Koldioxidbudgeten tar slut",


### PR DESCRIPTION
### ✨ What’s Changed?

- Update tooltip to not show trend and paris if there are approximated emissions
- update copy on total emissions tooltip
- 
### 📸 Screenshots (if applicable)
After
<img width="424" alt="Screenshot 2025-05-15 at 14 57 37" src="https://github.com/user-attachments/assets/bbfadd43-ed43-4f4c-8bdf-a3192a2eab5b" />



### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #[issue-number] <!-- or: Related to #[issue-number] -->