### PR TITLE
[1115] Update card size and change description to industry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11832,9 +11832,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.7.tgz",
-      "integrity": "sha512-VbA8ScMvAISJNJVbRDTJdCwqQoAareR/wutevKanhR2/1EkoXVZVkkORaYm/tNVCjP/UDTKtcw3bAkwOUdedmA==",
+      "version": "7.1.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.11.tgz",
+      "integrity": "sha512-uzcxnSDVjAopEUjljkWh8EIrg6tlzrjFUfMcR1EVsRDGwf/ccef0qQPRyOrROwhrTDaApueq+ja+KLPlzR/zdg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/components/layout/ListCard.tsx
+++ b/src/components/layout/ListCard.tsx
@@ -8,7 +8,7 @@ import { CardInfo } from "@/components/layout/CardInfo";
 interface ListCardProps {
   // Basic info
   name: string;
-  description: string;
+  description: string; // For municipalities: region, For companies: sector
   linkTo: string;
   logoUrl?: string | null;
 
@@ -80,7 +80,7 @@ export function ListCard({
           </div>
 
           {/* Meets Paris section */}
-          <div className="flex items-center gap-2 text-grey mb-2 text-lg">
+          <div className="flex items-center gap-2 text-grey mb-2 text-lg h-[40px]">
             {t(meetsParisTranslationKey, { name })}
           </div>
           <div


### PR DESCRIPTION
### ✨ What’s Changed?

- add height to meets paris section on the list view to ensure card height is the same for companies with long names that force the text onto multiple lines
- changed the company description to industry in prep for having company logo on the upper right corner, and to declutter the card

### 📸 Screenshots (if applicable)
Before:
<img width="1409" height="598" alt="Screenshot 2025-10-21 at 16 52 04" src="https://github.com/user-attachments/assets/7c5f6865-c8af-497f-884f-4293b1775c1e" />

After:
<img width="1329" height="542" alt="Screenshot 2025-10-21 at 16 51 08" src="https://github.com/user-attachments/assets/5155badb-0d82-4f5e-9ebc-661282e9e0f3" />


### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #1115  <!-- or: Related to #[issue-number] -->