### PR TITLE
[fix] Extract loading, error and no data components

### DIFF
--- a/src/components/pageStates/Error.tsx
+++ b/src/components/pageStates/Error.tsx
@@ -1,0 +1,23 @@
+import { Text } from "@/components/ui/text";
+import { useTranslation } from "react-i18next";
+
+type ErrorProps = {
+  titleKey?: string;
+  descriptionKey?: string;
+};
+
+export const PageError = ({
+  titleKey = "components.error.title",
+  descriptionKey = "components.error.description",
+}: ErrorProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="text-center py-24">
+      <Text variant="h3" className="text-red-500 mb-4">
+        {t(titleKey)}
+      </Text>
+      <Text variant="body">{t(descriptionKey)}</Text>
+    </div>
+  );
+};

--- a/src/components/pageStates/Loading.tsx
+++ b/src/components/pageStates/Loading.tsx
@@ -1,0 +1,6 @@
+export const PageLoading = () => (
+  <div className="animate-pulse space-y-16">
+    <div className="h-12 w-1/3 bg-black-1 rounded" />
+    <div className="h-96 bg-black-1 rounded-level-1" />
+  </div>
+);

--- a/src/components/pageStates/NoData.tsx
+++ b/src/components/pageStates/NoData.tsx
@@ -1,0 +1,23 @@
+import { useTranslation } from "react-i18next";
+import { Text } from "../ui/text";
+
+type PageNoDataProps = {
+  titleKey?: string;
+  descriptionKey?: string;
+};
+
+export const PageNoData = ({
+  titleKey = "components.noData.title",
+  descriptionKey = "components.noData.description",
+}: PageNoDataProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="text-center py-24">
+      <Text variant="h3" className="text-red-500 mb-4">
+        {t(titleKey)}
+      </Text>
+      <Text variant="body">{t(descriptionKey)}</Text>
+    </div>
+  );
+};

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -35,7 +35,7 @@
   },
   "components": {
     "error": {
-      "title": "Unable to retrieve company information",
+      "title": "Unable to retrieve information",
       "description": "Please try again later"
     },
     "noData": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -33,6 +33,16 @@
     "internationalLicense": "International Licence",
     "ccBySa": "CC BY-SA - Attribution-ShareAlike 4.0"
   },
