### PR TITLE
[fix] make comapny scope and sector line graphs appear again

### DIFF
--- a/src/components/companies/detail/history/EmissionsLineChart.tsx
+++ b/src/components/companies/detail/history/EmissionsLineChart.tsx
@@ -234,7 +234,7 @@ export default function EmissionsLineChart({
                       trendAnalysis?.cleanData &&
                       trendAnalysis.cleanData.length >= 2
                         ? (() => {
-                            const cleanData = trendAnalysis.cleanData;
+                            const { cleanData } = trendAnalysis;
                             const avgEmissions =
                               cleanData.reduce(
                                 (sum, point) => sum + point.value,
@@ -271,7 +271,7 @@ export default function EmissionsLineChart({
                     dot={
                       isMobile
                         ? false
-                        : { r: 4, fill: "white", cursor: "pointer" }
+                        : { r: 0, fill: "white", cursor: "pointer" }
                     }
                     activeDot={
                       isMobile
@@ -324,6 +324,69 @@ export default function EmissionsLineChart({
 
               {dataView === "scopes" && (
                 <>
+                  {!hiddenScopes.includes("scope1") && (
+                    <Line
+                      type="monotone"
+                      dataKey="scope1.value"
+                      stroke="var(--pink-3)"
+                      strokeWidth={2}
+                      dot={{
+                        r: 0,
+                        cursor: "pointer",
+                        onClick: () => handleScopeToggle("scope1"),
+                      }}
+                      activeDot={{
+                        r: 6,
+                        fill: "var(--pink-3)",
+                        cursor: "pointer",
+                      }}
+                      name="Scope 1"
+                    />
+                  )}
+                  {!hiddenScopes.includes("scope2") && (
+                    <Line
+                      type="monotone"
+                      dataKey="scope2.value"
+                      stroke="var(--green-2)"
+                      strokeWidth={2}
+                      dot={{
+                        r: 0,
+                        cursor: "pointer",
+                        onClick: () => handleScopeToggle("scope2"),
+                      }}
+                      activeDot={{
+                        r: 6,
+                        fill: "var(--green-2)",
+                        cursor: "pointer",
+                      }}
+                      name="Scope 2"
+                    />
+                  )}
+                  {!hiddenScopes.includes("scope3") && (
+                    <Line
+                      type="monotone"
+                      dataKey="scope3.value"
+                      stroke="var(--blue-2)"
+                      strokeWidth={2}
+                      dot={{
+                        r: 0,
+                        cursor: "pointer",
+                        onClick: () => handleScopeToggle("scope3"),
+                      }}
+                      activeDot={{
+                        r: 6,
+                        fill: "var(--blue-2)",
+                        cursor: "pointer",
+                        onClick: () => handleScopeToggle("scope3"),
+                      }}
+                      name="Scope 3"
+                    />
+                  )}
+                </>
+              )}
+
+              {/* {dataView === "scopes" && (
+                <>
                   <ScopeLine
                     scope="scope1"
                     isHidden={hiddenScopes.includes("scope1")}
@@ -340,9 +403,57 @@ export default function EmissionsLineChart({
                     onToggle={handleScopeToggle}
                   />
                 </>
-              )}
+              )} */}
 
               {dataView === "categories" &&
+                Object.keys(data[0])
+                  .filter(
+                    (key) =>
+                      key.startsWith("cat") && !key.includes("Interpolated"),
+                  )
+                  .sort((a, b) => {
+                    const aCatId = parseInt(a.replace("cat", ""));
+                    const bCatId = parseInt(b.replace("cat", ""));
+                    return aCatId - bCatId;
+                  })
+                  .map((categoryKey) => {
+                    const categoryId = parseInt(categoryKey.replace("cat", ""));
+                    const isInterpolatedKey = `${categoryKey}Interpolated`;
+
+                    // Check if the category is hidden
+                    if (hiddenCategories.includes(categoryId)) {
+                      return null;
+                    }
+                    // Calculate strokeDasharray based on the first data point
+                    const strokeDasharray = data[0][isInterpolatedKey]
+                      ? "4 4"
+                      : "0";
+
+                    return (
+                      <Line
+                        key={categoryKey}
+                        type="monotone"
+                        dataKey={categoryKey}
+                        stroke={getCategoryColor(categoryId)}
+                        strokeWidth={2}
+                        strokeDasharray={strokeDasharray}
+                        dot={{
+                          r: 0,
+                          cursor: "pointer",
+                          onClick: () => handleCategoryToggle(categoryId),
+                        }}
+                        activeDot={{
+                          r: 6,
+                          fill: getCategoryColor(categoryId),
+                          cursor: "pointer",
+                          onClick: () => handleCategoryToggle(categoryId),
+                        }}
+                        name={getCategoryName(categoryId)}
+                      />
+                    );
+                  })}
+
+              {/* {dataView === "categories" &&
                 Object.keys(data[0])
                   .filter(
                     (key) =>
@@ -378,7 +489,7 @@ export default function EmissionsLineChart({
                         onToggle={handleCategoryToggle}
                       />
                     );
-                  })}
+                  })} */}
             </LineChart>
           </ResponsiveContainer>
         ) : (


### PR DESCRIPTION
### ✨ What’s Changed?

* Make company emissions scope and sector line graphs appear again
* Align active dots of different data views

### 📸 Screenshots (if applicable)

Before
<img width="908" height="615" alt="Screenshot 2025-08-29 at 13 17 02" src="https://github.com/user-attachments/assets/6e38f001-b44f-4d56-8a0c-d6b41bcbca30" />

After
<img width="908" height="615" alt="Screenshot 2025-08-29 at 13 17 22" src="https://github.com/user-attachments/assets/2c371342-3a6f-49dd-b19e-3788dd711b39" />

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)