### PR TITLE
[907] Adjust 'Base Year' label position 

### DIFF
--- a/src/components/companies/detail/history/EmissionsLineChart.tsx
+++ b/src/components/companies/detail/history/EmissionsLineChart.tsx
@@ -81,6 +81,8 @@ export default function EmissionsLineChart({
   const shortEndYear = currentYear + 5;
   const longEndYear = 2050;
   const [chartEndYear, setChartEndYear] = useState(shortEndYear);
+  const isFirstYear = companyBaseYear === data[0]?.year;
+
   // --- New logic for dynamic explore steps ---
   const hasDataBeforeBaseYear =
     companyBaseYear && data.some((d) => d.year < companyBaseYear);
@@ -375,6 +377,7 @@ export default function EmissionsLineChart({
                   label={{
                     value: t("companies.emissionsHistory.baseYear"),
                     position: "top",
+                    dx: isFirstYear ? 15 : 0,
                     fill: "white",
                     fontSize: 12,
                     fontWeight: "normal",


### PR DESCRIPTION
### ✨ What’s Changed?

Base Year no longer overlaps with the y-axis when the base year is the first year.

### 📸 Screenshots (if applicable)

<img width="383" height="478" alt="Skärmavbild 2025-07-26 kl  15 26 59" src="https://github.com/user-attachments/assets/12d7d457-9444-4e0a-aeba-31777e8c3d98" />


### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed 

### 🛠 Related Issue

Closes #907 