+  "components": {
+    "error": {
+      "title": "Unable to retrieve company information",
+      "description": "Please try again later"
+    },
+    "noData": {
+      "title": "No Data Available",
+      "description": "There is currently no data available for this page."
+    }
+  },
   "newsletter": {
     "subscribe": "Subscribe to our newsletter",
     "description": "Stay informed with our newsletter—get the latest updates on emissions delivered straight to your inbox.",
@@ -721,9 +731,6 @@
   "municipalityDetailPage": {
     "metaTitle": "Data on emissions and transition",
     "metaDescription": "Overview of emissions and transition",
-    "loading": "Loading...",
-    "error": "Error loading data",
-    "noData": "No data available",
     "procurementScore": {
       "high": "Yes",
       "medium": "Maybe",

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -33,6 +33,16 @@
     "internationalLicense": "International license",
     "ccBySa": "CC BY-SA - Attribution-ShareAlike 4.0"
   },
+  "components": {
+    "error": {
+      "title": "Det gick inte att hämta informationen",
+      "description": "Försök igen senare"
+    },
+    "noData": {
+      "title": "Ingen data tillgänglig",
+      "description": "Kontrollera att länken är korrekt"
+    }
+  },
   "newsletter": {
     "subscribe": "Prenumerera på vårt nyhetsbrev",
     "emailPlaceholder": "Din e-postadress",
@@ -720,9 +730,6 @@
   "municipalityDetailPage": {
     "metaTitle": "Data om utsläpp och omställning",
     "metaDescription": "Översikt över klimatpåverkan och hållbarhetsarbete",
-    "loading": "Laddar...",
-    "error": "Fel vid inläsning av data",
-    "noData": "Ingen data tillgänglig",
     "procurementScore": {
       "high": "Ja",
       "medium": "Kanske",

--- a/src/pages/CompanyDetailPage.tsx
+++ b/src/pages/CompanyDetailPage.tsx
@@ -12,6 +12,9 @@ import { getCompanyDescription } from "@/utils/business/company";
 import { useLanguage } from "@/components/LanguageProvider";
 import RelatableNumbers from "@/components/relatableNumbers";
 import type { Scope3Category } from "@/types/company";
+import { PageLoading } from "@/components/pageStates/Loading";
+import { PageError } from "@/components/pageStates/Error";
+import { PageNoData } from "@/components/pageStates/NoData";
 
 export function CompanyDetailPage() {
   const { t } = useTranslation();
@@ -30,33 +33,24 @@ export function CompanyDetailPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="animate-pulse space-y-16">
-        <div className="h-12 w-1/3 bg-black-1 rounded" />
-        <div className="h-96 bg-black-1 rounded-level-1" />
-      </div>
-    );
+    return <PageLoading />;
   }
 
   if (error) {
     return (
-      <div className="text-center py-24">
-        <Text variant="h3" className="text-red-500 mb-4">
-          {t("companyDetailPage.errorTitle")}
-        </Text>
-        <Text variant="body">{t("companyDetailPage.errorDescription")}</Text>
-      </div>
+      <PageError
+        titleKey="companyDetailPage.errorTitle"
+        descriptionKey="companyDetailPage.errorDescription"
+      />
     );
   }
 
   if (!company || !company.reportingPeriods.length) {
     return (
-      <div className="text-center py-24">
-        <Text variant="h3" className="text-red-500 mb-4">
-          {t("companyDetailPage.notFoundTitle")}
-        </Text>
-        <Text variant="body">{t("companyDetailPage.notFoundDescription")}</Text>
-      </div>
+      <PageNoData
+        titleKey="companyDetailPage.notFoundTitle"
+        descriptionKey="companyDetailPage.notFoundDescription"
+      />
     );
   }
 

--- a/src/pages/MunicipalityDetailPage.tsx
+++ b/src/pages/MunicipalityDetailPage.tsx
@@ -24,6 +24,9 @@ import { MunicipalityEmissions } from "@/components/municipalities/MunicipalityE
 import { useHiddenItems } from "@/components/charts";
 import { YearSelector } from "@/components/layout/YearSelector";
 import { SectionWithHelp } from "@/data-guide/SectionWithHelp";
+import { PageLoading } from "@/components/pageStates/Loading";
+import { PageError } from "@/components/pageStates/Error";
+import { PageNoData } from "@/components/pageStates/NoData";
 
 export function MunicipalityDetailPage() {
   const { t } = useTranslation();
@@ -39,9 +42,9 @@ export function MunicipalityDetailPage() {
 
   const [selectedYear, setSelectedYear] = useState<string>("2023");
 
-  if (loading) return <Text>{t("municipalityDetailPage.loading")}</Text>;
-  if (error) return <Text>{t("municipalityDetailPage.error")}</Text>;
-  if (!municipality) return <Text>{t("municipalityDetailPage.noData")}</Text>;
+  if (loading) return <PageLoading />;
+  if (error) return <PageError />;
+  if (!municipality) return <PageNoData />;
 
   const requirementsInProcurement =
     municipality.procurementScore == 2


### PR DESCRIPTION
### ✨ What’s Changed?

Extract these components from the company detail page and reuse them in the municipality detail page.

At some point it would be nice to go over these to ensure they look better but they aren't heavily used as we fetch and cache all companies and municipalities on load.

### 📸 Screenshots (if applicable)

<!-- Add before/after images or UI previews -->


### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #[issue-number] <!-- or: Related to #[issue-number] -->