### PR TITLE
[fix] Make all cards on landing page have same margins left and right on mobile

### DIFF
--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -174,7 +174,7 @@ export function LandingPage() {
       </div>
 
       <div className="pb-8 md:pb-16">
-        <div className="container mx-auto">
+        <div className="mx-2 sm:mx-8">
           <ContentBlock
             title={t("landingPage.aboutUsTitle")}
             content={t("landingPage.aboutUsContent")}


### PR DESCRIPTION
### ✨ What’s Changed?

* Make all cards on landing page have same margins left and right on mobile
* Minor cleanup of outcommented code

### 📸 Screenshots (if applicable)

Before
<img width="359" height="537" alt="Screenshot 2025-08-13 at 08 28 52" src="https://github.com/user-attachments/assets/b3770107-550c-419a-ac56-76a60031333d" />

After
<img width="359" height="537" alt="Screenshot 2025-08-13 at 08 28 42" src="https://github.com/user-attachments/assets/a2354d4a-9884-4432-b20f-6688f6b9deb5" />


### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)
