### PR TITLE
[768] Fix misspelled key 'visualization' in English locale

### DIFF
--- a/src/components/companies/detail/Scope3Data.tsx
+++ b/src/components/companies/detail/Scope3Data.tsx
@@ -101,7 +101,7 @@ export function Scope3Data({
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-4">
           <TabsList className="bg-black-1 w-full sm:w-auto flex">
             <TabsTrigger value="chart" className="flex-1 text-center">
-              {t("companies.scope3Data.visualization")}
+              {t("companies.scope3Data.visualisation")}
             </TabsTrigger>
             <TabsTrigger value="data" className="flex-1 text-center">
               {t("companies.scope3Data.data")}

--- a/src/lib/calculations/emissions.ts
+++ b/src/lib/calculations/emissions.ts
@@ -44,7 +44,7 @@ export interface TrendAnalysis {
 
 /**
  * Interpolate missing Scope 3 category data between periods
- * This helps create smoother visualizations while clearly marking interpolated values
+ * This helps create smoother visualisations while clearly marking interpolated values
  */
 export function interpolateScope3Categories(
   periods: EmissionPeriod[],

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -984,7 +984,7 @@
       "categories": "Scope 3 Categories",
       "selectYear": "Select Year",
       "latestYear": "Latest Year",
-      "visualisation": "Visualisation",
+      "visualization": "Visualization",
       "data": "Data",
       "historicalDevelopment": "Historical Development"
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -984,7 +984,7 @@
       "categories": "Scope 3 Categories",
       "selectYear": "Select Year",
       "latestYear": "Latest Year",
-      "visualization": "Visualization",
+      "visualisation": "Visualisation",
       "data": "Data",
       "historicalDevelopment": "Historical Development"
     },
@@ -1190,7 +1190,7 @@
     "subtitle": "Why tracking, reporting and transparency of emissions is critical to enacting tangible change.",
     "impactTitle": "Understanding the Impact",
     "impactDescription": "Each particle represents millions of tons of CO₂ emissions. Watch as they accumulate over time, demonstrating the exponential growth of global emissions since the industrial revolution.",
-    "impactDescription2": "The visualization above shows how emissions have increased dramatically since 1950, with particularly rapid growth in recent decades.",
+    "impactDescription2": "The visualisation above shows how emissions have increased dramatically since 1950, with particularly rapid growth in recent decades.",
     "trackingTitle": "Measuring to Manage",
     "trackingDescription": "We cannot effectively reduce what is not measured. Accurate emissions tracking is the foundation for meaningful climate action.",
     "companies": "Companies",

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -983,7 +983,7 @@
       "categories": "Scope 3-kategorier",
       "selectYear": "Välj år",
       "latestYear": "Senaste året",
-      "visualization": "Visualisering",
+      "visualisation": "Visualisering",
       "data": "Data",
       "historicalDevelopment": "Historisk utveckling"
     },

--- a/src/pages/EmissionsTestPage.tsx
+++ b/src/pages/EmissionsTestPage.tsx
@@ -96,7 +96,7 @@ export function EmissionsTestPage() {
       id: "interpolateScope3",
       label: "Interpolate Scope 3",
       description:
-        "Fill gaps in scope 3 reporting by interpolating between known values. This helps create smoother visualizations while clearly marking interpolated data points.",
+        "Fill gaps in scope 3 reporting by interpolating between known values. This helps create smoother visualisations while clearly marking interpolated data points.",
       enabled: true,
     },
     {
@@ -213,7 +213,7 @@ export function EmissionsTestPage() {
           <div className="space-y-4">
             <Text variant="h2">EmissionsHistory Test Cases</Text>
             <Text variant="muted">
-              Testing edge cases and visualization methods for emissions data
+              Testing edge cases and visualisation methods for emissions data
             </Text>
           </div>
 
@@ -280,7 +280,7 @@ export function EmissionsTestPage() {
           <div className="space-y-8">
             {renderTestCase(
               "Inconsistent Scope 3 Reporting",
-              "Company reports scope 3 emissions for some years but not all. Tests the interpolation and visualization of incomplete scope 3 data.",
+              "Company reports scope 3 emissions for some years but not all. Tests the interpolation and visualisation of incomplete scope 3 data.",
               testCases.inconsistentScope3,
             )}
 
@@ -292,7 +292,7 @@ export function EmissionsTestPage() {
 
             {renderTestCase(
               "Missing Years",
-              "Company has gaps in reporting years. Tests the visualization and trend calculation with incomplete time series.",
+              "Company has gaps in reporting years. Tests the visualisation and trend calculation with incomplete time series.",
               testCases.missingYears,
             )}
           </div>
@@ -304,7 +304,7 @@ export function EmissionsTestPage() {
           <div className="space-y-8">
             {renderTestCase(
               "Long Reporting History",
-              "Company with many years of consistent reporting. Shows how the visualization handles larger datasets.",
+              "Company with many years of consistent reporting. Shows how the visualisation handles larger datasets.",
               testCases.manyYearsReporting,
             )}
 


### PR DESCRIPTION
### ✨ What’s Changed?

Fixed misspelled key "vizualization" to "visualization" in the English translation file. This was causing English locale to show Swedish text ("Visualisering") on company details pages.

### 📸 Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/17502d8d-55e6-45d9-858e-9a878c81a076)

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [ ] I've set the labels, issue, and milestone for the PR
- [ ] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #768 