### PR TITLE
[965] Change to subscribe button translations, added button to newsletterpage

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -114,6 +114,10 @@ export function Header() {
           path: `${currentLanguage}/methodology?view=general`,
         },
         {
+          label: t("header.newsletterArchive"),
+          path: `${currentLanguage}/newsletter-archive`,
+        },
+        {
           label: t("header.press"),
           path: "https://www.mynewsdesk.com/se/klimatbyraan/latest_news",
         },
@@ -126,10 +130,6 @@ export function Header() {
       sublinks: [
         { label: t("header.reports"), path: `${currentLanguage}/reports` },
         { label: t("header.articles"), path: `${currentLanguage}/articles` },
-        {
-          label: t("header.newsletterArchive"),
-          path: `${currentLanguage}/newsletter-archive`,
-        },
         { label: t("header.learnMore"), path: `${currentLanguage}/learn-more` },
       ],
     },

--- a/src/components/newsletters/NewsletterNavigation.tsx
+++ b/src/components/newsletters/NewsletterNavigation.tsx
@@ -11,6 +11,7 @@ import {
   PaginationPrevious,
 } from "../ui/pagination";
 import { Page } from "@/utils/itemPagination";
+import { useTranslation } from "react-i18next";
 
 interface NewsletterNavigationProps {
   newsletterList: Array<NewsletterType>;
@@ -24,6 +25,7 @@ export function NewsletterNavigation({
   setDisplayedNewsletter,
 }: NewsletterNavigationProps) {
   const { isMobile } = useScreenSize();
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const [currentPage, setCurrentPage] = useState<number>(1);
   const [paginatedContent, setPaginatedContent] = useState<Record<
@@ -82,10 +84,14 @@ export function NewsletterNavigation({
             {paginatedContent["page" + currentPage].hasPreviousPage && (
               <PaginationPrevious
                 onClick={() => setCurrentPage(currentPage - 1)}
-              />
+              >
+                {t("newsletterArchivePage.previous")}
+              </PaginationPrevious>
             )}
             {paginatedContent["page" + currentPage].hasNextPage && (
-              <PaginationNext onClick={() => setCurrentPage(currentPage + 1)} />
+              <PaginationNext onClick={() => setCurrentPage(currentPage + 1)}>
+                {t("newsletterArchivePage.next")}
+              </PaginationNext>
             )}
           </div>
         </Pagination>

--- a/src/components/newsletters/NewsletterNavigation.tsx
+++ b/src/components/newsletters/NewsletterNavigation.tsx
@@ -61,7 +61,7 @@ export function NewsletterNavigation({
                       key={index}
                       className={`
                       ${displayedNewsLetter?.long_archive_url === item.long_archive_url ? "bg-black-1" : null}
-                      ${isMobile ? "max-h-[100px]" : "max-h-[125px]"}
+                      ${isMobile ? "min-h-[90px] max-h-[100px]" : "max-h-[125px]"}
                        flex flex-col h-full gap-[5px] w-full p-3 my-1 text-left items-start text-sm font-medium text-grey hover:bg-black-1 transition-colors cursor-pointer duration-200 rounded-lg`}
                       onClick={() => {
                         setDisplayedNewsletter?.(item);

--- a/src/components/newsletters/NewsletterNavigation.tsx
+++ b/src/components/newsletters/NewsletterNavigation.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from "react";
-import { useScreenSize } from "@/hooks/useScreenSize";
 import { NewsletterType } from "@/lib/newsletterArchive/newsletterData";
 import { useNavigate } from "react-router-dom";
 import itemPagination from "@/utils/itemPagination";
@@ -24,7 +23,6 @@ export function NewsletterNavigation({
   displayedNewsLetter,
   setDisplayedNewsletter,
 }: NewsletterNavigationProps) {
-  const { isMobile } = useScreenSize();
   const { t } = useTranslation();
   const navigate = useNavigate();
   const [currentPage, setCurrentPage] = useState<number>(1);
@@ -48,10 +46,14 @@ export function NewsletterNavigation({
     <>
       {paginatedContent && (
         <Pagination
-          className={`${isMobile ? "h-[575px] p-2" : "h-[585px] p-2"} flex flex-col bg-black-2 rounded-md lg:max-w-[280px] justify-between`}
+          className={
+            "h-[525px] p-2 flex flex-col md:h-[585px] bg-black-2 rounded-md lg:max-w-[280px] justify-between"
+          }
         >
           <PaginationContent
-            className={`${isMobile ? "min-h-[300px]" : "h-3/4"} flex flex-col divide-y divide-black-1 items-baseline text-left`}
+            className={
+              "min-h-[300px] md: h-3/4 flex flex-col divide-y divide-black-1 items-baseline text-left"
+            }
           >
             {paginatedContent &&
               paginatedContent["page" + currentPage].items.map(
@@ -61,8 +63,8 @@ export function NewsletterNavigation({
                       key={index}
                       className={`
                       ${displayedNewsLetter?.long_archive_url === item.long_archive_url ? "bg-black-1" : null}
-                      ${isMobile ? "min-h-[90px] max-h-[100px]" : "max-h-[125px]"}
-                       flex flex-col h-full gap-[5px] w-full p-3 my-1 text-left items-start text-sm font-medium text-grey hover:bg-black-1 transition-colors cursor-pointer duration-200 rounded-lg`}
+                      "min-h-[90px] max-h-[100px]
+                       md:max-h-[125px] flex flex-col h-full gap-[5px] w-full p-3 my-1 text-left items-start text-sm font-medium text-grey hover:bg-black-1 transition-colors cursor-pointer duration-200 rounded-lg`}
                       onClick={() => {
                         setDisplayedNewsletter?.(item);
                         navigate(`?view=${item.id}`);
@@ -80,7 +82,7 @@ export function NewsletterNavigation({
                 },
               )}
           </PaginationContent>
-          <div className="flex justify-center mt-4">
+          <div className="flex justify-center mt-0 md:mt-8">
             {paginatedContent["page" + currentPage].hasPreviousPage && (
               <PaginationPrevious
                 onClick={() => setCurrentPage(currentPage - 1)}

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -33,7 +33,8 @@ const buttonVariants = (props: {
     baseClasses,
     variantClasses[props.variant as keyof typeof variantClasses] ||
       "bg-black-2 text-white hover:opacity-80 active:ring-1 active:ring-white disabled:opacity-50",
-    sizeClasses[(props.size || "default") as keyof typeof sizeClasses] || "h-10 px-6 py-2",
+    sizeClasses[(props.size || "default") as keyof typeof sizeClasses] ||
+      "h-10 px-6 py-2",
     props.className,
   );
 };
@@ -52,11 +53,7 @@ const PaginationContent = React.forwardRef<
   HTMLUListElement,
   React.ComponentProps<"ul">
 >(({ className, ...props }, ref) => (
-  <ul
-    ref={ref}
-    className={cn("flex flex-row", className)}
-    {...props}
-  />
+  <ul ref={ref} className={cn("flex flex-row", className)} {...props} />
 ));
 PaginationContent.displayName = "PaginationContent";
 
@@ -95,6 +92,7 @@ PaginationLink.displayName = "PaginationLink";
 
 const PaginationPrevious = ({
   className,
+  children,
   ...props
 }: React.ComponentProps<typeof PaginationLink>) => (
   <PaginationLink
@@ -104,13 +102,14 @@ const PaginationPrevious = ({
     {...props}
   >
     <ChevronLeftIcon className="h-4 w-4" />
-    <span>Previous</span>
+    <span>{children}</span>
   </PaginationLink>
 );
 PaginationPrevious.displayName = "PaginationPrevious";
 
 const PaginationNext = ({
   className,
+  children,
   ...props
 }: React.ComponentProps<typeof PaginationLink>) => (
   <PaginationLink
@@ -119,7 +118,7 @@ const PaginationNext = ({
     className={cn("gap-1 pr-2.5 cursor-pointer", className)}
     {...props}
   >
-    <span>Next</span>
+    <span>{children}</span>
     <ChevronRightIcon className="h-4 w-4" />
   </PaginationLink>
 );

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -14,7 +14,7 @@
     "insights": "Insights",
     "methodology": "Sources and Method",
     "support": "Support Us",
-    "newsletter": "Newsletter",
+    "newsletter": "Join Newsletter",
     "openMenu": "Open Menu",
     "closeMenu": "Close Menu",
     "articles": "Articles",
@@ -1330,7 +1330,9 @@
     "title": "Newsletter archive",
     "description": "Read previous newsletters",
     "loading": "Loading...",
-    "error": "Error loading data"
+    "error": "Error loading data",
+    "next": "Next",
+    "previous": "Previous"
   },
   "insightCategories": {
     "analysis": "Analysis",

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -14,7 +14,7 @@
     "insights": "Insikter",
     "methodology": "Källor och metod",
     "support": "Stöd oss",
-    "newsletter": "Nyhetsbrev",
+    "newsletter": "Prenumerera på nyhetsbrev",
     "openMenu": "Öppna meny",
     "closeMenu": "Stäng meny",
     "articles": "Artiklar",
@@ -1329,7 +1329,9 @@
     "title": "Nyhetsbrevsarkiv",
     "description": "Läs tidigare nyhetsbrev",
     "loading": "Laddar...",
-    "error": "Fel vid inläsning av data"
+    "error": "Fel vid inläsning av data",
+    "next": "Nästa",
+    "previous": "Föregående"
   },
   "insightCategories": {
     "analysis": "Analys",

--- a/src/pages/NewslettersPage.tsx
+++ b/src/pages/NewslettersPage.tsx
@@ -7,6 +7,7 @@ import { NewsletterType } from "@/lib/newsletterArchive/newsletterData";
 import { useNewsletters } from "@/hooks/useNewsletters";
 import { PageSEO } from "@/components/SEO/PageSEO";
 import { Text } from "@/components/ui/text";
+import { NewsletterPopover } from "@/components/NewsletterPopover";
 
 export function NewsLetterArchivePage() {
   const { t } = useTranslation();
@@ -55,6 +56,9 @@ export function NewsLetterArchivePage() {
             setDisplayedNewsletter={setDisplayedNewsletter}
             displayedNewsLetter={displayedNewsletter}
           />
+          {isMobile && (
+            <NewsletterPopover buttonText={t("header.newsletter")} />
+          )}
 
           {displayedNewsletter && (
             <iframe

--- a/src/pages/NewslettersPage.tsx
+++ b/src/pages/NewslettersPage.tsx
@@ -51,14 +51,14 @@ export function NewsLetterArchivePage() {
         <div
           className={`${isMobile ? "flex flex-col" : "flex"} mt-6 relative md:flex-col lg:flex-row gap-8`}
         >
+          {isMobile && (
+            <NewsletterPopover buttonText={t("header.newsletter")} />
+          )}
           <NewsletterNavigation
             newsletterList={data}
             setDisplayedNewsletter={setDisplayedNewsletter}
             displayedNewsLetter={displayedNewsletter}
           />
-          {isMobile && (
-            <NewsletterPopover buttonText={t("header.newsletter")} />
-          )}
 
           {displayedNewsletter && (
             <iframe


### PR DESCRIPTION

### ✨ What’s Changed?

Per change request from Ola, the following changes has been made in this pr:
- Newsletter Archive link moved from Insights nav to About us nav
- Changed translation text for the header subscribe button to "Join Newsletter" in English, and "Prenumerera på nyhetsbrev" in Swedish. Do differentiate from the newsletter archive site. 
- Added the header's "Subscribe to newsletter" button to the newsletter archive page below the navigation, but only visible on mobile.
- Switched newsletter navigation buttons to say "Previous & Next" in English, and "Föregående & Nästa" in Swedish.

### 📸 Screenshots (if applicable)

New button:
<img width="370" height="799" alt="image" src="https://github.com/user-attachments/assets/e695f360-6ec5-4b73-8cfe-00175e8623e0" />

New translations Newsletter nav:
<img width="313" height="490" alt="image" src="https://github.com/user-attachments/assets/2fd4de63-87f4-4a7d-88d8-6285294d37ef" />

New translations header subscribe button:
<img width="954" height="167" alt="image" src="https://github.com/user-attachments/assets/3dac4e5a-1607-4a25-ac5c-3e710e81e9a2" />

<img width="994" height="173" alt="image" src="https://github.com/user-attachments/assets/8419854f-284a-410e-8bd2-f0c69ee93ded" />

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [x] I've set the labels, issue, and milestone for the PR
- [ ] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #965 