### PR TITLE
[954] Misalignment of emissions values on company details page

### DIFF
--- a/src/components/companies/detail/overview/CompanyOverview.tsx
+++ b/src/components/companies/detail/overview/CompanyOverview.tsx
@@ -173,36 +173,35 @@ export function CompanyOverview({
           >
             {t("companies.overview.totalEmissions")} {periodYear}
           </Text>
-          <div className="flex items-baseline gap-4">
-            <Text
-              className={cn(
-                "text-3xl md:text-4xl lg:text-6xl font-light tracking-tighter leading-none",
-                selectedPeriod.emissions?.calculatedTotalEmissions === 0
-                  ? "text-grey"
-                  : "text-orange-2",
-              )}
-            >
-              {!selectedPeriod.emissions ||
+
+          <Text
+            className={cn(
+              "text-3xl md:text-4xl lg:text-6xl font-light tracking-tighter leading-none",
               selectedPeriod.emissions?.calculatedTotalEmissions === 0
-                ? t("companies.overview.noData")
-                : formatEmissionsAbsolute(
-                    selectedPeriod.emissions.calculatedTotalEmissions,
-                    currentLanguage,
-                  )}
-              <span className="text-lg lg:text-2xl md:text-lg sm:text-sm ml-2 text-grey">
-                {t(
-                  selectedPeriod.emissions?.calculatedTotalEmissions === 0
-                    ? " "
-                    : "emissionsUnit",
+                ? "text-grey"
+                : "text-orange-2",
+            )}
+          >
+            {!selectedPeriod.emissions ||
+            selectedPeriod.emissions?.calculatedTotalEmissions === 0
+              ? t("companies.overview.noData")
+              : formatEmissionsAbsolute(
+                  selectedPeriod.emissions.calculatedTotalEmissions,
+                  currentLanguage,
                 )}
-              </span>
-            </Text>
+            <span className="text-lg lg:text-2xl md:text-lg sm:text-sm ml-2 text-grey">
+              {t(
+                selectedPeriod.emissions?.calculatedTotalEmissions === 0
+                  ? " "
+                  : "emissionsUnit",
+              )}
+            </span>
             {totalEmissionsAIGenerated && (
               <span className="ml-2 absolute">
-                <AiIcon size="md" className="absolute top-0" />
+                <AiIcon size="md" className="absolute top-0 " />
               </span>
             )}
-          </div>
+          </Text>
         </div>
 
         <div className="flex-1">

--- a/src/components/companies/detail/overview/CompanyOverview.tsx
+++ b/src/components/companies/detail/overview/CompanyOverview.tsx
@@ -198,8 +198,8 @@ export function CompanyOverview({
               </span>
             </Text>
             {totalEmissionsAIGenerated && (
-              <span className="ml-2">
-                <AiIcon size="md" />
+              <span className="ml-2 absolute">
+                <AiIcon size="md" className="absolute top-0" />
               </span>
             )}
           </div>
@@ -227,8 +227,8 @@ export function CompanyOverview({
               </span>
             )}
             {yearOverYearAIGenerated && (
-              <span className="ml-2">
-                <AiIcon size="md" />
+              <span className="ml-2 absolute">
+                <AiIcon size="md" className="absolute top-0" />
               </span>
             )}
           </Text>


### PR DESCRIPTION
### ✨ What’s Changed?

Added absolute positioning to AI-icon and parent container to prevent shifting alignment of text if one value has an icon and the other don't. Also corrected AI-icon positioning to upper right of value.

### 📸 Screenshots (if applicable)

Before:
<img width="1409" height="873" alt="image" src="https://github.com/user-attachments/assets/4aa04c64-a7f4-4de0-8437-861f6f3d3e43" />

After:
<img width="1271" height="807" alt="image" src="https://github.com/user-attachments/assets/53cfdc68-68a1-4f83-9678-9691935c57fe" />



### 📋 Checklist

- [ ] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [ ] I've verified the change runs locally both on mobile and desktop
- [ ] I've set the labels, issue, and milestone for the PR
- [ ] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #954 