### PR TITLE
[796] Linking to corresponding methodology category when AI-tooltip is clicked

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -90,7 +90,7 @@ export function Header() {
         { label: t("header.aboutUs"), path: `${currentLanguage}/about` },
         {
           label: t("header.methodology"),
-          path: `${currentLanguage}/methodology`,
+          path: `${currentLanguage}/methodology?view=general`,
         },
         {
           label: t("header.press"),

--- a/src/components/methods/MethodNavigation.tsx
+++ b/src/components/methods/MethodNavigation.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect, useRef } from "react";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import { methodologySections } from "@/lib/methods/methodologyData";
 import { useScreenSize } from "@/hooks/useScreenSize";
+import { useNavigate } from "react-router-dom";
 
 interface MethodologyNavigationProps {
   selectedMethod: string;
@@ -20,6 +21,7 @@ export function MethodologyNavigation({
     Object.keys(methodologySections),
   );
   const { isMobile } = useScreenSize();
+  const navigate = useNavigate();
 
   useEffect(() => {
     if (isMobile) {
@@ -79,7 +81,10 @@ export function MethodologyNavigation({
                 {methods.map((method) => (
                   <li key={method.id}>
                     <button
-                      onClick={() => handleMethodChange(method.id)}
+                      onClick={() => {
+                        handleMethodChange(method.id);
+                        navigate(`?view=${category}`);
+                      }}
                       className={`w-full p-2 my-0.5 text-left text-sm rounded-lg transition-colors duration-200 ${
                         selectedMethod === method.id
                           ? "bg-black-1 text-blue-3 font-medium"

--- a/src/components/ui/ai-icon.tsx
+++ b/src/components/ui/ai-icon.tsx
@@ -49,7 +49,7 @@ export const AiIcon = ({
       <Tooltip>
         <TooltipTrigger asChild>
           <Link
-            to={`/${currentLang}/methodology?view=companydata`}
+            to={`/${currentLang}/methodology?view=company`}
             className="inline-block"
           >
             {iconElement}

--- a/src/components/ui/ai-icon.tsx
+++ b/src/components/ui/ai-icon.tsx
@@ -20,6 +20,8 @@ export const AiIcon = ({
   showTooltip = true,
 }: AiIconProps) => {
   const { t } = useTranslation();
+  const { i18n } = useTranslation();
+  const currentLang = i18n.language;
   const sizeClasses = {
     sm: "w-4 h-3 rounded",
     md: "w-5 h-4 rounded-md",
@@ -46,7 +48,10 @@ export const AiIcon = ({
     <TooltipProvider>
       <Tooltip>
         <TooltipTrigger asChild>
-          <Link to="/methodology" className="inline-block">
+          <Link
+            to={`/${currentLang}/methodology?view=companydata`}
+            className="inline-block"
+          >
             {iconElement}
           </Link>
         </TooltipTrigger>

--- a/src/lib/methods/methodologyData.ts
+++ b/src/lib/methods/methodologyData.ts
@@ -1,94 +1,148 @@
 // This file contains the structure of methodology sections and their relationships
 
 export type MethodType = {
-    id: string;
-    relatedMethods?: string[];
-    category: string;
-  };
-  
-  export type MethodologySectionType = {
-    [category: string]: MethodType[];
-  };
-  
-  // Main categories and methods
-  export const methodologySections: MethodologySectionType = {
-    general: [
-      { id: "parisAgreement", category: "general" },
-      { id: "co2Budgets", category: "general" },
-      { id: "emissionTypes", category: "general" }
-    ],
-    municipality: [
-      { id: "sources", category: "municipality" },
-      { id: "calculations", category: "municipality" }
-    ],
-    company: [
-      { id: "companyDataOverview", category: "company" },
-      { id: "companyDataCollection", category: "company" },
-      { id: "emissionCategories", category: "company" },
-      { id: "historicalData", category: "company" }
+  id: string;
+  relatedMethods?: string[];
+  category: string;
+};
+
+export type MethodologySectionType = {
+  [category: string]: MethodType[];
+};
+
+// Main categories and methods
+export const methodologySections: MethodologySectionType = {
+  general: [
+    { id: "parisAgreement", category: "general" },
+    { id: "co2Budgets", category: "general" },
+    { id: "emissionTypes", category: "general" },
+  ],
+  municipality: [
+    { id: "sources", category: "municipality" },
+    { id: "calculations", category: "municipality" },
+  ],
+  company: [
+    { id: "companyDataOverview", category: "company" },
+    { id: "companyDataCollection", category: "company" },
+    { id: "emissionCategories", category: "company" },
+    { id: "historicalData", category: "company" },
+  ],
+};
+
+// Function to get a method by ID
+export const getMethodById = (id: string): MethodType | undefined => {
+  for (const category in methodologySections) {
+    const method = methodologySections[category].find((m) => m.id === id);
+    if (method) return method;
+  }
+  return undefined;
+};
+
+// Function to get related methods
+export const getRelatedMethods = (methodId: string): MethodType[] => {
+  const method = getMethodById(methodId);
+  if (!method || !method.relatedMethods || method.relatedMethods.length === 0) {
+    return [];
+  }
+
+  return method.relatedMethods
+    .map((id) => getMethodById(id))
+    .filter((m): m is MethodType => m !== undefined);
+};
+
+// Function to get all methods as a flat array
+export const getAllMethods = (): MethodType[] => {
+  return Object.values(methodologySections).flat();
+};
+
+// Search-related terms mapping
+const searchTerms: { [key: string]: string[] } = {
+  parisAgreement: [
+    "climate goals",
+    "1.5°C",
+    "global warming",
+    "emissions reduction",
+    "climate treaty",
+  ],
+  co2Budgets: [
+    "carbon budget",
+    "emissions allowance",
+    "CO2 allowance",
+    "carbon allowance",
+    "climate budget",
+  ],
+  emissionTypes: [
+    "greenhouse gases",
+    "GHG",
+    "carbon dioxide",
+    "methane",
+    "emissions categories",
+  ],
+  sources: [
+    "data sources",
+    "public data",
+    "statistics",
+    "references",
+    "information sources",
+  ],
+  calculations: [
+    "methodology",
+    "computation",
+    "analysis",
+    "measurement",
+    "data processing",
+  ],
+  companyDataOverview: [
+    "company overview",
+    "business data",
+    "corporate information",
+    "company scope",
+  ],
+  companyDataCollection: [
+    "data collection",
+    "reporting methodology",
+    "data gathering",
+    "company reporting",
+  ],
+  emissionCategories: [
+    "emission types",
+    "scope categories",
+    "emission classification",
+    "GHG categories",
+  ],
+  historicalData: [
+    "historical emissions",
+    "past data",
+    "emission history",
+    "previous years",
+    "trends",
+  ],
+};
+
+// Enhanced search function that includes related terms and translations
+export const searchMethods = (query: string): MethodType[] => {
+  if (!query.trim()) return [];
+
+  const lowerQuery = query.toLowerCase();
+
+  return getAllMethods().filter((method) => {
+    // Check method ID
+    if (method.id.toLowerCase().includes(lowerQuery)) return true;
+
+    // Check related terms
+    const terms = searchTerms[method.id] || [];
+    if (terms.some((term) => term.toLowerCase().includes(lowerQuery)))
+      return true;
+
+    // Check if query matches any part of the method's content
+    const methodContent = [
+      `methodsPage.accordion.${method.id}.title`,
+      `methodsPage.accordion.${method.id}.description`,
+      `methodsPage.categories.${method.category}`,
     ]
-  };
-  
-  // Function to get a method by ID
-  export const getMethodById = (id: string): MethodType | undefined => {
-    for (const category in methodologySections) {
-      const method = methodologySections[category].find(m => m.id === id);
-      if (method) return method;
-    }
-    return undefined;
-  };
-  
-  // Function to get related methods
-  export const getRelatedMethods = (methodId: string): MethodType[] => {
-    const method = getMethodById(methodId);
-    if (!method || !method.relatedMethods || method.relatedMethods.length === 0) {
-      return [];
-    }
-    
-    return method.relatedMethods
-      .map(id => getMethodById(id))
-      .filter((m): m is MethodType => m !== undefined);
-  };
-  
-  // Function to get all methods as a flat array
-  export const getAllMethods = (): MethodType[] => {
-    return Object.values(methodologySections).flat();
-  };
-  
-  // Search-related terms mapping
-  const searchTerms: { [key: string]: string[] } = {
-    parisAgreement: ["climate goals", "1.5°C", "global warming", "emissions reduction", "climate treaty"],
-    co2Budgets: ["carbon budget", "emissions allowance", "CO2 allowance", "carbon allowance", "climate budget"],
-    emissionTypes: ["greenhouse gases", "GHG", "carbon dioxide", "methane", "emissions categories"],
-    sources: ["data sources", "public data", "statistics", "references", "information sources"],
-    calculations: ["methodology", "computation", "analysis", "measurement", "data processing"],
-    companyDataOverview: ["company overview", "business data", "corporate information", "company scope"],
-    companyDataCollection: ["data collection", "reporting methodology", "data gathering", "company reporting"],
-    emissionCategories: ["emission types", "scope categories", "emission classification", "GHG categories"],
-    historicalData: ["historical emissions", "past data", "emission history", "previous years", "trends"]
-  };
-  
-  // Enhanced search function that includes related terms and translations
-  export const searchMethods = (query: string): MethodType[] => {
-    if (!query.trim()) return [];
-    
-    const lowerQuery = query.toLowerCase();
-    
-    return getAllMethods().filter(method => {
-      // Check method ID
-      if (method.id.toLowerCase().includes(lowerQuery)) return true;
-      
-      // Check related terms
-      const terms = searchTerms[method.id] || [];
-      if (terms.some(term => term.toLowerCase().includes(lowerQuery))) return true;
-      
-      // Check if query matches any part of the method's content
-      const methodContent = [
-        `methodsPage.accordion.${method.id}.title`,
-        `methodsPage.accordion.${method.id}.description`,
-        `methodsPage.categories.${method.category}`
-      ].join(' ').toLowerCase();
-      
-      return methodContent.includes(lowerQuery);
-    });
-  };
+      .join(" ")
+      .toLowerCase();
+
+    return methodContent.includes(lowerQuery);
+  });
+};

--- a/src/pages/MethodsPage.tsx
+++ b/src/pages/MethodsPage.tsx
@@ -7,18 +7,34 @@ import { Search } from "lucide-react";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { PageSEO } from "@/components/SEO/PageSEO";
 import { useScreenSize } from "@/hooks/useScreenSize";
+import { useLocation } from "react-router-dom";
+import { methodologySections } from "@/lib/methods/methodologyData";
 
 export function MethodsPage() {
   const { t } = useTranslation();
-  const [selectedMethod, setSelectedMethod] = useState("parisAgreement");
+  const [selectedMethod, setSelectedMethod] = useState<String>();
   const [searchQuery, setSearchQuery] = useState("");
   const [showSearch, setShowSearch] = useState(false);
   const { isMobile } = useScreenSize();
   const contentRef = useRef<HTMLDivElement>(null);
+  const location = useLocation();
 
   useEffect(() => {
     window.scrollTo(0, 0);
   }, [selectedMethod]);
+
+  useEffect(() => {
+    const searchParams = new URLSearchParams(location.search);
+
+    if (searchParams) {
+      const view = searchParams.get("view");
+      if (view === "companydata") {
+        setSelectedMethod(methodologySections.company[0].id);
+      } else {
+        setSelectedMethod("parisAgreement");
+      }
+    }
+  }, [location]);
 
   // Prepare SEO data
   const canonicalUrl = "https://klimatkollen.se/methodology";

--- a/src/pages/MethodsPage.tsx
+++ b/src/pages/MethodsPage.tsx
@@ -12,7 +12,7 @@ import { methodologySections } from "@/lib/methods/methodologyData";
 
 export function MethodsPage() {
   const { t } = useTranslation();
-  const [selectedMethod, setSelectedMethod] = useState<String>();
+  const [selectedMethod, setSelectedMethod] = useState<String>("");
   const [searchQuery, setSearchQuery] = useState("");
   const [showSearch, setShowSearch] = useState(false);
   const { isMobile } = useScreenSize();
@@ -25,11 +25,17 @@ export function MethodsPage() {
 
   useEffect(() => {
     const searchParams = new URLSearchParams(location.search);
-
     if (searchParams) {
+      const allMethods = Object.values(methodologySections).flat();
       const view = searchParams.get("view");
+
       if (view === "companydata") {
-        setSelectedMethod(methodologySections.company[0].id);
+        const matchingMethod = allMethods.find(
+          (method) => method.id === "companyDataOverview",
+        );
+        if (matchingMethod) {
+          setSelectedMethod(matchingMethod.id);
+        }
       } else {
         setSelectedMethod("parisAgreement");
       }

--- a/src/pages/MethodsPage.tsx
+++ b/src/pages/MethodsPage.tsx
@@ -8,7 +8,6 @@ import { PageHeader } from "@/components/layout/PageHeader";
 import { PageSEO } from "@/components/SEO/PageSEO";
 import { useScreenSize } from "@/hooks/useScreenSize";
 import { useLocation } from "react-router-dom";
-import { methodologySections } from "@/lib/methods/methodologyData";
 
 export function MethodsPage() {
   const { t } = useTranslation();
@@ -26,21 +25,22 @@ export function MethodsPage() {
   useEffect(() => {
     const searchParams = new URLSearchParams(location.search);
     if (searchParams) {
-      const allMethods = Object.values(methodologySections).flat();
-      const view = searchParams.get("view");
+      const searchQuery = searchParams.get("view") || "";
 
-      if (view === "companydata") {
-        const matchingMethod = allMethods.find(
-          (method) => method.id === "companyDataOverview",
-        );
-        if (matchingMethod) {
-          setSelectedMethod(matchingMethod.id);
-        }
-      } else {
-        setSelectedMethod("parisAgreement");
-      }
+      const matchingMethod = matchMethodWithSearchQuery(searchQuery);
+      matchingMethod && setSelectedMethod(matchingMethod);
     }
-  }, [location]);
+  }, []);
+
+  const matchMethodWithSearchQuery = (searchQuery: string) => {
+    if (searchQuery === "company") {
+      return "companyDataOverview";
+    } else if (searchQuery === "municipality") {
+      return "sources";
+    } else {
+      return "parisAgreement";
+    }
+  };
 
   // Prepare SEO data
   const canonicalUrl = "https://klimatkollen.se/methodology";


### PR DESCRIPTION
### ✨ What’s Changed?

Added linking to the company category of the Methodology page when the AI-icon is clicked on company cards. Also added view querys (general, municipality & company) for the three different categories on the Methodology page where we can link to from other sources later on if needed.

### 📋 Checklist

- [X] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [X] I've verified the change runs locally
- [x] I've set the labels, issue, and milestone for the PR
- [ ] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #796  