### PR TITLE
[fix] Add LocalizedLink to replace Link

### DIFF
--- a/src/components/LocalizedLink.tsx
+++ b/src/components/LocalizedLink.tsx
@@ -1,0 +1,14 @@
+import { LinkProps, Link as RouterLink } from "react-router-dom";
+import { useLanguage } from "./LanguageProvider";
+
+export const LocalizedLink = ({
+  lang,
+  to,
+  ...props
+}: { lang?: string } & LinkProps) => {
+  const { currentLanguage } = useLanguage();
+
+  const localisedTo = `/${lang ?? currentLanguage}${to}`;
+
+  return <RouterLink to={localisedTo} {...props} />;
+};

--- a/src/components/RankedList.tsx
+++ b/src/components/RankedList.tsx
@@ -1,6 +1,7 @@
 import { LucideProps } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Text } from "@/components/ui/text";
+import { LocalizedLink } from "./LocalizedLink";
 
 export interface RankedListItem {
   name: string;
@@ -53,9 +54,9 @@ export function RankedList({
       <div className="grid gap-y-6 grid-cols-[auto_1fr_auto]">
         <Text className="col-span-full text-md text-grey">{description}</Text>
         {items.map((item, index) => (
-          <a
+          <LocalizedLink
             key={item.link}
-            href={item.link}
+            to={item.link}
             className="grid grid-cols-subgrid col-span-full items-center gap-4 hover:bg-black-1 transition-colors rounded-lg"
           >
             <span className={cn("text-2xl sm:text-5xl font-light", rankColor)}>
@@ -65,7 +66,7 @@ export function RankedList({
             <div className="flex items-center md:justify-end">
               {itemValueRenderer(item)}
             </div>
-          </a>
+          </LocalizedLink>
         ))}
       </div>
     </div>

--- a/src/components/companies/list/CompanyCard.tsx
+++ b/src/components/companies/list/CompanyCard.tsx
@@ -17,6 +17,7 @@ import { cn } from "@/lib/utils";
 import { AiIcon } from "@/components/ui/ai-icon";
 import { useVerificationStatus } from "@/hooks/useVerificationStatus";
 import { InfoTooltip } from "@/components/layout/InfoTooltip";
+import { LocalizedLink } from "@/components/LocalizedLink";
 
 type CompanyCardProps = Pick<
   RankedCompany,
@@ -96,7 +97,7 @@ export function CompanyCard({
 
   return (
     <div className="relative rounded-level-2 @container">
-      <Link
+      <LocalizedLink
         to={`/companies/${wikidataId}`}
         className="block bg-black-2 rounded-level-2 p-8 space-y-8 transition-all duration-300 hover:shadow-[0_0_10px_rgba(153,207,255,0.15)] hover:bg-[#1a1a1a]"
       >
@@ -260,7 +261,7 @@ export function CompanyCard({
             noSustainabilityReport ? "text-pink-3" : "text-green-3"
           }
         />
-      </Link>
+      </LocalizedLink>
     </div>
   );
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,5 +1,5 @@
 import { BarChart3, ChevronDown, Menu, X, Mail } from "lucide-react";
-import { Link, useLocation, matchPath } from "react-router-dom";
+import { useLocation, matchPath } from "react-router-dom";
 import { cn } from "@/lib/utils";
 import { useState, useCallback, useEffect } from "react";
 import { useTranslation } from "react-i18next";
@@ -17,6 +17,7 @@ import { HeaderSearchButton } from "../search/HeaderSearchButton";
 import { useScreenSize } from "@/hooks/useScreenSize";
 import useHeaderTitle from "@/hooks/useHeaderTitle";
 import { useAuth } from "@/contexts/AuthContext";
+import { LocalizedLink } from "../LocalizedLink";
 
 export function Header() {
   const { t } = useTranslation();
@@ -26,8 +27,8 @@ export function Header() {
   const [isSignUpOpen, setIsSignUpOpen] = useState(false);
   const toggleMenu = useCallback(() => setMenuOpen((prev) => !prev), []);
   const { isMobile } = useScreenSize();
-  const { headerTitle, showTitle, setShowTitle } = useHeaderTitle();
   const { user } = useAuth();
+  const { headerTitle, showTitle, setShowTitle } = useHeaderTitle();
 
   useEffect(() => {
     const searchParams = new URLSearchParams(location.search);
@@ -83,54 +84,54 @@ export function Header() {
     {
       label: t("header.companies"),
       icon: <BarChart3 className="w-4 h-4" aria-hidden="true" />,
-      path: `${currentLanguage}/companies`,
+      path: `/companies`,
     },
     {
       label: t("header.municipalities"),
       icon: <BarChart3 className="w-4 h-4" aria-hidden="true" />,
-      path: `${currentLanguage}/municipalities`,
+      path: `/municipalities`,
       sublinks: [
         {
           label: t("header.municipalitiesRanked"),
-          path: `${currentLanguage}/municipalities/`,
+          path: `/municipalities`,
         },
         {
           label: t("header.municipalitiesExplore"),
-          path: `${currentLanguage}/municipalities/explore`,
+          path: `/municipalities/explore`,
         },
       ],
     },
     {
       label: t("header.products"),
-      path: `${currentLanguage}/products`,
+      path: `/products`,
     },
     {
       label: t("header.about"),
-      path: `${currentLanguage}/about`,
+      path: `/about`,
       sublinks: [
-        { label: t("header.aboutUs"), path: `${currentLanguage}/about` },
+        { label: t("header.aboutUs"), path: `/about` },
         {
           label: t("header.methodology"),
-          path: `${currentLanguage}/methodology?view=general`,
+          path: `/methodology?view=general`,
         },
         {
           label: t("header.newsletterArchive"),
-          path: `${currentLanguage}/newsletter-archive`,
+          path: `/newsletter-archive`,
         },
         {
           label: t("header.press"),
           path: "https://www.mynewsdesk.com/se/klimatbyraan/latest_news",
         },
-        { label: t("header.support"), path: `${currentLanguage}/support` },
+        { label: t("header.support"), path: `/support` },
       ],
     },
     {
-      path: `${currentLanguage}/articles`,
+      path: `/articles`,
       label: t("header.insights"),
       sublinks: [
-        { label: t("header.reports"), path: `${currentLanguage}/reports` },
-        { label: t("header.articles"), path: `${currentLanguage}/articles` },
-        { label: t("header.learnMore"), path: `${currentLanguage}/learn-more` },
+        { label: t("header.reports"), path: `/reports` },
+        { label: t("header.articles"), path: `/articles` },
+        { label: t("header.learnMore"), path: `/learn-more` },
       ],
     },
   ];
@@ -153,12 +154,12 @@ export function Header() {
     <>
       <header className="fixed w-screen overflow-x-hidden overflow-y-hidden top-0 left-0 right-0 z-50 bg-black-2 h-10 lg:h-12">
         <div className="container relative mx-auto px-4 flex items-center justify-between pt-2 lg:pt-0">
-          <Link
+          <LocalizedLink
             to="/"
             className="flex items-center gap-2 text-base font-medium"
           >
             Klimatkollen
-          </Link>
+          </LocalizedLink>
           {showTitle && (
             <span className="absolute left-1/2 transform -translate-x-1/2">
               {isMobile && headerTitle}
@@ -208,7 +209,7 @@ export function Header() {
                               {sublink.label}
                             </a>
                           ) : (
-                            <Link
+                            <LocalizedLink
                               to={sublink.path}
                               className="flex justify-between w-full"
                             >
@@ -218,14 +219,14 @@ export function Header() {
                                   {sublink.shortcut}
                                 </MenubarShortcut>
                               )}
-                            </Link>
+                            </LocalizedLink>
                           )}
                         </MenubarItem>
                       ))}
                     </MenubarContent>
                   </MenubarMenu>
                 ) : (
-                  <Link
+                  <LocalizedLink
                     key={item.path}
                     to={item.path}
                     className={cn(
@@ -237,7 +238,7 @@ export function Header() {
                   >
                     {item.icon}
                     <span>{item.label}</span>
-                  </Link>
+                  </LocalizedLink>
                 ),
               )}
               {user && (
@@ -249,12 +250,12 @@ export function Header() {
                   <MenubarContent>
                     {INTERNAL_LINKS.map((link) => (
                       <MenubarItem key={link.path}>
-                        <Link
+                        <LocalizedLink
                           to={link.path}
                           className="flex justify-between w-full"
                         >
                           {link.label}
-                        </Link>
+                        </LocalizedLink>
                       </MenubarItem>
                     ))}
                   </MenubarContent>

--- a/src/components/municipalities/list/MunicipalityCard.tsx
+++ b/src/components/municipalities/list/MunicipalityCard.tsx
@@ -1,4 +1,3 @@
-import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import type { Municipality } from "@/types/municipality";
@@ -9,6 +8,7 @@ import {
 } from "@/utils/formatting/localization";
 import { useLanguage } from "@/components/LanguageProvider";
 import { LinkCard } from "@/components/ui/link-card";
+import { LocalizedLink } from "@/components/LocalizedLink";
 
 interface MunicipalityCardProps {
   municipality: Municipality;
@@ -34,7 +34,7 @@ export function MunicipalityCard({ municipality }: MunicipalityCardProps) {
   const noClimatePlan = !municipality.climatePlanLink;
 
   return (
-    <Link
+    <LocalizedLink
       to={`/municipalities/${municipality.name}`}
       className="block bg-black-2 rounded-level-2 p-8 space-y-8 transition-all duration-300 hover:shadow-[0_0_10px_rgba(153,207,255,0.15)] hover:bg-[#1a1a1a]"
     >
@@ -91,6 +91,6 @@ export function MunicipalityCard({ municipality }: MunicipalityCardProps) {
         }
         descriptionColor={noClimatePlan ? "text-pink-3" : "text-green-3"}
       />
-    </Link>
+    </LocalizedLink>
   );
 }

--- a/src/components/municipalities/rankedList/MunicipalityInsightsList.tsx
+++ b/src/components/municipalities/rankedList/MunicipalityInsightsList.tsx
@@ -1,5 +1,5 @@
+import { LocalizedLink } from "@/components/LocalizedLink";
 import { Municipality } from "@/types/municipality";
-import { Link } from "react-router-dom";
 
 interface InsightsListProps {
   title: string;
@@ -29,7 +29,7 @@ function InsightsList({
         const position = isBottomRanking ? totalCount - index : index + 1;
 
         return (
-          <Link
+          <LocalizedLink
             key={municipality.name}
             to={`/municipalities/${municipality.name}`}
             className="block transition-colors hover:bg-white/5 rounded-lg"
@@ -40,10 +40,12 @@ function InsightsList({
                 <span>{municipality.name}</span>
               </div>
               <span className={`${textColor} font-semibold`}>
-                {municipality[dataPointKey] != null ? (municipality[dataPointKey] as number).toFixed(1) + unit : nullValues }
+                {municipality[dataPointKey] != null
+                  ? (municipality[dataPointKey] as number).toFixed(1) + unit
+                  : nullValues}
               </span>
             </div>
-          </Link>
+          </LocalizedLink>
         );
       })}
     </div>


### PR DESCRIPTION
### ✨ What’s Changed?

Using LocalizedLink takes into account which language the user is using. This way we can centralize the logic to add the path prefix instead of spreading out it in different places.

There are a couple of places where we use buttons or click handlers to navigate that we should replace with links which also fixes accessibility issues of using custom navigation.

This was noticed due to problems with #918 where the current implementation does not support the non-languaged URLs.

### 📸 Screenshots (if applicable)

<!-- Add before/after images or UI previews -->

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #[issue-number] <!-- or: Related to #[issue-number] -->