### PR TITLE
[fix] Improve padding in section cards

### DIFF
--- a/src/components/relatableNumbers.tsx
+++ b/src/components/relatableNumbers.tsx
@@ -6,6 +6,7 @@ import {
 import { useTranslation } from "react-i18next";
 import { Flame, Lightbulb } from "lucide-react";
 import { SupportedLanguage } from "@/lib/languageDetection";
+import { cn } from "@/lib/utils";
 
 type RelatableNumbersProps = {
   emissionsChange: number;
@@ -83,7 +84,14 @@ const RelatableNumbers = ({
     : null;
 
   return (
-    <div className="bg-black-2 rounded-level-1 px-4 py-8 md:py-16 md:px-8">
+    <div
+      className={cn(
+        "bg-black-2",
+        "rounded-level-3 md:rounded-level-1",
+        "px-4 md:px-8",
+        "py-4 md:py-8",
+      )}
+    >
       <Text variant={"h3"}>{t("relatableNumbers.title")}</Text>
       <Text
         variant="body"

--- a/src/data-guide/SectionWithHelp.tsx
+++ b/src/data-guide/SectionWithHelp.tsx
@@ -15,12 +15,17 @@ export const SectionWithHelp = ({
   const showDataGuide = dataGuideFeatureFlagEnabled() && helpItems.length > 0;
 
   return (
-    <div className="bg-black-2 rounded-level-1 py-8 md:py-16 px-2 md:px-0">
-      <div className={cn("px-2 md:px-8", !showDataGuide && "md:mb-8")}>
-        {children}
-      </div>
+    <div
+      className={cn(
+        " bg-black-2",
+        "rounded-level-3 md:rounded-level-1",
+        "py-2 md:py-8",
+        "px-2 md:px-8",
+      )}
+    >
+      <div className={cn(!showDataGuide && "md:mb-8 pb-8")}>{children}</div>
       {showDataGuide && (
-        <div className="mt-8 pt-2 md:pt-8 px-2 md:px-8 border-t border-black-1">
+        <div className="mt-4 md:mt-8 pt-2 md:pt-8 px-2 md:px-0 border-t border-black-1">
           <ProgressiveDataGuide items={helpItems} style="sectionFooter" />
         </div>
       )}

--- a/src/index.css
+++ b/src/index.css
@@ -177,6 +177,10 @@
   @apply text-lg;
 }
 
+.rounded-level-3 {
+  border-radius: 15px;
+}
+
 input[type="number"] {
   text-align: right; /* Align numbers to the right */
   padding-right: 10px; /* Add some padding as needed */


### PR DESCRIPTION
### ✨ What’s Changed?
As we needed more space horizontally the x padding was reduced but not the y padding which made the cards look unaligned.

This makes the padding match better and also introduce a new level of rounded that we can use on small devices.

### 📸 Screenshots (if applicable)

Before Desktop:
<img width="427" height="1440" alt="image" src="https://github.com/user-attachments/assets/0fde51d8-9866-4615-adb8-9bcfcf493f52" />

After Desktop:
<img width="396" height="1384" alt="image" src="https://github.com/user-attachments/assets/21efbea8-b2ab-46cb-8aae-f9823bb548b4" />

Before Mobile:
<img width="577" height="622" alt="image" src="https://github.com/user-attachments/assets/a5f3c15c-1afa-44d0-ae12-6fa14a55f3f6" />

After Mobile:
<img width="528" height="558" alt="image" src="https://github.com/user-attachments/assets/0670bc8d-9bea-456d-8974-8c27a53891bf" />

<!-- Add before/after images or UI previews -->

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #[issue-number] <!-- or: Related to #[issue-number] -->