### PR TITLE
[678] Fix scope 3 pie chart tooltip to include percentage

### DIFF
--- a/src/components/companies/CompanyPieChartView.tsx
+++ b/src/components/companies/CompanyPieChartView.tsx
@@ -7,6 +7,7 @@ interface PieChartData {
   value: number;
   color: string;
   category?: number;
+  total?: number;
 }
 
 interface PieChartViewProps {
@@ -84,6 +85,7 @@ const PieChartView: React.FC<PieChartViewProps> = ({
         <Tooltip
           content={
             <CompanyPieTooltip
+              showPercentage={true}
               percentageLabel={percentageLabel}
               customActionLabel={customActionLabel}
             />

--- a/src/components/companies/detail/Scope3Data.tsx
+++ b/src/components/companies/detail/Scope3Data.tsx
@@ -123,6 +123,7 @@ export function Scope3Data({
                   value: cat.total,
                   color: getCategoryColor(cat.category),
                   category: cat.category,
+                  total: selectedScope3Total,
                 }))}
                 size={size}
                 filterable={true}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -986,7 +986,8 @@
       "latestYear": "Latest Year",
       "visualisation": "Visualisation",
       "data": "Data",
-      "historicalDevelopment": "Historical Development"
+      "historicalDevelopment": "Historical Development",
+      "ofTotal": "of total"
     },
     "scopeReportingList": {
       "category": "Category"

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -989,7 +989,9 @@
       "latestYear": "Senaste året",
       "visualisation": "Visualisering",
       "data": "Data",
-      "historicalDevelopment": "Historisk utveckling"
+      "historicalDevelopment": "Historisk utveckling",
+      "ofTotal": "av total"
+
     },
     "scopeReportingList": {
       "category": "Kategori"


### PR DESCRIPTION
### ✨ What's Changed?

Fixed the company detailed page scope 3 pie chart tooltip to include the percentage of total scope 3 emissions that each category accounts for.

- Added `total` field to `PieChartData` interface
- Modified `Scope3Data` component to pass `selectedScope3Total` to each pie chart data item
- Added translation keys `companies.scope3Data.ofTotal` for both locales

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Fixes #678 