### PR TITLE
[1020] Adjusted left margin to counter legend clipping

### DIFF
--- a/src/components/municipalities/emissionsGraph/OverviewChart.tsx
+++ b/src/components/municipalities/emissionsGraph/OverviewChart.tsx
@@ -26,7 +26,7 @@ export const OverviewChart: FC<OverviewChartProps> = ({ projectedData }) => {
 
   return (
     <ResponsiveContainer width="100%" height="90%">
-      <LineChart data={projectedData} margin={{ left: -50 }}>
+      <LineChart data={projectedData} margin={{ left: -30 }}>
         <Legend
           verticalAlign="bottom"
           align="right"

--- a/src/components/municipalities/emissionsGraph/SectorsChart.tsx
+++ b/src/components/municipalities/emissionsGraph/SectorsChart.tsx
@@ -101,12 +101,16 @@ export const SectorsChart: FC<SectorsChartProps> = ({
 
   return (
     <ResponsiveContainer width="100%" height="90%">
-      <ComposedChart data={chartData} margin={{ left: -50 }}>
+      <ComposedChart data={chartData} margin={{ left: -30 }}>
         <Legend
           verticalAlign="bottom"
           align="right"
           iconType="line"
-          wrapperStyle={{ fontSize: "12px", color: "var(--grey)", paddingLeft: "50px" }}
+          wrapperStyle={{
+            fontSize: "12px",
+            color: "var(--grey)",
+            paddingLeft: "50px",
+          }}
           formatter={(value) => {
             const sectorInfo = getSectorInfo?.(value) || {
               translatedName: value,


### PR DESCRIPTION
### ✨ What’s Changed?

Adjusted left margin of Y-axis to counter the clipping of Y-axis values. 

### 📸 Screenshots (if applicable)

Before:
<img width="1385" height="815" alt="image" src="https://github.com/user-attachments/assets/fda5c05a-afff-4850-ba01-1418f69bbff9" />


After:
<img width="1133" height="892" alt="image" src="https://github.com/user-attachments/assets/ec226926-c92b-454a-98ac-2a0ea9b5e1ec" />



### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [x] I've set the labels, issue, and milestone for the PR
- [ ] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #1020 