### PR TITLE
[Fix] Update Municipality KPI Order

### DIFF
--- a/src/hooks/municipalities/useMunicipalityKPIs.ts
+++ b/src/hooks/municipalities/useMunicipalityKPIs.ts
@@ -41,6 +41,39 @@ export const useMunicipalityKPIs = (): KPIValue[] => {
       higherIsBetter: false,
     },
     {
+      label: t("municipalities.list.kpis.totalConsumptionEmission.label"),
+      key: "totalConsumptionEmission",
+      unit: "t",
+      source: "municipalities.list.totalConsumptionEmission.source",
+      sourceUrls: ["https://konsumtionskompassen.se/"],
+      description: t(
+        "municipalities.list.kpis.totalConsumptionEmission.description",
+      ),
+      detailedDescription: t(
+        "municipalities.list.kpis.totalConsumptionEmission.detailedDescription",
+      ),
+      higherIsBetter: false,
+    },
+    {
+      label: t("municipalities.list.kpis.climatePlan.label"),
+      key: "climatePlan",
+      unit: "",
+      source: "municipalities.list.climatePlan.source",
+      sourceUrls: ["https://docs.google.com/spreadsheets/d/13CMqmfdd6QUD6agKFyVhwZUol4PKzvy253_EwtsFyvw/edit#gid=0"],
+      description: t("municipalities.list.kpis.climatePlan.description"),
+      detailedDescription: t(
+        "municipalities.list.kpis.climatePlan.detailedDescription",
+      ),
+      higherIsBetter: true,
+      isBoolean: true,
+      booleanLabels: {
+        true: t("municipalities.list.kpis.climatePlan.booleanLabels.true"),
+        false: t("municipalities.list.kpis.climatePlan.booleanLabels.false"),
+      },
+      belowString: t("municipalities.list.kpis.climatePlan.belowString"),
+      aboveString: t("municipalities.list.kpis.climatePlan.aboveString"),
+    },
+    {
       label: t("municipalities.list.kpis.electricCarChangePercent.label"),
       key: "electricCarChangePercent",
       unit: "%",
@@ -56,20 +89,6 @@ export const useMunicipalityKPIs = (): KPIValue[] => {
         "municipalities.list.kpis.electricCarChangePercent.nullValues",
       ),
       higherIsBetter: true,
-    },
-    {
-      label: t("municipalities.list.kpis.totalConsumptionEmission.label"),
-      key: "totalConsumptionEmission",
-      unit: "t",
-      source: "municipalities.list.totalConsumptionEmission.source",
-      sourceUrls: ["https://konsumtionskompassen.se/"],
-      description: t(
-        "municipalities.list.kpis.totalConsumptionEmission.description",
-      ),
-      detailedDescription: t(
-        "municipalities.list.kpis.totalConsumptionEmission.detailedDescription",
-      ),
-      higherIsBetter: false,
     },
     {
       label: t("municipalities.list.kpis.electricVehiclePerChargePoints.label"),
@@ -104,26 +123,7 @@ export const useMunicipalityKPIs = (): KPIValue[] => {
         "municipalities.list.kpis.bicycleMetrePerCapita.detailedDescription",
       ),
       higherIsBetter: true,
-    },
-    {
-      label: t("municipalities.list.kpis.climatePlan.label"),
-      key: "climatePlan",
-      unit: "",
-      source: "municipalities.list.climatePlan.source",
-      sourceUrls: ["https://docs.google.com/spreadsheets/d/13CMqmfdd6QUD6agKFyVhwZUol4PKzvy253_EwtsFyvw/edit#gid=0"],
-      description: t("municipalities.list.kpis.climatePlan.description"),
-      detailedDescription: t(
-        "municipalities.list.kpis.climatePlan.detailedDescription",
-      ),
-      higherIsBetter: true,
-      isBoolean: true,
-      booleanLabels: {
-        true: t("municipalities.list.kpis.climatePlan.booleanLabels.true"),
-        false: t("municipalities.list.kpis.climatePlan.booleanLabels.false"),
-      },
-      belowString: t("municipalities.list.kpis.climatePlan.belowString"),
-      aboveString: t("municipalities.list.kpis.climatePlan.aboveString"),
-    },
+    }
   ];
 
   return KPIs;


### PR DESCRIPTION
### ✨ What’s Changed?

Before releasing the new insta reels, we wanted to re-order the KPIs on the RankedList page so that they are grouped by emissions kpis then by transit kpis. 

### 📸 Screenshots (if applicable)
Before:
<img width="407" height="516" alt="Screenshot 2025-10-06 at 10 32 00" src="https://github.com/user-attachments/assets/76c6c9f6-8ad8-4ffa-a1f8-d8edd11d87d3" />

After:
<img width="480" height="552" alt="Screenshot 2025-10-06 at 10 31 22" src="https://github.com/user-attachments/assets/7c549e84-a527-4965-88ce-d56b4d49d29e" />

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [x] I've set the labels, issue, and milestone for the PR
- [ ] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #[issue-number] <!-- or: Related to #[issue-number] -->