### PR TITLE
[fix] hide trend explanation from company emissions graph for now

### DIFF
--- a/src/components/companies/detail/history/EmissionsHistory.tsx
+++ b/src/components/companies/detail/history/EmissionsHistory.tsx
@@ -181,7 +181,8 @@ export function EmissionsHistory({
           />
 
           {/* Method Description - Hidden on mobile (mobile has popup version) */}
-          {methodExplanation && !isMobile && (
+          {/* FIXME: Uncomment when the Trend Analysis is ready */}
+          {/* {methodExplanation && !isMobile && (
             <div className="bg-black-2 rounded-lg p-4 max-w-4xl mx-auto">
               <Text
                 variant="body"
@@ -193,7 +194,7 @@ export function EmissionsHistory({
                 {methodExplanation}
               </Text>
             </div>
-          )}
+          )} */}
         </SectionWithHelp>
       )}
       {exploreMode && (


### PR DESCRIPTION
### ✨ What’s Changed?

Hide trend explanation from company emissions graph for now as it seems lite different trend calcs arent being used (and are a bit too premature to be released)

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)