### PR TITLE
[676] Changed typewriter component to stop animation after one cycle

### DIFF
--- a/src/components/ui/typewriter.tsx
+++ b/src/components/ui/typewriter.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 import { motion, Variants } from "framer-motion";
-
 import { cn } from "@/lib/utils";
 
 interface TypewriterProps {
@@ -19,6 +18,7 @@ interface TypewriterProps {
     animate: Variants["animate"];
   };
   cursorClassName?: string;
+  finalTextIndex?: number;
 }
 
 const Typewriter = ({
@@ -27,7 +27,8 @@ const Typewriter = ({
   initialDelay = 0,
   waitTime = 2000,
   deleteSpeed = 30,
-  loop = true,
+  loop = false,
+  finalTextIndex = 0,
   className,
   showCursor = true,
   hideCursorOnType = false,
@@ -50,6 +51,7 @@ const Typewriter = ({
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isDeleting, setIsDeleting] = useState(false);
   const [currentTextIndex, setCurrentTextIndex] = useState(0);
+  const [hasCompletedCycle, setHasCompletedCycle] = useState(false); 
 
   const texts = Array.isArray(text) ? text : [text];
 
@@ -63,6 +65,9 @@ const Typewriter = ({
         if (displayText === "") {
           setIsDeleting(false);
           if (currentTextIndex === texts.length - 1 && !loop) {
+            setCurrentTextIndex(finalTextIndex);
+            setCurrentIndex(0);
+            setHasCompletedCycle(true);
             return;
           }
           setCurrentTextIndex((prev) => (prev + 1) % texts.length);
@@ -80,6 +85,9 @@ const Typewriter = ({
             setCurrentIndex((prev) => prev + 1);
           }, speed);
         } else if (texts.length > 1) {
+          if (hasCompletedCycle && currentTextIndex === finalTextIndex) {
+            return;
+          }
           timeout = setTimeout(() => {
             setIsDeleting(true);
           }, waitTime);
@@ -105,6 +113,8 @@ const Typewriter = ({
     texts,
     currentTextIndex,
     loop,
+    finalTextIndex,
+    hasCompletedCycle,
   ]);
 
   return (


### PR DESCRIPTION
### ✨ What’s Changed?
Changed the typewriter animation on the landing page to cycle through all 5 texts once, then stop on the first text ("att minska utsläppen?") instead of looping infinitely.

- Added `finalTextIndex` prop to control which text to end on
- Added `hasCompletedCycle` state to track when one full cycle is complete
- Modified logic to stop animation after reaching the specified text

### 📸 Screenshots (if applicable)

![Screenshot from 2025-05-24 12-20-48](https://github.com/user-attachments/assets/0e9a306f-2562-4d91-88b9-b64c97aa2b7c)

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #676