### PR TITLE
[fix] Use proper locale string for formatters

### DIFF
--- a/src/utils/formatting/localization.ts
+++ b/src/utils/formatting/localization.ts
@@ -1,5 +1,12 @@
 import { SupportedLanguage } from "@/lib/languageDetection";
 
+const LANG_LOCALE: Record<SupportedLanguage, "sv-SE" | "en-GB"> = {
+  sv: "sv-SE",
+  en: "en-GB",
+};
+
+const lookupLocale = (lang: SupportedLanguage) => LANG_LOCALE[lang] ?? "sv-SE";
+
 export function localizeUnit(
   unit: number | Date,
   currentLanguage: SupportedLanguage,
@@ -9,7 +16,7 @@ export function localizeUnit(
   }
 
   if (unit instanceof Date) {
-    return new Intl.DateTimeFormat(currentLanguage, {
+    return new Intl.DateTimeFormat(lookupLocale(currentLanguage), {
       dateStyle: "short",
     }).format(unit);
   }
@@ -25,7 +32,9 @@ const localizeNumber = (
   currentLanguage: SupportedLanguage,
   options: Intl.NumberFormatOptions = defaultNumberFormatOptions,
 ) => {
-  return new Intl.NumberFormat(currentLanguage, options).format(nr);
+  return new Intl.NumberFormat(lookupLocale(currentLanguage), options).format(
+    nr,
+  );
 };
 
 export function formatEmployeeCount(
@@ -57,7 +66,7 @@ export function formatPercentChange(
   currentLanguage: SupportedLanguage,
   isAlreadyPercentage: boolean = false,
 ) {
-  return new Intl.NumberFormat(currentLanguage, {
+  return new Intl.NumberFormat(lookupLocale(currentLanguage), {
     style: "percent",
     minimumFractionDigits: 0,
     maximumFractionDigits: 1,
@@ -70,7 +79,7 @@ export function formatPercent(
   currentLanguage: SupportedLanguage,
   isAlreadyPercentage: boolean = false,
 ) {
-  return new Intl.NumberFormat(currentLanguage, {
+  return new Intl.NumberFormat(lookupLocale(currentLanguage), {
     style: "percent",
     minimumFractionDigits: 0,
     maximumFractionDigits: 1,


### PR DESCRIPTION
This fixes a problem where we get american locale instead of brittish when passing to Intl formatters.

Long term it would be better to specify the full locale everywhere and avoid only "sv" and "en" as it also clarifies that we mean "en-GB".

### 📸 Screenshots (if applicable)

<!-- Add before/after images or UI previews -->
Before: <img width="993" height="306" alt="image" src="https://github.com/user-attachments/assets/d9bfb31e-2230-4fd2-869d-16cd7ced05dc" />

After:
<img width="1076" height="295" alt="image" src="https://github.com/user-attachments/assets/96fba78e-bc29-4fa0-b232-9ae30977ca46" />

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #[issue-number] <!-- or: Related to #[issue-number] -->