### PR TITLE
[749] Added color coded squares back to stacked total chart legend

### DIFF
--- a/src/components/companies/sectors/charts/SectorEmissionsChart.tsx
+++ b/src/components/companies/sectors/charts/SectorEmissionsChart.tsx
@@ -58,7 +58,10 @@ const StackedTotalLegend = ({
     <div className="flex flex-wrap justify-center gap-4 mt-4">
       {payload?.map((entry, index) => (
         <div key={index} className="flex items-center gap-2">
-          <div className={cn("w-3 h-3 rounded", `bg-[${entry.color}]`)} />
+          <div
+            className={cn("w-3 h-3 rounded")}
+            style={{ backgroundColor: entry.color }}
+          />
           <span className="text-sm text-grey">{entry.value}</span>
         </div>
       ))}


### PR DESCRIPTION
### ✨ What’s Changed?

Added back the color coded squares next to the stacked graph legend. Tailwind wasn't picking up the the class, so had to resort to setting a style bg instead which worked fine.

### 📸 Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/1d82edb7-a893-4e35-814b-98767660ae13)

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #[749](https://github.com/Klimatbyran/frontend/issues/749)