### PR TITLE
[fix] Fit the dataguide better in sections and two column DataGuide on Desktop

### DIFF
--- a/src/components/companies/detail/history/EmissionsHistory.tsx
+++ b/src/components/companies/detail/history/EmissionsHistory.tsx
@@ -15,6 +15,8 @@ import ChartHeader from "./ChartHeader";
 import EmissionsLineChart from "./EmissionsLineChart";
 import { useVerificationStatus } from "@/hooks/useVerificationStatus";
 import { ProgressiveDataGuide } from "@/data-guide/ProgressiveDataGuide";
+import { Section } from "@/data-guide/Section";
+import { SectionWithHelp } from "@/data-guide/SectionWithHelp";
 
 export function EmissionsHistory({
   reportingPeriods,
@@ -115,8 +117,14 @@ export function EmissionsHistory({
   };
 
   return (
-    <div
-      className={cn("bg-black-2 rounded-level-1 px-4 md:px-16 py-8", className)}
+    <SectionWithHelp
+      helpItems={[
+        "scope1",
+        "scope2",
+        "scope3",
+        "scope3EmissionLevels",
+        "companyMissingData",
+      ]}
     >
       <ChartHeader
         title={t("companies.emissionsHistory.title")}
@@ -149,16 +157,6 @@ export function EmissionsHistory({
         getCategoryName={getCategoryName}
         getCategoryColor={getCategoryColor}
       />
-
-      <ProgressiveDataGuide
-        items={[
-          "scope1",
-          "scope2",
-          "scope3",
-          "scope3EmissionLevels",
-          "companyMissingData",
-        ]}
-      />
-    </div>
+    </SectionWithHelp>
   );
 }

--- a/src/components/companies/detail/overview/CompanyOverview.tsx
+++ b/src/components/companies/detail/overview/CompanyOverview.tsx
@@ -31,6 +31,8 @@ import { CompanyOverviewTooltip } from "./CompanyOverviewTooltip";
 import { CompanyDescription } from "./CompanyDescription";
 import { calculateRateOfChange } from "@/lib/calculations/general";
 import { ProgressiveDataGuide } from "@/data-guide/ProgressiveDataGuide";
+import { Section } from "@/data-guide/Section";
+import { SectionWithHelp } from "@/data-guide/SectionWithHelp";
 
 interface CompanyOverviewProps {
   company: CompanyDetails;
@@ -91,7 +93,15 @@ export function CompanyOverview({
     : t("companies.overview.notReported");
 
   return (
-    <div className="bg-black-2 rounded-level-1 p-8 md:p-16">
+    <SectionWithHelp
+      helpItems={[
+        "totalEmissions",
+        "co2units",
+        "companySectors",
+        "companyMissingData",
+        "yearOverYearChange",
+      ]}
+    >
       <div className="flex items-start justify-between mb-4 md:mb-12">
         <div className="space-y-4">
           <div className="flex items-center gap-4">
@@ -230,16 +240,6 @@ export function CompanyOverview({
         employeesAIGenerated={employeesAIGenerated}
         className="mt-3 md:mt-0"
       />
-
-      <ProgressiveDataGuide
-        items={[
-          "totalEmissions",
-          "co2units",
-          "companySectors",
-          "companyMissingData",
-          "yearOverYearChange",
-        ]}
-      />
-    </div>
+    </SectionWithHelp>
   );
 }

--- a/src/data-guide/DataGuideMarkdown.tsx
+++ b/src/data-guide/DataGuideMarkdown.tsx
@@ -2,15 +2,20 @@ import Markdown from "react-markdown";
 import remarkBreaks from "remark-breaks";
 import { DataGuideItem } from "./items";
 import { useTranslation } from "react-i18next";
+import { cn } from "@/lib/utils";
 
 type DataGuideMarkdownProps = {
   item: DataGuideItem;
+  className?: string;
 };
-export const DataGuideMarkdown = ({ item }: DataGuideMarkdownProps) => {
+export const DataGuideMarkdown = ({
+  className,
+  item,
+}: DataGuideMarkdownProps) => {
   const { t } = useTranslation();
   return (
     <Markdown
-      className="max-w-[75ch] px-0 sm:px-4"
+      className={cn(className)}
       remarkPlugins={[remarkBreaks]}
       components={{
         ol: ({ node, children, ...props }) => (
@@ -31,13 +36,13 @@ export const DataGuideMarkdown = ({ item }: DataGuideMarkdownProps) => {
         p: ({ node, children, ...props }) => (
           <p
             {...props}
-            className="my-4 first:mt-0 last:mb-0 whitespace-pre-wrap leading-relaxed"
+            className="my-4 first:mt-0 md:first:mt-4 last:mb-0 whitespace-pre-wrap leading-relaxed"
           >
             {children}
           </p>
         ),
         a: ({ node, children, ...props }) => (
-          <a {...props} className="text-blue-2 font-bold">
+          <a {...props} className="text-blue-2">
             {children}
           </a>
         ),

--- a/src/data-guide/ProgressiveDataGuide.tsx
+++ b/src/data-guide/ProgressiveDataGuide.tsx
@@ -1,53 +1,62 @@
-import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ChevronDownIcon } from "@radix-ui/react-icons";
 import { GraduationCap } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { DataGuideItemId, dataGuideHelpItems } from "./items";
+import { DataGuideItemId } from "./items";
 import {
   Collapsible,
   CollapsibleTrigger,
   CollapsibleContent,
 } from "@/components/ui/collapsible";
-import { DataGuideMarkdown } from "./DataGuideMarkdown";
+import { useScreenSize } from "@/hooks/useScreenSize";
+import {
+  NonEmptyArray,
+  ProgressiveDataGuideDesktop,
+} from "./ProgressiveDataGuideDesktop";
+import { ProgressiveDataGuideMobile } from "./ProgressiveDataGuideMobile";
+import { useState } from "react";
 
 interface ProgressiveDataGuideProps {
   titleKey?: string;
   items: DataGuideItemId[];
   className?: string;
+  style?: "button" | "sectionFooter";
 }
 
 export function ProgressiveDataGuide({
   titleKey,
   items,
   className,
+  style = "button",
 }: ProgressiveDataGuideProps) {
   const { t } = useTranslation();
-  const [activeItem, setActiveItem] = useState<string | null>(null);
+  const { isMobile, isTablet } = useScreenSize();
+  const isDesktop = !isMobile && !isTablet;
+  const [open, setOpen] = useState(false);
 
   const title = titleKey ? t(titleKey) : t("dataGuide.buttonFallbackTitle");
-
-  const handleItemToggle = (itemId: string, isOpen: boolean) => {
-    setActiveItem(isOpen ? itemId : null);
-  };
 
   const dataGuideEnabled = ["localhost", "stage"].some((enabledHost) =>
     window.location.hostname.includes(enabledHost),
   );
 
-  if (!dataGuideEnabled) {
+  if (!dataGuideEnabled || items.length < 1) {
     return null;
   }
 
+  const nonEmptyItems = items as NonEmptyArray<DataGuideItemId>;
+
   return (
-    <div className={cn(className, "space-y-2 mt-8")}>
-      <Collapsible>
+    <div className={cn(className, "space-y-2")}>
+      <Collapsible open={open} onOpenChange={setOpen}>
         <CollapsibleTrigger asChild>
           <button
             className={cn(
               "flex items-center gap-2 px-3 py-2 rounded-md text-sm transition-all duration-200 w-full",
-              "bg-blue-5/40 text-gray-300 hover:bg-blue-5/70",
-              "data-[state=open]:bg-blue-5/60 data-[state=open]:text-blue-1 data-[state=open]:hover:bg-blue-5/70",
+              "text-gray-300 hover:bg-black-1/60",
+              style === "button"
+                ? "data-[state=open]:hover:bg-black-1/60 bg-black-1/40 py-4 text-sm"
+                : "text-base",
             )}
           >
             <GraduationCap className="w-4 h-4 text-blue-1" />
@@ -55,7 +64,7 @@ export function ProgressiveDataGuide({
             <ChevronDownIcon
               className={cn(
                 "w-4 h-4 transition-transform ml-auto",
-                "data-[state=open]:rotate-180",
+                open && "rotate-180",
               )}
             />
           </button>
@@ -67,40 +76,11 @@ export function ProgressiveDataGuide({
             "data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down",
           )}
         >
-          <div className="bg-black-1/60 rounded-md p-3 space-y-1 mt-2">
-            {items.map((itemId) => {
-              const item = dataGuideHelpItems[itemId];
-              return (
-                <Collapsible
-                  key={itemId}
-                  open={activeItem === itemId}
-                  onOpenChange={(isOpen) => handleItemToggle(itemId, isOpen)}
-                >
-                  <CollapsibleTrigger asChild>
-                    <button className="flex justify-between w-full py-1.5 px-2 items-center text-sm hover:bg-black-1/70 rounded transition-colors text-blue-2/80">
-                      <span className="text-left">{t(item.titleKey)}</span>
-                      <ChevronDownIcon
-                        className={cn(
-                          "w-3 h-3 transition-transform",
-                          "data-[state=open]:rotate-180",
-                        )}
-                      />
-                    </button>
-                  </CollapsibleTrigger>
-                  <CollapsibleContent
-                    className={cn(
-                      "transition-all duration-200 ease-out overflow-hidden",
-                      "data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down",
-                    )}
-                  >
-                    <div className="px-2 py-2 text-sm text-gray-300 leading-relaxed border-b border-t border-black-1/80">
-                      <DataGuideMarkdown item={item} />
-                    </div>
-                  </CollapsibleContent>
-                </Collapsible>
-              );
-            })}
-          </div>
+          {isDesktop ? (
+            <ProgressiveDataGuideDesktop items={nonEmptyItems} />
+          ) : (
+            <ProgressiveDataGuideMobile items={items} />
+          )}
         </CollapsibleContent>
       </Collapsible>
     </div>

--- a/src/data-guide/ProgressiveDataGuideDesktop.tsx
+++ b/src/data-guide/ProgressiveDataGuideDesktop.tsx
@@ -1,0 +1,52 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { cn } from "@/lib/utils";
+import { DataGuideItemId, dataGuideHelpItems } from "./items";
+import { DataGuideMarkdown } from "./DataGuideMarkdown";
+
+export type NonEmptyArray<T> = [T, ...T[]];
+interface ProgressiveDataGuideDesktopProps {
+  items: NonEmptyArray<DataGuideItemId>;
+}
+
+export function ProgressiveDataGuideDesktop({
+  items,
+}: ProgressiveDataGuideDesktopProps) {
+  const { t } = useTranslation();
+  const [activeItemId, setActiveItemId] = useState<DataGuideItemId>(items[0]);
+
+  const activeHelpItem = activeItemId && dataGuideHelpItems[activeItemId];
+
+  return (
+    <div className="py-8 mt-2 grid grid-cols-[1fr_2fr] gap-8 min-h-[300px] font-thin">
+      {/* Left column - Navigation */}
+      <div className="space-y-1">
+        {items.map((itemId) => {
+          const item = dataGuideHelpItems[itemId];
+          return (
+            <button
+              key={itemId}
+              onClick={() => setActiveItemId(itemId)}
+              className={cn(
+                "flex w-full py-1.5 px-2 items-center hover:bg-black-1/70 transition-colors text-left border-blue-2",
+                activeItemId === itemId
+                  ? "text-white border-l-2 font-bold"
+                  : "text-white/70",
+              )}
+            >
+              <span>{t(item.titleKey)}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Right column - Content */}
+      <div className="p-8 bg-black-1/60 rounded-md">
+        <div className="text-gray-300 leading-relaxed">
+          <h2 className="text-lg font-bold">{t(activeHelpItem.titleKey)}</h2>
+          <DataGuideMarkdown item={activeHelpItem} className="max-w-prose" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/data-guide/ProgressiveDataGuideMobile.tsx
+++ b/src/data-guide/ProgressiveDataGuideMobile.tsx
@@ -1,0 +1,70 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { ChevronDownIcon } from "@radix-ui/react-icons";
+import { cn } from "@/lib/utils";
+import { DataGuideItemId, dataGuideHelpItems } from "./items";
+import {
+  Collapsible,
+  CollapsibleTrigger,
+  CollapsibleContent,
+} from "@/components/ui/collapsible";
+import { DataGuideMarkdown } from "./DataGuideMarkdown";
+
+interface ProgressiveDataGuideMobileProps {
+  items: DataGuideItemId[];
+}
+
+export function ProgressiveDataGuideMobile({
+  items,
+}: ProgressiveDataGuideMobileProps) {
+  const { t } = useTranslation();
+  const [activeItem, setActiveItem] = useState<DataGuideItemId | null>(null);
+
+  const handleItemToggle = (itemId: DataGuideItemId, isOpen: boolean) => {
+    setActiveItem(isOpen ? itemId : null);
+  };
+
+  return (
+    <div className="p-3 space-y-1 mt-2">
+      {items.map((itemId) => {
+        const item = dataGuideHelpItems[itemId];
+        return (
+          <Collapsible
+            key={itemId}
+            open={activeItem === itemId}
+            onOpenChange={(isOpen) => handleItemToggle(itemId, isOpen)}
+          >
+            <CollapsibleTrigger asChild>
+              <button
+                className={cn(
+                  "flex justify-between w-full py-1.5 px-2 items-center text-sm hover:bg-black-1/70 rounded transition-colors text-white font-bold",
+                )}
+              >
+                <span className="text-left">{t(item.titleKey)}</span>
+                <ChevronDownIcon
+                  className={cn(
+                    "w-3 h-3 transition-transform",
+                    activeItem === itemId && "rotate-180",
+                  )}
+                />
+              </button>
+            </CollapsibleTrigger>
+            <CollapsibleContent
+              className={cn(
+                "transition-all duration-200 ease-out overflow-hidden",
+                "data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down",
+              )}
+            >
+              <div className="px-2 mb-2 pt-2 pb-4 text-sm font-light text-gray-300 leading-relaxed border-b border-black-1">
+                <DataGuideMarkdown
+                  item={item}
+                  className="max-w-prose px-0 sm:px-4"
+                />
+              </div>
+            </CollapsibleContent>
+          </Collapsible>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/data-guide/ProgressiveDataGuideMobile.tsx
+++ b/src/data-guide/ProgressiveDataGuideMobile.tsx
@@ -18,10 +18,18 @@ export function ProgressiveDataGuideMobile({
   items,
 }: ProgressiveDataGuideMobileProps) {
   const { t } = useTranslation();
-  const [activeItem, setActiveItem] = useState<DataGuideItemId | null>(null);
+  const [openItems, setOpenItems] = useState<Set<DataGuideItemId>>(new Set());
 
   const handleItemToggle = (itemId: DataGuideItemId, isOpen: boolean) => {
-    setActiveItem(isOpen ? itemId : null);
+    setOpenItems(prev => {
+      const newSet = new Set(prev);
+      if (isOpen) {
+        newSet.add(itemId);
+      } else {
+        newSet.delete(itemId);
+      }
+      return newSet;
+    });
   };
 
   return (
@@ -31,7 +39,7 @@ export function ProgressiveDataGuideMobile({
         return (
           <Collapsible
             key={itemId}
-            open={activeItem === itemId}
+            open={openItems.has(itemId)}
             onOpenChange={(isOpen) => handleItemToggle(itemId, isOpen)}
           >
             <CollapsibleTrigger asChild>
@@ -44,7 +52,7 @@ export function ProgressiveDataGuideMobile({
                 <ChevronDownIcon
                   className={cn(
                     "w-3 h-3 transition-transform",
-                    activeItem === itemId && "rotate-180",
+                    openItems.has(itemId) && "rotate-180",
                   )}
                 />
               </button>

--- a/src/data-guide/SectionWithHelp.tsx
+++ b/src/data-guide/SectionWithHelp.tsx
@@ -1,0 +1,28 @@
+import { DataGuideItemId } from "@/data-guide/items";
+import { ProgressiveDataGuide } from "./ProgressiveDataGuide";
+import { cn } from "@/lib/utils";
+
+type SectionWithHelpProps = {
+  children: React.ReactNode;
+  helpItems: DataGuideItemId[];
+};
+
+export const SectionWithHelp = ({
+  children,
+  helpItems,
+}: SectionWithHelpProps) => {
+  const showDataGuide = helpItems.length > 0;
+
+  return (
+    <div className="bg-black-2 rounded-level-1 py-4 md:py-8">
+      <div className={cn("px-4 md:px-16", !showDataGuide && "mb-8")}>
+        {children}
+      </div>
+      {showDataGuide && (
+        <div className="mt-8 pt-4 md:pt-8 px-4 md:px-16 border-t border-black-1">
+          <ProgressiveDataGuide items={helpItems} style="sectionFooter" />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1251,6 +1251,7 @@
   },
   "dataGuide": {
     "buttonFallbackTitle": "Learn more about these metrics",
+    "selectItemPrompt": "Select a topic you want to learn more about",
     "items": {
       "totalEmissions": {
         "title": "What our total emissions represent",

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -1254,6 +1254,7 @@
   },
   "dataGuide": {
     "buttonFallbackTitle": "Lär dig mer om dessa mätvärden",
+    "selectItemPrompt": "Välj ett ämne du vill veta mer om",
     "items": {
       "totalEmissions": {
         "title": "Vad menas med totala utsläpp?",


### PR DESCRIPTION
### ✨ What’s Changed?
To reduce vertical scrolling and make better use of the extra width, this is a version of the inline data guide that that have two columns and allows more informatio to be visible without scrolling.

The data guide was also made to fit nicely into the gray section boxes as a section footer.

Mobile version was cleaned up to better fit the design of the site.

### 📸 Screenshots (if applicable)

<img width="1403" alt="image" src="https://github.com/user-attachments/assets/a98919fb-31bd-43e0-9ba4-22b659c17953" />

<img width="1411" alt="image" src="https://github.com/user-attachments/assets/42d40450-ec9e-4e2b-a9ab-75af272c68f5" />

Mobile:
<img width="552" alt="image" src="https://github.com/user-attachments/assets/0896d6af-6391-4226-8d19-3eadb5ed3cf7" />


### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

#677 <!-- or: Related to #[issue-number] -->