### PR TITLE
[817] Added iFrame player for displaying klimatkollen video on About Us-page

### DIFF
--- a/src/components/ui/klimatkollenVideoPlayer.tsx
+++ b/src/components/ui/klimatkollenVideoPlayer.tsx
@@ -3,7 +3,7 @@ import { useScreenSize } from "@/hooks/useScreenSize";
 const KlimatkollenVideo = () => {
   const { isMobile } = useScreenSize();
   return (
-    <div className={`${isMobile ? "h-[600px]" : "h-[800px]"} py-24 w-full`}>
+    <div className={`${isMobile ? "h-[450px]" : "h-[800px]"} py-12 w-full`}>
       <iframe
         width="100%"
         height="100%"

--- a/src/components/ui/klimatkollenVideoPlayer.tsx
+++ b/src/components/ui/klimatkollenVideoPlayer.tsx
@@ -1,0 +1,22 @@
+import { useScreenSize } from "@/hooks/useScreenSize";
+
+const KlimatkollenVideo = () => {
+  const { isMobile } = useScreenSize();
+  return (
+    <div className={`${isMobile ? "h-[600px]" : "h-[800px]"} py-24 w-full`}>
+      <iframe
+        width="100%"
+        height="100%"
+        src="https://www.youtube.com/embed/oRm2W7LiwME?si=PN9bT_8JTvLkS9Kg"
+        title="YouTube video player"
+        frameborder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        referrerpolicy="strict-origin-when-cross-origin"
+        controls="1"
+        loading="lazy"
+      ></iframe>
+    </div>
+  );
+};
+
+export default KlimatkollenVideo;

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from "react-i18next";
 import { MembersGrid } from "@/components/MembersGrid";
 import { PageSEO } from "@/components/SEO/PageSEO";
 import { useEffect } from "react";
+import KlimatkollenVideo from "@/components/ui/klimatkollenVideoPlayer";
 
 export function AboutPage() {
   const { t } = useTranslation();
@@ -78,6 +79,7 @@ export function AboutPage() {
                 <div className="prose prose-invert w-full max-w-5xl space-y-4">
                   <p>{t("aboutPage.mainContent.paragraph4")}</p>
                 </div>
+                <KlimatkollenVideo />
               </div>
             </div>
           </div>


### PR DESCRIPTION
### ✨ What’s Changed?

Added the Klimatkollen video(https://www.youtube.com/watch?v=oRm2W7LiwME) to the About Us page. Unsure about sizing for mobile and desktop, so let me know your thoughts on this.

### 📸 Screenshots (if applicable)

Desktop: 
<img width="1372" height="806" alt="image" src="https://github.com/user-attachments/assets/ba3a21eb-7e70-49d5-a847-4c88020d8c42" />

Mobile:
<img width="370" height="805" alt="image" src="https://github.com/user-attachments/assets/086a4c6c-4821-45c8-9421-8f552e3d1e29" />


### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [x] I've set the labels, issue, and milestone for the PR
- [ ] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #817 