### PR TITLE
[fix] prevent newly opened items from being out of view in data guide

### DIFF
--- a/src/data-guide/ProgressiveDataGuide.tsx
+++ b/src/data-guide/ProgressiveDataGuide.tsx
@@ -28,6 +28,30 @@ export function ProgressiveDataGuide({
   const title = titleKey ? t(titleKey) : t("dataGuide.buttonFallbackTitle");
 
   const handleItemToggle = (itemId: string, isOpen: boolean) => {
+    if (isOpen) {
+      // Check if the item trigger button will be visible after opening
+      setTimeout(() => {
+        const triggerButton = document.querySelector(
+          `[data-item-id="${itemId}"]`,
+        );
+        if (triggerButton) {
+          const rect = triggerButton.getBoundingClientRect();
+          const isVisible =
+            rect.top >= 60 && rect.top <= window.innerHeight * 0.8;
+
+          if (!isVisible) {
+            const rect = triggerButton.getBoundingClientRect();
+            const headerOffset = 80; // Adjust this value based on your header height
+            const targetPosition = window.pageYOffset + rect.top - headerOffset;
+
+            window.scrollTo({
+              top: targetPosition,
+              behavior: "smooth",
+            });
+          }
+        }
+      }, 200);
+    }
     setActiveItem(isOpen ? itemId : null);
   };
 
@@ -77,7 +101,10 @@ export function ProgressiveDataGuide({
                   onOpenChange={(isOpen) => handleItemToggle(itemId, isOpen)}
                 >
                   <CollapsibleTrigger asChild>
-                    <button className="flex justify-between w-full py-1.5 px-2 items-center text-sm hover:bg-black-1/70 rounded transition-colors text-blue-2/80">
+                    <button
+                      data-item-id={itemId}
+                      className="flex justify-between w-full py-1.5 px-2 items-center text-sm hover:bg-black-1/70 rounded transition-colors text-blue-2/80"
+                    >
                       <span className="text-left">{t(item.titleKey)}</span>
                       <ChevronDownIcon
                         className={cn(


### PR DESCRIPTION
### ✨ What’s Changed?
When a long item was expanded and scrolled, clicking the next item would leave it out of viewport due to the previous item collapsing. Add a check to see if the trigger button ends up outside of view and scroll it in if needed.


### 📸 Screenshots (if applicable)

In situations where you have scrolled to read a long text (so that it's action button is out of view), like this
<img width="390" alt="image" src="https://github.com/user-attachments/assets/994292be-848c-47a7-878a-123ffc84c55d" />

Clicking the next item "Varför saknar vissa..." would have the its trigger button and beginning of the text be out of view:
<img width="393" alt="image" src="https://github.com/user-attachments/assets/44c59e5f-80c5-478c-ad85-faaae6566cc4" />

### 🪾Alternative solution
An alternative solution could be to allow multiple items to be open (in other words, not folding the ones above as you click). The benefit to that solution is simpler code and that you can have more than one help item open at the same time (for example to compare Scope 1, Scope 2 and Scope 3).

The drawback is that you leave items open as you continue to read which means you need to scroll more to get back up to the graph.

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)
