### PR TITLE
[931] Aligning municipality graph to card heading

### DIFF
--- a/src/components/municipalities/MunicipalityEmissions.tsx
+++ b/src/components/municipalities/MunicipalityEmissions.tsx
@@ -56,7 +56,7 @@ export const MunicipalityEmissions: FC<MunicipalityEmissionsProps> = ({
         />
       </div>
 
-      <div className="mt-8 h-[400px] mr-4 md:mr-8">
+      <div className="mt-8 h-[400px]">
         <MunicipalityEmissionsGraph
           projectedData={emissionsData}
           sectorEmissions={sectorEmissions || undefined}

--- a/src/components/municipalities/emissionsGraph/OverviewChart.tsx
+++ b/src/components/municipalities/emissionsGraph/OverviewChart.tsx
@@ -35,7 +35,7 @@ export const OverviewChart: FC<OverviewChartProps> = ({ projectedData }) => {
           wrapperStyle={{
             fontSize: "12px",
             color: "var(--grey)",
-            paddingLeft: "24px",
+            paddingLeft: "50px",
           }}
         />
         <Tooltip

--- a/src/components/municipalities/emissionsGraph/OverviewChart.tsx
+++ b/src/components/municipalities/emissionsGraph/OverviewChart.tsx
@@ -26,13 +26,17 @@ export const OverviewChart: FC<OverviewChartProps> = ({ projectedData }) => {
 
   return (
     <ResponsiveContainer width="100%" height="90%">
-      <LineChart data={projectedData}>
+      <LineChart data={projectedData} margin={{ left: -50 }}>
         <Legend
           verticalAlign="bottom"
           align="right"
           height={36}
           iconType="line"
-          wrapperStyle={{ fontSize: "12px", color: "var(--grey)" }}
+          wrapperStyle={{
+            fontSize: "12px",
+            color: "var(--grey)",
+            paddingLeft: "24px",
+          }}
         />
         <Tooltip
           content={

--- a/src/components/municipalities/emissionsGraph/SectorsChart.tsx
+++ b/src/components/municipalities/emissionsGraph/SectorsChart.tsx
@@ -106,7 +106,7 @@ export const SectorsChart: FC<SectorsChartProps> = ({
           verticalAlign="bottom"
           align="right"
           iconType="line"
-          wrapperStyle={{ fontSize: "12px", color: "var(--grey)", paddingLeft: "24px" }}
+          wrapperStyle={{ fontSize: "12px", color: "var(--grey)", paddingLeft: "50px" }}
           formatter={(value) => {
             const sectorInfo = getSectorInfo?.(value) || {
               translatedName: value,

--- a/src/components/municipalities/emissionsGraph/SectorsChart.tsx
+++ b/src/components/municipalities/emissionsGraph/SectorsChart.tsx
@@ -101,12 +101,12 @@ export const SectorsChart: FC<SectorsChartProps> = ({
 
   return (
     <ResponsiveContainer width="100%" height="90%">
-      <ComposedChart data={chartData}>
+      <ComposedChart data={chartData} margin={{ left: -50 }}>
         <Legend
           verticalAlign="bottom"
           align="right"
           iconType="line"
-          wrapperStyle={{ fontSize: "12px", color: "var(--grey)" }}
+          wrapperStyle={{ fontSize: "12px", color: "var(--grey)", paddingLeft: "24px" }}
           formatter={(value) => {
             const sectorInfo = getSectorInfo?.(value) || {
               translatedName: value,


### PR DESCRIPTION
### ✨ What’s Changed?

Changed graph margins and paddings to align graph Y-axis to the card heading on the municipality graph cards.

### 📸 Screenshots (if applicable)

Before:
<img width="708" height="1440" alt="image" src="https://github.com/user-attachments/assets/3c1c21b9-bff2-4001-a128-7821d46afbee" />


After:
<img width="327" height="740" alt="image" src="https://github.com/user-attachments/assets/96bf8d1a-cf82-4156-86fd-d1587ad140a6" />



### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [x] I've set the labels, issue, and milestone for the PR
- [ ] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes  #[[931]](https://github.com/Klimatbyran/frontend/issues/931)