### PR TITLE
[Fix] Added min-h to description container to prevent resizing on card and flickering

### DIFF
--- a/src/components/companies/list/CompanyCard.tsx
+++ b/src/components/companies/list/CompanyCard.tsx
@@ -100,7 +100,9 @@ export function CompanyCard({
         <div className="flex items-start justify-between rounded-level-2">
           <div className="space-y-2">
             <h2 className="text-3xl font-light">{name}</h2>
-            <p className="text-grey text-sm line-clamp-2">{description}</p>
+            <p className="text-grey text-sm line-clamp-2 min-h-[40px]">
+              {description}
+            </p>
           </div>
           <div
             className="w-12 h-12 rounded-full flex shrink-0 items-center justify-center"


### PR DESCRIPTION
### ✨ What’s Changed?

Hotfix: Added min-h to description container to prevent resizing on card. This value was added on previous flicker-PR but somehow disappeared.


### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [x] I've set the labels, issue, and milestone for the PR
- [ ] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)
