### PR TITLE
[fix] Use date renderer for budget runs out date on municipality details

### DIFF
--- a/src/pages/MunicipalityDetailPage.tsx
+++ b/src/pages/MunicipalityDetailPage.tsx
@@ -179,7 +179,10 @@ export function MunicipalityDetailPage() {
               value={
                 !municipality.budgetRunsOut
                   ? t("municipalityDetailPage.budgetHolds")
-                  : municipality.budgetRunsOut.toString()
+                  : localizeUnit(
+                      new Date(municipality.budgetRunsOut),
+                      currentLanguage,
+                    )
               }
               valueClassName={
                 !municipality.budgetRunsOut ? "text-green-3" : "text-pink-3"


### PR DESCRIPTION
### ✨ What’s Changed?

Always use a date renderer to render dates.

### 📸 Screenshots (if applicable)

Before:
<img width="1125" alt="image" src="https://github.com/user-attachments/assets/65de32de-3dfc-46fc-9c67-994e7c5e66a3" />

After:
<img width="1116" alt="image" src="https://github.com/user-attachments/assets/e76a7aef-9fcc-4653-b0ff-ccaca31dec66" />

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #[issue-number] <!-- or: Related to #[issue-number] -->