### PR TITLE
[FIX] Change title of 2024 report to 2025 to match report title page

### DIFF
--- a/src/lib/blog/blogPostsList.ts
+++ b/src/lib/blog/blogPostsList.ts
@@ -64,9 +64,9 @@ export const blogMetadata: ContentMeta[] = [
   {
     id: "sv-2024-report",
     title:
-      "Klimatkollens 2024-rapport - Översikt",
+      "Klimatkollens 2025-rapport - Översikt",
     excerpt:
-      "Vi granskar klimatrapporteringen från 235 storbolag för 2024 och visar varför utsläppsminskningarna går för långsamt – samt ger tre konkreta rekommendationer för mer transparent och effektiv klimatredovisning.",
+      "Vi granskar klimatrapporteringen från 235 storbolag för 2024 data och visar varför utsläppsminskningarna går för långsamt – samt ger tre konkreta rekommendationer för mer transparent och effektiv klimatredovisning.",
     date: "2025-07-07",
     readTime: "2 min",
     category: CategoryEnum.Analysis,
@@ -82,9 +82,9 @@ export const blogMetadata: ContentMeta[] = [
   {
     id: "2024-report",
     title:
-      "Klimatkollens 2024 Report Overview",
+      "Klimatkollens 2025 Report Overview",
     excerpt:
-      "We reviewed the corporate climate reporting from 235 large companies for 2024 and show why the emission reductions are too slow – and give three concrete recommendations for more transparent and effective climate reporting.",
+      "We reviewed the corporate climate reporting from 235 large companies for 2024 data and show why the emission reductions are too slow – and give three concrete recommendations for more transparent and effective climate reporting.",
     date: "2025-07-07",
     readTime: "2 min",
     category: CategoryEnum.Analysis,

--- a/src/lib/blog/posts/2024-report.md
+++ b/src/lib/blog/posts/2024-report.md
@@ -2,7 +2,7 @@
 id: "2024-report"
 ---
 
-> **[New report on large companies’ climate reporting for 2024](/reports/2025-06-23_Bolagsklimatkollen.pdf)**  
+> **[New report on large companies’ climate reporting for 2024 data](/reports/2025-06-23_Bolagsklimatkollen.pdf)**  
 >  
 
 ---

--- a/src/lib/blog/posts/sv-2024-report.md
+++ b/src/lib/blog/posts/sv-2024-report.md
@@ -2,7 +2,7 @@
 id: "sv-2024-report"
 ---
 
-> **[Ny rapport: storbolagens klimatrapportering för 2024](/reports/2025-06-23_Bolagsklimatkollen.pdf)**  
+> **[Ny rapport: storbolagens klimatrapportering för 2024 data](/reports/2025-06-23_Bolagsklimatkollen.pdf)**  
 >  
 
 ---


### PR DESCRIPTION
### ✨ What’s Changed?

Update the blog post title to match the report's title page and clarify it's 2024 data.

### 📸 Screenshots (if applicable)

copy change only


### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #[issue-number] <!-- or: Related to #[issue-number] -->