### PR TITLE
[fix] Change name of 2024 report to match 2025 report

### DIFF
--- a/public/reports/2024-06-Bolagsklimatkollen/index.html
+++ b/public/reports/2024-06-Bolagsklimatkollen/index.html
@@ -2,15 +2,15 @@
 <html lang="sv">
   <head>
     <meta charset="UTF-8" />
-    <title>Bolagsklimatkollen 2023</title>
+    <title>Bolagsklimatkollen 2024</title>
     <meta name="description" content="En analys av 150 svenska storbolags klimatredovisning 2023" />
-    <meta property="og:title" content="Bolagsklimatkollen 2023" />
+    <meta property="og:title" content="Bolagsklimatkollen 2024" />
     <meta property="og:description" content="En analys av 150 svenska storbolags klimatredovisning 2023" />
     <meta property="og:image" content="https://klimatkollen.se/images/reportImages/2023_bolagsklimatkollen2.png" />
     <meta property="og:type" content="article" />
     <meta property="og:url" content="https://klimatkollen.se/reports/2024-06-Bolagsklimatkollen" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Bolagsklimatkollen 2023" />
+    <meta name="twitter:title" content="Bolagsklimatkollen 2024" />
     <meta name="twitter:description" content="En analys av 150 svenska storbolags klimatredovisning 2023" />
     <meta name="twitter:image" content="https://klimatkollen.se/images/reportImages/2023_bolagsklimatkollen2.png" />
     <link rel="canonical" href="https://klimatkollen.se/reports/2024-06-Bolagsklimatkollen" />
@@ -79,10 +79,10 @@
   </head>
   <body>
     <div class="container">
-      <div class="title">Bolagsklimatkollen 2023</div>
+      <div class="title">Bolagsklimatkollen 2024</div>
       <div class="card">
-        <img src="/images/reportImages/2023_bolagsklimatkollen2.png" alt="Bolagsklimatkollen 2023" class="cover" />
-        <div class="subtitle">Bolagsklimatkollen 2023</div>
+        <img src="/images/reportImages/2023_bolagsklimatkollen2.png" alt="Bolagsklimatkollen 2024" class="cover" />
+        <div class="subtitle">Bolagsklimatkollen 2024</div>
         <div class="desc">En analys av 150 svenska storbolags klimatredovisning 2023</div>
         <a href="/reports/2024-06-Bolagsklimatkollen.pdf" class="button">Öppna rapporten (PDF)</a>
       </div>

--- a/src/lib/constants/reports.ts
+++ b/src/lib/constants/reports.ts
@@ -20,8 +20,8 @@ export const reports: ContentMeta[] = [
   },
   {
     id: "2",
-    title: "Bolagsklimatkollen 2023",
-    slug: "bolags-klimatkollen-2023",
+    title: "Bolagsklimatkollen 2024",
+    slug: "bolags-klimatkollen-2024",
     date: "2024-06-01",
     excerpt: "En analys av 150 svenska storbolags klimatredovisning 2023",
     readTime: "15 min",


### PR DESCRIPTION
While the report analyse data from 2023, the report itself is the Klimatkollen 2024 report.

### ✨ What’s Changed?

Update last years report to be named "Bolagsklimatkollen 2024" to be inline with the 2025 report as suggested on Discord.

### 📸 Screenshots (if applicable)
<img width="598" height="396" alt="image" src="https://github.com/user-attachments/assets/818cb329-03e6-4477-97ce-12831dd3919c" />


### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #[issue-number] <!-- or: Related to #[issue-number] -->