### PR TITLE
[fix] adapt company editor to overflowing reporting periods

### DIFF
--- a/src/components/companies/edit/CompanyEditRow.tsx
+++ b/src/components/companies/edit/CompanyEditRow.tsx
@@ -2,23 +2,28 @@ export interface CompanyEditRowProps {
   name: string;
   noHover?: boolean;
   headerName?: boolean;
-  children: React.ReactNode
+  children: React.ReactNode;
 }
 
-export function CompanyEditRow({name, noHover, headerName, children}: CompanyEditRowProps) {
+export function CompanyEditRow({
+  name,
+  noHover,
+  headerName,
+  children,
+}: CompanyEditRowProps) {
   return (
     <div
       key={"row-" + name}
-      className={`flex justify-between ps-4 rounded-s-lg items-center
-    ${noHover ? "" : "hover:bg-[#1F1F1F]"}`}
+      className={`flex ps-4 rounded-s-lg items-center min-w-max
+    ${noHover ? "" : "hover:bg-black-1/50"}`}
     >
       <h2
         key={"header-" + name}
-        className={headerName ? "text-lg font-bold" : "text-md ps-2"}
+        className={`${headerName ? "text-lg font-bold" : "text-md ps-2"} flex-shrink-0 w-60`}
       >
         {name}
       </h2>
-      <div key={"fields-" + name} className="flex">
+      <div key={"fields-" + name} className="flex flex-shrink-0">
         {children}
       </div>
     </div>

--- a/src/pages/CompanyEditPage.tsx
+++ b/src/pages/CompanyEditPage.tsx
@@ -180,27 +180,31 @@ export function CompanyEditPage() {
         />
         {selectedPeriods !== null && selectedPeriods.length > 0 && (
           <form onSubmit={handleSubmit} ref={formRef}>
-            <CompanyEditPeriod
-              periods={selectedPeriods}
-              onInputChange={onInputChange}
-              formData={formData}
-              resetPeriod={resetPeriod}
-            ></CompanyEditPeriod>
-            <CompanyEditScope1
-              periods={selectedPeriods}
-              onInputChange={onInputChange}
-              formData={formData}
-            ></CompanyEditScope1>
-            <CompanyEditScope2
-              periods={selectedPeriods}
-              onInputChange={onInputChange}
-              formData={formData}
-            ></CompanyEditScope2>
-            <CompanyEditScope3
-              periods={selectedPeriods}
-              onInputChange={onInputChange}
-              formData={formData}
-            ></CompanyEditScope3>
+            <div className="overflow-x-auto overflow-y-visible">
+              <div className="min-w-max">
+                <CompanyEditPeriod
+                  periods={selectedPeriods}
+                  onInputChange={onInputChange}
+                  formData={formData}
+                  resetPeriod={resetPeriod}
+                ></CompanyEditPeriod>
+                <CompanyEditScope1
+                  periods={selectedPeriods}
+                  onInputChange={onInputChange}
+                  formData={formData}
+                ></CompanyEditScope1>
+                <CompanyEditScope2
+                  periods={selectedPeriods}
+                  onInputChange={onInputChange}
+                  formData={formData}
+                ></CompanyEditScope2>
+                <CompanyEditScope3
+                  periods={selectedPeriods}
+                  onInputChange={onInputChange}
+                  formData={formData}
+                ></CompanyEditScope3>
+              </div>
+            </div>
             <div className="w-full ps-4 pe-2 mt-6">
               <textarea
                 className="ms-2 w-full p-2 border-gray-300 rounded text-white bg-black-1"


### PR DESCRIPTION
### ✨ What’s Changed?

Adapted company editor to cases where there's too many reporting periods too fit on the screen, with set column widths and horizontal scroll.

### 📸 Screenshots (if applicable)
Before
<img width="1177" alt="Screenshot 2025-05-28 at 15 07 01" src="https://github.com/user-attachments/assets/e67c673b-886a-4b45-859f-1b54f41b58b4" />


After
<img width="1177" alt="Screenshot 2025-05-28 at 15 04 49" src="https://github.com/user-attachments/assets/7348ce43-251a-4199-9aad-6ed0ddc2c45a" />


### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)