### PR TITLE
[fix] allow for several issues to be shown per company on the validation dashboard

### DIFF
--- a/src/pages/ValidationDashboard.tsx
+++ b/src/pages/ValidationDashboard.tsx
@@ -52,14 +52,15 @@ const githubUrl = (company: RankedCompany, reportUrl?: string | null) => {
 };
 
 type IssueViewProps = {
-  issue?: GithubValidationIssue;
+  issues?: GithubValidationIssue[];
   company: RankedCompany;
   period?: ReportingPeriod;
   className?: string;
   error: boolean;
 };
+
 const IssueView = ({
-  issue,
+  issues,
   company,
   period,
   className,
@@ -72,7 +73,8 @@ const IssueView = ({
       </a>
     );
   }
-  if (!issue) {
+
+  if (!issues || issues.length === 0) {
     return (
       <a
         target="_blank"
@@ -85,27 +87,33 @@ const IssueView = ({
   }
 
   return (
-    <span className={className}>
-      <a
-        href={issue.html_url}
-        target="_blank"
-        className={cn(
-          "mr-2",
-          issue.state == "open" ? "text-green-3" : "text-gray-500",
-        )}
-      >
-        {issue.state === "open" ? "Issue reported" : "Issue closed"}
-      </a>
-      {issue.state === "open" &&
-        issue.labels.map((label) => (
-          <span
-            style={{ backgroundColor: `#${label.color}` }}
-            className="rounded-sm text-xs font-bold uppercase mx-[2px] px-1"
+    <div className={cn("flex flex-col gap-1", className)}>
+      {issues.map((issue, _index) => (
+        <div key={issue.number} className="flex items-center">
+          <a
+            href={issue.html_url}
+            target="_blank"
+            className={cn(
+              "mr-2",
+              issue.state == "open" ? "text-green-3" : "text-gray-500",
+            )}
           >
-            {label.name}
-          </span>
-        ))}
-    </span>
+            {issues.length > 1 ? `#${issue.number} ` : ""}
+            {issue.state === "open" ? "Issue reported" : "Issue closed"}
+          </a>
+          {issue.state === "open" &&
+            issue.labels.map((label) => (
+              <span
+                key={label.name}
+                style={{ backgroundColor: `#${label.color}` }}
+                className="rounded-sm text-xs font-bold uppercase mx-[2px] px-1"
+              >
+                {label.name}
+              </span>
+            ))}
+        </div>
+      ))}
+    </div>
   );
 };
 
@@ -259,7 +267,7 @@ export const ValidationDashboard = () => {
                 )}
               </div>
               <IssueView
-                issue={issues?.[company.wikidataId]}
+                issues={issues?.[company.wikidataId]}
                 company={company}
                 period={period as ReportingPeriod}
                 error={!!issuesError}


### PR DESCRIPTION
### ✨ What’s Changed?

Allowing for companies to have serveral linked issues on the validation dashboard.

### 📸 Screenshots (if applicable)

Before
<img width="1246" alt="Screenshot 2025-06-04 at 13 53 41" src="https://github.com/user-attachments/assets/6604c0c1-7e2d-4027-9171-2f25d1169f0b" />

After
<img width="1246" alt="Screenshot 2025-06-04 at 13 53 32" src="https://github.com/user-attachments/assets/86693937-8cf1-44bc-803b-3529ad86a3a2" />


### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)