### PR TITLE
[945] Put fixed heights on dynamically sized elements to flicker on scroll

### DIFF
--- a/src/components/companies/list/CompanyCard.tsx
+++ b/src/components/companies/list/CompanyCard.tsx
@@ -135,7 +135,9 @@ export function CompanyCard({
               </TooltipProvider>
             </div>
           )} */}
-            <p className="text-grey text-sm line-clamp-2">{description}</p>
+            <p className="min-h-[40px] text-grey text-sm line-clamp-2">
+              {description}
+            </p>
           </div>
           <div
             className="w-12 h-12 rounded-full flex shrink-0 items-center justify-center"
@@ -148,7 +150,7 @@ export function CompanyCard({
           </div>
         </div>
         <div className="flex flex-col gap-4 @xl:grid grid-cols-2">
-          <div className="space-y-2">
+          <div className="space-y-2 h-[80px]">
             <div className="flex items-center gap-2 text-grey mb-2 text-lg">
               <TrendingDown className="w-4 h-4" />
               {t("companies.card.emissions")}
@@ -163,7 +165,7 @@ export function CompanyCard({
                 </Tooltip>
               </TooltipProvider>
             </div>
-            <div className="text-3xl font-light">
+            <div className="text-3xl flex font-light h-[44px]">
               {currentEmissions != null ? (
                 <span className="text-orange-2">
                   {formatEmissionsAbsolute(currentEmissions, currentLanguage)}
@@ -181,7 +183,7 @@ export function CompanyCard({
               )}
             </div>
           </div>
-          <div className="space-y-2">
+          <div className="space-y-2 h-[80px]">
             <div className="flex items-center gap-2 text-grey mb-2 text-lg">
               <TrendingDown className="w-4 h-4" />
               <span>{t("companies.card.emissionsChangeRate")}</span>
@@ -211,7 +213,7 @@ export function CompanyCard({
                 </Tooltip>
               </TooltipProvider>
             </div>
-            <div className="text-3xl font-light">
+            <div className="text-3xl font-light h-[44px]">
               {emissionsChange !== null ? (
                 <span
                   className={cn(


### PR DESCRIPTION

### ✨ What’s Changed?

Put fixed heights in dynamically sized elements inside the company card to prevent them from growing to different sizes depending on content to prevent flicker.

### 📋 Checklist

- [X] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [X] I've verified the change runs locally both on mobile and desktop
- [X] I've set the labels, issue, and milestone for the PR
- [ ] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #945 