### PR TITLE
[916] Translate category and language labels and localize dates for article and report

### DIFF
--- a/src/components/layout/ContentCard.tsx
+++ b/src/components/layout/ContentCard.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { Text } from "@/components/ui/text";
 import { useTranslation } from "react-i18next";
 import { useLanguage } from "@/components/LanguageProvider";
+import { localizeUnit } from "@/utils/formatting/localization";
 
 interface ContentCardProps {
   item: {
@@ -50,7 +51,7 @@ export function ContentCard({ item, basePath }: ContentCardProps) {
               <div className="flex items-center gap-2 text-grey text-sm">
                 <CalendarDays className="w-4 h-4" />
                 <span aria-label="Date Published">
-                  {new Date(item.date).toLocaleDateString("sv-SE")}
+                  {localizeUnit(new Date(item.date), currentLanguage)}
                 </span>
               </div>
             )}

--- a/src/components/layout/ContentCard.tsx
+++ b/src/components/layout/ContentCard.tsx
@@ -63,7 +63,7 @@ export function ContentCard({ item, basePath }: ContentCardProps) {
             {item.language && (
               <div className="flex items-center gap-2 text-grey text-sm">
                 <Globe2 className="w-4 h-4" />
-                <span aria-label="Language">{item.language}</span>
+                <span aria-label="Language">{t("language." + item.language)}</span>
               </div>
             )}
           </div>

--- a/src/lib/blog/blogPostsList.ts
+++ b/src/lib/blog/blogPostsList.ts
@@ -18,7 +18,7 @@ export const blogMetadata: ContentMeta[] = [
     category: CategoryEnum.Analysis,
     image: "/images/blogImages/only-radical-futures.jpg",
     displayLanguages: ["en"],
-    language: "English",
+    language: "en",
     author: {
       name: "Frida Berry Eklund",
       avatar: "/people/frida.jpg",
@@ -36,7 +36,7 @@ export const blogMetadata: ContentMeta[] = [
     category: CategoryEnum.Analysis,
     image: "/images/blogImages/only-radical-futures.jpg",
     displayLanguages: ["sv"],
-    language: "Svenska",
+    language: "sv",
     author: {
       name: "Frida Berry Eklund",
       avatar: "/people/frida.jpg",
@@ -54,7 +54,7 @@ export const blogMetadata: ContentMeta[] = [
     category: CategoryEnum.Methodology,
     image: "/images/blogImages/2025_Carbon_Law.png",
     displayLanguages: ["en"],
-    language: "English",
+    language: "en",
     author: {
       name: "Frida Berry Eklund",
       avatar: "/people/frida.jpg",
@@ -72,7 +72,7 @@ export const blogMetadata: ContentMeta[] = [
     category: CategoryEnum.Methodology,
     image: "/images/blogImages/2025_Carbon_Law.png",
     displayLanguages: ["sv"],
-    language: "Svenska",
+    language: "sv",
     author: {
       name: "Frida Berry Eklund",
       avatar: "/people/frida.jpg",
@@ -90,7 +90,7 @@ export const blogMetadata: ContentMeta[] = [
     category: CategoryEnum.Analysis,
     image: "/images/reportImages/2024_bolagsklimatkollen.png",
     displayLanguages: ["sv"],
-    language: "Svenska",
+    language: "sv",
     author: {
       name: "Ola Spännar",
       avatar: "/people/ola.jpg",
@@ -108,7 +108,7 @@ export const blogMetadata: ContentMeta[] = [
     category: CategoryEnum.Analysis,
     image: "/images/reportImages/2024_bolagsklimatkollen.png",
     displayLanguages: ["en"],
-    language: "English",
+    language: "en",
     author: {
       name: "Ola Spännar",
       avatar: "/people/ola.jpg",
@@ -125,7 +125,7 @@ export const blogMetadata: ContentMeta[] = [
     category: CategoryEnum.Analysis,
     image: "/images/blogImages/matthias-heyde-co2-unsplash.jpg",
     displayLanguages: ["sv"],
-    language: "Svenska",
+    language: "sv",
     author: {
       name: "John Carlbäck, volontär och rådgivare",
       avatar: "/people/carlback_john.jpg",
@@ -144,7 +144,7 @@ export const blogMetadata: ContentMeta[] = [
     image:
       "https://images.unsplash.com/photo-1551288049-bebda4e38f71?w=1200&h=600&fit=crop",
     displayLanguages: ["sv","all"],
-    language: "Svenska",
+    language: "sv",
     author: {
       name: "Christian Landgren",
       avatar: "/people/christian.jpg",
@@ -162,7 +162,7 @@ export const blogMetadata: ContentMeta[] = [
     image:
       "https://images.unsplash.com/photo-1451187580459-43490279c0fa?w=800&h=400&fit=crop",
     displayLanguages: ["sv","all"],
-    language: "Svenska",
+    language: "sv",
     author: {
       name: "Alexandra Palmquist",
       avatar: "/people/alex.jpg",
@@ -180,7 +180,7 @@ export const blogMetadata: ContentMeta[] = [
     image:
       "https://images.unsplash.com/photo-1464938050520-ef2270bb8ce8?w=800&h=400&fit=crop",
     displayLanguages: ["sv"],
-    language: "Svenska",
+    language: "sv",
     author: {
       name: "Alexandra Palmquist",
       avatar: "/people/alex.jpg",
@@ -197,7 +197,7 @@ export const blogMetadata: ContentMeta[] = [
     category: CategoryEnum.Analysis,
     image: "/images/blogImages/image1-31.webp",
     displayLanguages: ["sv"],
-    language: "Svenska",
+    language: "sv",
     author: {
       name: "Ola Spännar",
       avatar: "/people/ola.jpg",
@@ -214,7 +214,7 @@ export const blogMetadata: ContentMeta[] = [
     category: CategoryEnum.Analysis,
     image: "/images/blogImages/totala-utslapp-alla-partier.webp",
     displayLanguages: ["sv"],
-    language: "Svenska",
+    language: "sv",
     author: {
       name: "Ola Spännar",
       avatar: "/people/ola.jpg",

--- a/src/lib/blog/blogPostsList.ts
+++ b/src/lib/blog/blogPostsList.ts
@@ -1,9 +1,9 @@
 import { ContentMeta } from "@/types/content";
 
 export enum CategoryEnum {
-  Methodology = "Metodik",
-  Analysis = "Analys",
-  Guide = "Guide",
+  Methodology = "methodology",
+  Analysis = "analysis",
+  Guide = "guide",
 }
 
 export const blogMetadata: ContentMeta[] = [

--- a/src/lib/constants/reports.ts
+++ b/src/lib/constants/reports.ts
@@ -8,7 +8,7 @@ export const reports: ContentMeta[] = [
     date: "2025-03-11",
     excerpt: "En analys av 150 bolags klimatredovisningar",
     readTime: "15 min",
-    category: "Rapport",
+    category: "report",
     author: {
       name: "Alexandra Palmquist",
       avatar: "/people/alex.jpg",
@@ -25,7 +25,7 @@ export const reports: ContentMeta[] = [
     date: "2024-06-01",
     excerpt: "En analys av 150 svenska storbolags klimatredovisning 2023",
     readTime: "15 min",
-    category: "Rapport",
+    category: "report",
     author: {
       name: "Alexandra Palmquist",
       avatar: "/people/alex.jpg",
@@ -43,7 +43,7 @@ export const reports: ContentMeta[] = [
     excerpt:
       "An analysis of 150 major Swedish companies' climate reporting 2023",
     readTime: "15 min",
-    category: "Report",
+    category: "report",
     author: {
       name: "Alexandra Palmquist",
       avatar: "/people/alex.jpg",
@@ -62,7 +62,7 @@ export const reports: ContentMeta[] = [
     excerpt:
       "A typology of data quality problems in corporate reporting of GHG emissions. A report by Green Data, Indicators, Algorithms (Green DIA), funded by the Bavarian Research Institute for Digital Transformation (bidt) and Klimatkollen.",
     readTime: "15 min",
-    category: "Report",
+    category: "report",
     author: {
       name: "Green DIA",
     },
@@ -79,7 +79,7 @@ export const reports: ContentMeta[] = [
     excerpt:
       "I årets version av rapporten Bolagsklimatkollen analyserar vi 235 storbolags klimatredovisning för 2024. Rapporten är ett samarbete mellan 2050 Consulting och Klimatkollen.",
     readTime: "15 min",
-    category: "Report",
+    category: "report",
     author: {
       name: "Frida Berry Eklund",
       avatar: "/people/frida.jpg",
@@ -97,7 +97,7 @@ export const reports: ContentMeta[] = [
     excerpt:
       "Summary of Klimatkollen's investigations for adjustments to the Carbon Law target trajectory, based on 2024 emissions and updated carbon budgets.",
     readTime: "7 min",
-    category: "Report",
+    category: "report",
     author: {
       name: "Frida Berry Eklund",
       avatar: "/people/frida.jpg",

--- a/src/lib/constants/reports.ts
+++ b/src/lib/constants/reports.ts
@@ -16,7 +16,7 @@ export const reports: ContentMeta[] = [
     link: "/reports/2025-03-17_StorfoeretagensHistoriskaUtslaepp.pdf",
     image: "/images/reportImages/2024_report_sv2.png",
     displayLanguages: ["sv"],
-    language: "Svenska",
+    language: "sv",
   },
   {
     id: "2",
@@ -33,7 +33,7 @@ export const reports: ContentMeta[] = [
     link: "/reports/2024-06-Bolagsklimatkollen.pdf",
     image: "/images/reportImages/2023_bolagsklimatkollen2.png",
     displayLanguages: ["sv"],
-    language: "Svenska",
+    language: "sv",
   },
   {
     id: "3",
@@ -51,7 +51,7 @@ export const reports: ContentMeta[] = [
     link: "/reports/2024-08_CorporateClimateChecker.pdf",
     image: "/images/reportImages/2023_corportateclimatechecker2.png",
     displayLanguages: ["en"],
-    language: "English",
+    language: "en",
   },
   {
     id: "4",
@@ -69,7 +69,7 @@ export const reports: ContentMeta[] = [
     link: "/reports/Typology_of_Data_Quality_Problems_in_Corporate_Reporting.docx.pdf",
     image: "/images/reportImages/typology-of-errors.png",
     displayLanguages: ["en", "all"],
-    language: "English",
+    language: "en",
   },
   {
     id: "5",
@@ -87,7 +87,7 @@ export const reports: ContentMeta[] = [
     link: "/reports/2025-06-23_Bolagsklimatkollen.pdf",
     image: "/images/reportImages/2024_bolagsklimatkollen.png",
     displayLanguages: ["sv", "all"],
-    language: "Svenska",
+    language: "sv",
   },
   {
     id: "6",
@@ -105,6 +105,6 @@ export const reports: ContentMeta[] = [
     link: "/reports/2025-06-19_ApplyingCarbonLawFrom2025.pdf",
     image: "/images/reportImages/2025_Carbon_Law.png",
     displayLanguages: ["en", "all"],
-    language: "English",
+    language: "en",
   },
 ];

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -217,7 +217,10 @@
     "title": "Reports",
     "description": "In-depth analyses and reports on Sweden's climate transition.",
     "readMore": "Read more",
-    "openReport": "Open Report"
+    "openReport": "Open Report",
+    "reportCategories": {
+      "report": "Report"
+    }
   },
   "blogDetailPage": {
     "loading": "Loading...",
@@ -1327,5 +1330,10 @@
     "description": "Read previous newsletters",
     "loading": "Loading...",
     "error": "Error loading data"
+  },
+  "insightCategories": {
+    "analysis": "Analysis",
+    "guide": "Guide",
+    "methodology": "Methodology"
   }
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1335,5 +1335,9 @@
     "analysis": "Analysis",
     "guide": "Guide",
     "methodology": "Methodology"
+  },
+  "language": {
+    "sv": "Swedish",
+    "en": "English"
   }
 }

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -1334,5 +1334,9 @@
     "analysis": "Analys",
     "guide": "Guide",
     "methodology": "Metodik"
+  },
+  "language": {
+    "sv": "Svenska",
+    "en": "Engelska"
   }
 }

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -217,7 +217,10 @@
     "title": "Rapporter",
     "description": "Fördjupande analyser och rapporter om klimatomställningen i Sverige.",
     "readMore": "Läs mer",
-    "openReport": "Öppna rapport"
+    "openReport": "Öppna rapport",
+    "reportCategories": {
+      "report": "Rapport"
+    }
   },
   "blogDetailPage": {
     "loading": "Laddar...",
@@ -1326,5 +1329,10 @@
     "description": "Läs tidigare nyhetsbrev",
     "loading": "Laddar...",
     "error": "Fel vid inläsning av data"
+  },
+  "insightCategories": {
+    "analysis": "Analys",
+    "guide": "Guide",
+    "methodology": "Metodik"
   }
 }

--- a/src/pages/BlogDetailPage.tsx
+++ b/src/pages/BlogDetailPage.tsx
@@ -133,7 +133,7 @@ export function BlogDetailPage() {
       <div className={`space-y-${isMobile ? "4" : "8"}`}>
         <div className="flex flex-wrap items-center gap-4">
           <span className="px-3 py-1 bg-blue-5/50 rounded-full text-blue-2 text-sm">
-            {blogPost.metadata.category}
+            {t("insightCategories." + blogPost.metadata.category)}
           </span>
           <div className="flex items-center gap-2 text-grey text-sm">
             <CalendarDays className="w-4 h-4" />

--- a/src/pages/BlogDetailPage.tsx
+++ b/src/pages/BlogDetailPage.tsx
@@ -13,6 +13,8 @@ import { blogMetadata } from "../lib/blog/blogPostsList";
 import { useTranslation } from "react-i18next";
 import { useScreenSize } from "@/hooks/useScreenSize";
 import { ContentMeta } from "@/types/content";
+import { localizeUnit } from "@/utils/formatting/localization";
+import { useLanguage } from "@/components/LanguageProvider";
 
 // Import Markdown files
 const markdownFiles = import.meta.glob("/src/lib/blog/posts/*.md", {
@@ -31,6 +33,7 @@ export function BlogDetailPage() {
   const [copied, setCopied] = useState(false);
   const location = useLocation();
   const { isMobile } = useScreenSize();
+  const { currentLanguage } = useLanguage();
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -138,7 +141,7 @@ export function BlogDetailPage() {
           <div className="flex items-center gap-2 text-grey text-sm">
             <CalendarDays className="w-4 h-4" />
             <span>
-              {new Date(blogPost.metadata.date).toLocaleDateString("sv-SE")}
+              {localizeUnit(new Date(blogPost.metadata.date), currentLanguage)}
             </span>
           </div>
           <div className="flex items-center gap-2 text-grey text-sm">

--- a/src/pages/InsightsPage.tsx
+++ b/src/pages/InsightsPage.tsx
@@ -45,7 +45,7 @@ export function InsightsPage() {
     title: post.title,
     excerpt: post.excerpt,
     image: post.image || "/images/default-blog-image.jpg",
-    category: post.category,
+    category: t("insightCategories." + post.category),
     date: post.date,
     readTime: post.readTime,
     language: post.language,
@@ -71,7 +71,7 @@ export function InsightsPage() {
                 aria-label="Category"
                 className="px-3 py-1 bg-blue-5/50 rounded-full text-blue-2 text-sm"
               >
-                {featuredPost.category}
+                {t("insightCategories." + featuredPost.category)}
               </span>
               <div className="flex items-center gap-2 text-grey text-sm">
                 <CalendarDays className="w-4 h-4" />

--- a/src/pages/InsightsPage.tsx
+++ b/src/pages/InsightsPage.tsx
@@ -85,7 +85,7 @@ export function InsightsPage() {
               </div>
               <div className="flex items-center gap-2 text-grey text-sm">
                 <Globe2 className="w-4 h-4" />
-                <span aria-label="Language">{featuredPost.language}</span>
+                <span aria-label="Language">{t("language." + featuredPost.language)}</span>
               </div>
             </div>
             <Text

--- a/src/pages/InsightsPage.tsx
+++ b/src/pages/InsightsPage.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from "react-i18next";
 import { useLanguage } from "@/components/LanguageProvider";
 import { ContentGridPage } from "@/components/layout/ContentGridPage";
 import { ContentCard } from "@/components/layout/ContentCard";
+import { localizeUnit } from "@/utils/formatting/localization";
 
 export function InsightsPage() {
   const { t } = useTranslation();
@@ -76,7 +77,7 @@ export function InsightsPage() {
               <div className="flex items-center gap-2 text-grey text-sm">
                 <CalendarDays className="w-4 h-4" />
                 <span aria-label="Date Published">
-                  {new Date(featuredPost.date).toLocaleDateString("sv-SE")}
+                  {localizeUnit(new Date(featuredPost.date), currentLanguage)}
                 </span>
               </div>
               <div className="flex items-center gap-2 text-grey text-sm">

--- a/src/pages/ReportsPage.tsx
+++ b/src/pages/ReportsPage.tsx
@@ -50,7 +50,7 @@ export function ReportsPage() {
     title: report.title,
     excerpt: report.excerpt,
     image: report.image || "",
-    category: report.category,
+    category: t("reportsPage.reportCategories." + report.category),
     date: report.date,
     readTime: report.readTime,
     link: report.link || "",

--- a/src/types/content.ts
+++ b/src/types/content.ts
@@ -8,7 +8,7 @@ export type ContentMeta = {
   category: string;
   image?: string;
   displayLanguages: string[]; // for filtering/visibility (e.g. ["all", "sv", "en"])
-  language: string; // for display of language article is written in (e.g. "English", "Svenska")
+  language: "en" | "sv"; // for display of language article is written in (e.g. "English", "Svenska")
   link?: string;
   author?: {
     name: string;


### PR DESCRIPTION
### ✨ What’s Changed?

The category and language labels in report and article pages (both the list and the individual articles) have been translated to the selected language of the website. Dates used on those pages are also localized.

### 📸 Screenshots

<!-- Add before/after images or UI previews -->
Before:
<img width="1251" height="567" alt="bild" src="https://github.com/user-attachments/assets/9951e80c-61a5-485d-be7a-6bcbb2322fb5" />

After:
<img width="1212" height="555" alt="bild" src="https://github.com/user-attachments/assets/56c9c107-3926-4745-adfd-a47ae6c1dde8" />


### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [ ] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue