### PR TITLE
[806] Handle null values in municipality rankings

### DIFF
--- a/src/components/municipalities/map/SwedenMap.tsx
+++ b/src/components/municipalities/map/SwedenMap.tsx
@@ -67,9 +67,18 @@ function SwedenMap({
   const maxValue = Math.max(...values);
 
   const sortedMunicipalities = [...municipalityData].sort((a, b) => {
-    const aValue = a[selectedKPI.key] as number;
-    const bValue = b[selectedKPI.key] as number;
-    return selectedKPI.higherIsBetter ? bValue - aValue : aValue - bValue;
+    const aValue = a[selectedKPI.key] ?? null;
+    const bValue = b[selectedKPI.key] ?? null;
+
+    if(aValue === null && bValue === null){
+      return 0;
+    } else if(aValue === null){
+      return 1;
+    } else if(bValue === null){
+      return -1;
+    }
+
+    return selectedKPI.higherIsBetter ? (bValue as number) - (aValue as number) : (aValue as number) - (bValue as number);
   });
 
   const handleZoomIn = () => {

--- a/src/components/municipalities/map/SwedenMap.tsx
+++ b/src/components/municipalities/map/SwedenMap.tsx
@@ -5,7 +5,7 @@ import {
   Geography,
   ZoomableGroup,
 } from "react-simple-maps";
-import { Municipality } from "@/types/municipality";
+import { KPIValue, Municipality, getSortedMunicipalKPIValues } from "@/types/municipality";
 import { MapZoomControls } from "./MapZoomControls";
 import { MapGradientLegend } from "./MapLegendGradient";
 import { MapTooltip } from "./MapTooltip";
@@ -14,18 +14,10 @@ import { MUNICIPALITY_MAP_COLORS } from "./constants";
 import { isMobile } from "react-device-detect";
 import { t } from "i18next";
 
-interface MunicipalityKPI {
-  label: string;
-  key: keyof Municipality;
-  unit: string;
-  description?: string;
-  higherIsBetter: boolean;
-}
-
 interface SwedenMapProps {
   geoData: FeatureCollection;
   municipalityData: Municipality[];
-  selectedKPI: MunicipalityKPI;
+  selectedKPI: KPIValue;
   onMunicipalityClick: (name: string) => void;
 }
 
@@ -66,20 +58,7 @@ function SwedenMap({
   const minValue = Math.min(...values);
   const maxValue = Math.max(...values);
 
-  const sortedMunicipalities = [...municipalityData].sort((a, b) => {
-    const aValue = a[selectedKPI.key] ?? null;
-    const bValue = b[selectedKPI.key] ?? null;
-
-    if(aValue === null && bValue === null){
-      return 0;
-    } else if(aValue === null){
-      return 1;
-    } else if(bValue === null){
-      return -1;
-    }
-
-    return selectedKPI.higherIsBetter ? (bValue as number) - (aValue as number) : (aValue as number) - (bValue as number);
-  });
+  const sortedMunicipalities = getSortedMunicipalKPIValues(municipalityData, selectedKPI);
 
   const handleZoomIn = () => {
     if (position.zoom >= 4) {

--- a/src/components/municipalities/rankedList/KPIDetailsPanel.tsx
+++ b/src/components/municipalities/rankedList/KPIDetailsPanel.tsx
@@ -55,7 +55,7 @@ export default function KPIDetailsPanel({
         {nullValues > 0 && (
           <p className="text-gray-400 text-sm italic">
             {nullValues}{" "}
-            {t(`municipalities.list.kpis.${selectedKPI.key}.nullValues`)}
+            {t(`municipalities.list.kpis.${selectedKPI.key}.nullValues`).toLowerCase()}
           </p>
         )}
       </div>

--- a/src/components/municipalities/rankedList/MunicipalityInsightsList.tsx
+++ b/src/components/municipalities/rankedList/MunicipalityInsightsList.tsx
@@ -9,6 +9,7 @@ interface InsightsListProps {
   textColor: string;
   totalCount: number;
   isBottomRanking?: boolean;
+  nullValues?: string;
 }
 
 function InsightsList({
@@ -19,6 +20,7 @@ function InsightsList({
   textColor,
   totalCount,
   isBottomRanking = false,
+  nullValues,
 }: InsightsListProps) {
   return (
     <div className="bg-white/10 rounded-level-2 p-4 md:p-6">
@@ -38,7 +40,7 @@ function InsightsList({
                 <span>{municipality.name}</span>
               </div>
               <span className={`${textColor} font-semibold`}>
-                {municipality[dataPointKey] != null ? (municipality[dataPointKey] as number).toFixed(1) + unit : "-"}
+                {municipality[dataPointKey] != null ? (municipality[dataPointKey] as number).toFixed(1) + unit : nullValues }
               </span>
             </div>
           </Link>

--- a/src/components/municipalities/rankedList/MunicipalityInsightsList.tsx
+++ b/src/components/municipalities/rankedList/MunicipalityInsightsList.tsx
@@ -38,8 +38,7 @@ function InsightsList({
                 <span>{municipality.name}</span>
               </div>
               <span className={`${textColor} font-semibold`}>
-                {(municipality[dataPointKey] as number).toFixed(1)}
-                {unit}
+                {municipality[dataPointKey] != null ? (municipality[dataPointKey] as number).toFixed(1) + unit : "-"}
               </span>
             </div>
           </Link>

--- a/src/components/municipalities/rankedList/MunicipalityInsightsPanel.tsx
+++ b/src/components/municipalities/rankedList/MunicipalityInsightsPanel.tsx
@@ -37,11 +37,20 @@ function InsightsPanel({ municipalityData, selectedKPI }: InsightsPanelProps) {
     );
   }
 
-  const sortedData = [...validData].sort((a, b) =>
-    selectedKPI.higherIsBetter
-      ? (b[selectedKPI.key] as number) - (a[selectedKPI.key] as number)
-      : (a[selectedKPI.key] as number) - (b[selectedKPI.key] as number),
-  );
+  const sortedData = [...municipalityData].sort((a, b) => {
+    const aValue = a[selectedKPI.key] ?? null;
+    const bValue = b[selectedKPI.key] ?? null;
+
+    if(aValue === null && bValue === null){
+      return 0;
+    } else if(aValue === null){
+      return 1;
+    } else if(bValue === null){
+      return -1;
+    }
+
+    return selectedKPI.higherIsBetter ? (bValue as number) - (aValue as number) : (aValue as number) - (bValue as number);
+  });
 
   const topMunicipalities = sortedData.slice(0, 5);
   const bottomMunicipalities = sortedData.slice(-5).reverse();

--- a/src/components/municipalities/rankedList/MunicipalityInsightsPanel.tsx
+++ b/src/components/municipalities/rankedList/MunicipalityInsightsPanel.tsx
@@ -72,6 +72,7 @@ function InsightsPanel({ municipalityData, selectedKPI }: InsightsPanelProps) {
           totalCount={municipalityData.length}
           dataPointKey={selectedKPI.key}
           unit={selectedKPI.unit}
+          nullValues={selectedKPI.nullValues}
           textColor="text-blue-3"
         />
 
@@ -82,6 +83,7 @@ function InsightsPanel({ municipalityData, selectedKPI }: InsightsPanelProps) {
           isBottomRanking={true}
           dataPointKey={selectedKPI.key}
           unit={selectedKPI.unit}
+          nullValues={selectedKPI.nullValues}
           textColor="text-pink-3"
         />
       </div>

--- a/src/components/municipalities/rankedList/MunicipalityInsightsPanel.tsx
+++ b/src/components/municipalities/rankedList/MunicipalityInsightsPanel.tsx
@@ -1,5 +1,5 @@
 import { t } from "i18next";
-import { KPIValue, Municipality } from "@/types/municipality";
+import { KPIValue, Municipality, getSortedMunicipalKPIValues } from "@/types/municipality";
 import InsightsList from "./MunicipalityInsightsList";
 import KPIDetailsPanel from "./KPIDetailsPanel";
 
@@ -37,20 +37,7 @@ function InsightsPanel({ municipalityData, selectedKPI }: InsightsPanelProps) {
     );
   }
 
-  const sortedData = [...municipalityData].sort((a, b) => {
-    const aValue = a[selectedKPI.key] ?? null;
-    const bValue = b[selectedKPI.key] ?? null;
-
-    if(aValue === null && bValue === null){
-      return 0;
-    } else if(aValue === null){
-      return 1;
-    } else if(bValue === null){
-      return -1;
-    }
-
-    return selectedKPI.higherIsBetter ? (bValue as number) - (aValue as number) : (aValue as number) - (bValue as number);
-  });
+  const sortedData = getSortedMunicipalKPIValues(municipalityData, selectedKPI);
 
   const topMunicipalities = sortedData.slice(0, 5);
   const bottomMunicipalities = sortedData.slice(-5).reverse();

--- a/src/components/municipalities/rankedList/MunicipalityRankedList.tsx
+++ b/src/components/municipalities/rankedList/MunicipalityRankedList.tsx
@@ -9,6 +9,7 @@ interface DataPoint {
   unit: string;
   description?: string;
   higherIsBetter: boolean;
+  nullValues?: string;
 }
 
 interface RankedListProps {
@@ -96,7 +97,7 @@ function MunicipalityRankedList({
               <span className="text-orange-2 font-medium">
                 {municipality[selectedKPI.key] !== null
                   ? `${(municipality[selectedKPI.key] as number).toFixed(1)}${selectedKPI.unit}`
-                  : "-"}
+                  : selectedKPI.nullValues}
               </span>
             </button>
           ))}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1089,7 +1089,7 @@
           "description": "Number of electric vehicles per charging point",
           "detailedDescription": "Number of electric vehicles per public charging point, per municipality in 2024. Lower numbers are better, as good infrastructure promotes increased electric vehicle adoption.",
           "source": "<0>Power Circle</0>",
-          "nullValues": "no charging points"
+          "nullValues": "No charging points"
         },
         "bicycleMetrePerCapita": {
           "label": "Bicycles",

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -1089,7 +1089,7 @@
           "description": "Antal elbilar per laddningspunkt",
           "detailedDescription": "Antal elbilar per publik laddningspunkt per kommun år 2024. Ju färre bilar per laddningspunkt desto bättre, god infrastruktur gynnar ökad elbilskonsumtion",
           "source": "<0>Power Circle</0>",
-          "nullValues": "saknar laddpunkter"
+          "nullValues": "Saknar laddpunkter"
         },
         "bicycleMetrePerCapita": {
           "label": "Cyklarna",

--- a/src/types/municipality.ts
+++ b/src/types/municipality.ts
@@ -130,6 +130,23 @@ export function transformEmissionsData(municipality: Municipality) {
     .filter((d) => d.year >= 1990 && d.year <= 2050);
 }
 
+export function getSortedMunicipalKPIValues(municipalities: Municipality[], kpi: KPIValue){
+  return [...municipalities].sort((a, b) => {
+    const aValue = a[kpi.key] ?? null;
+    const bValue = b[kpi.key] ?? null;
+
+    if(aValue === null && bValue === null){
+      return 0;
+    } else if(aValue === null){
+      return 1;
+    } else if(bValue === null){
+      return -1;
+    }
+
+    return kpi.higherIsBetter ? (bValue as number) - (aValue as number) : (aValue as number) - (bValue as number);
+  });
+}
+
 export type DataPoint = {
   year: number;
   total: number | undefined;


### PR DESCRIPTION
### ✨ What’s Changed?

I made sure that municipalities with null or undefined values for a given KPI are sorted last in the rankings on the map and in the insight panel.

### 📸 Screenshots (if applicable)

<img width="596" height="592" alt="bild" src="https://github.com/user-attachments/assets/58b11788-1985-425b-90dd-d9d6a0709ce9" />

<img width="457" height="306" alt="bild" src="https://github.com/user-attachments/assets/4fff0663-4c8e-4190-a855-046a1ae6fa3d" />

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #[806] <!-- or: Related to #[issue-number] -->