### PR TITLE
[695] Removed logic for filtering company by names longer than 3 letters.

### DIFF
--- a/src/hooks/companies/useCompanyFilters.ts
+++ b/src/hooks/companies/useCompanyFilters.ts
@@ -1,6 +1,6 @@
 import { useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import type { CompanyDetails as Company, RankedCompany } from "@/types/company";
+import type { CompanyDetails as RankedCompany } from "@/types/company";
 
 export const SECTOR_NAMES = {
   "10": "Energi",
@@ -251,16 +251,6 @@ export const useCompanyFilters = (companies: RankedCompany[]) => {
                   company.industry.industryGics.sectorCode as SectorCode
                 ]?.toLowerCase()
               : "";
-
-            // For terms longer than 3 characters, use word boundaries
-            if (term.length > 3) {
-              const companyNamePattern = new RegExp(`\\b${term}\\b`, "i");
-              const sectorNamePattern = new RegExp(`\\b${term}\\b`, "i");
-              return (
-                companyNamePattern.test(companyName) ||
-                sectorNamePattern.test(sectorName)
-              );
-            }
 
             // For shorter terms, use substring matching but require it to be at the start of a word
             const companyNamePattern = new RegExp(`\\b${term}`, "i");


### PR DESCRIPTION
The filtering logic on the companies page was behaving oddly writing the first 4 letters of a company, example: volv(volvo), and not finding the company(volvo) since the regex expression used was looking for a company named volv, and not volv being a part of the name volvo. 

### ✨ What’s Changed?

Removed the logic for filtering company names longer than 3 letters. The search now picks up volv as being a part of volvo, 

### 📸 Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/68d9035b-1c4a-4a43-a9a4-4cf4fffdc312)


### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [ ] I've set the labels, issue, and milestone for the PR
- [ ] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #[[695](https://github.com/Klimatbyran/frontend/issues/695)] 