### PR TITLE
[960] prevent labels from overflowing report card

### DIFF
--- a/src/components/layout/ContentCard.tsx
+++ b/src/components/layout/ContentCard.tsx
@@ -38,7 +38,7 @@ export function ContentCard({ item, basePath }: ContentCardProps) {
       </div>
       <div className="p-8 space-y-4">
         {(item.category || item.date || item.readTime || item.language) && (
-          <div className="flex items-center gap-4">
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
             {item.category && (
               <span
                 aria-label="Category"
@@ -48,7 +48,7 @@ export function ContentCard({ item, basePath }: ContentCardProps) {
               </span>
             )}
             {item.date && (
-              <div className="flex items-center gap-2 text-grey text-sm">
+              <div className="flex items-center gap-2 text-grey text-sm min-w-0 max-w-full">
                 <CalendarDays className="w-4 h-4" />
                 <span aria-label="Date Published">
                   {localizeUnit(new Date(item.date), currentLanguage)}
@@ -56,15 +56,17 @@ export function ContentCard({ item, basePath }: ContentCardProps) {
               </div>
             )}
             {item.readTime && (
-              <div className="flex items-center gap-2 text-grey text-sm">
+              <div className="flex items-center gap-2 text-grey text-sm min-w-0 max-w-full">
                 <Clock className="w-4 h-4" />
                 <span aria-label="Read Time">{item.readTime}</span>
               </div>
             )}
             {item.language && (
-              <div className="flex items-center gap-2 text-grey text-sm">
+              <div className="flex items-center gap-2 text-grey text-sm min-w-0 max-w-full">
                 <Globe2 className="w-4 h-4" />
-                <span aria-label="Language">{t("language." + item.language)}</span>
+                <span aria-label="Language" className="break-words max-w-full">
+                  {t("language." + item.language)}
+                </span>
               </div>
             )}
           </div>


### PR DESCRIPTION
### ✨ What’s Changed?

Changes to prevent report card labels to overflow parent div on small screens

### 📸 Screenshots (if applicable)

Before
<img width="622" height="880" alt="Screenshot 2025-08-22 at 11 35 50" src="https://github.com/user-attachments/assets/dc47e4ba-b732-4547-ac77-79a409311f4e" />


After
<img width="622" height="880" alt="Screenshot 2025-08-22 at 13 39 27" src="https://github.com/user-attachments/assets/09b3726e-76fa-40ac-843b-02437576c6f0" />


### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #960 