### PR TITLE
[fix] replace top margin with gap in municipality kpi details panel

### DIFF
--- a/src/components/municipalities/rankedList/KPIDetailsPanel.tsx
+++ b/src/components/municipalities/rankedList/KPIDetailsPanel.tsx
@@ -43,7 +43,7 @@ export default function KPIDetailsPanel({
 
   const distributionStatItems = distributionStats.map(
     ({ count, colorClass, translationKey }) => (
-      <p key={translationKey} className="mt-2">
+      <p key={translationKey} className="gap-2">
         <span className={`font-medium ${colorClass}`}>{count} </span>
         {t(
           translationKey,


### PR DESCRIPTION
### ✨ What’s Changed?

Replace top margin with gap in municipality KPI details panel for better alignment.

### 📸 Screenshots (if applicable)

Before
<img width="774" height="423" alt="Screenshot 2025-09-16 at 08 02 42" src="https://github.com/user-attachments/assets/01ec06ce-c9a2-4140-875d-1cd515c50ce6" />


After
<img width="774" height="423" alt="Screenshot 2025-09-16 at 08 02 33" src="https://github.com/user-attachments/assets/53fe6766-9c40-4a5b-b383-ccd16dfed711" />


### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)