### PR TITLE
[849] add option to filter duplicate values in company emissions graph custom tooltip

### DIFF
--- a/src/components/companies/detail/CustomTooltip.tsx
+++ b/src/components/companies/detail/CustomTooltip.tsx
@@ -11,6 +11,7 @@ interface CustomTooltipProps {
   payload?: any[];
   label?: string;
   companyBaseYear: number | undefined;
+  filterDuplicateValues?: boolean;
 }
 
 export const CustomTooltip = ({
@@ -18,6 +19,7 @@ export const CustomTooltip = ({
   payload,
   label,
   companyBaseYear,
+  filterDuplicateValues = false,
 }: CustomTooltipProps) => {
   const { t } = useTranslation();
   const { getCategoryName } = useCategoryMetadata();
@@ -43,6 +45,19 @@ export const CustomTooltip = ({
 
     const isBaseYear = companyBaseYear === payload[0].payload.year;
 
+    let filteredPayload = payload;
+    if (filterDuplicateValues) {
+      const seenValues = new Set();
+      filteredPayload = payload.filter((entry) => {
+        const valueKey = `${entry.value}_${entry.payload.year}`;
+        if (seenValues.has(valueKey)) {
+          return false;
+        }
+        seenValues.add(valueKey);
+        return true;
+      });
+    }
+
     return (
       <div
         className={cn(
@@ -60,11 +75,7 @@ export const CustomTooltip = ({
             {t("companies.tooltip.tonsCO2e")}
           </span>
         </div>
-        {payload.map((entry: any) => {
-          if (entry.dataKey === "gap") {
-            return null;
-          }
-
+        {filteredPayload.map((entry) => {
           let { name } = entry;
           if (entry.dataKey.startsWith("cat")) {
             const categoryId = parseInt(entry.dataKey.replace("cat", ""));

--- a/src/components/companies/detail/history/EmissionsLineChart.tsx
+++ b/src/components/companies/detail/history/EmissionsLineChart.tsx
@@ -143,7 +143,12 @@ export default function EmissionsLineChart({
         />
 
         <Tooltip
-          content={<CustomTooltip companyBaseYear={companyBaseYear} />}
+          content={
+            <CustomTooltip
+              companyBaseYear={companyBaseYear}
+              filterDuplicateValues={dataView === "overview"}
+            />
+          }
         />
 
         {dataView === "overview" && (


### PR DESCRIPTION
### ✨ What’s Changed?

Add option to filter out duplicate values (such as same value for total emissions and approximated emissions, or approximated and carbon law) in company emissions graph tooltip. Useful for lines that have same values for same year.

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #849 