### PR TITLE
[fix] Reorder insights menu

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -104,8 +104,8 @@ export function Header() {
       path: `${currentLanguage}/articles`,
       label: t("header.insights"),
       sublinks: [
-        { label: t("header.articles"), path: `${currentLanguage}/articles` },
         { label: t("header.reports"), path: `${currentLanguage}/reports` },
+        { label: t("header.articles"), path: `${currentLanguage}/articles` },
         { label: t("header.learnMore"), path: `${currentLanguage}/learn-more` },
       ],
     },


### PR DESCRIPTION
### ✨ What’s Changed?
This puts the reports at the top of the insights menu as discussed during weekly meeting.

### 📸 Screenshots (if applicable)

<img width="287" alt="image" src="https://github.com/user-attachments/assets/ee57cf8f-025d-43b5-94d2-d058650074e4" />

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #[issue-number] <!-- or: Related to #[issue-number] -->