### PR TITLE
[1122] Reduced padding and rounding on About us section on landing page to match other sections

### DIFF
--- a/src/components/ContentBlock.tsx
+++ b/src/components/ContentBlock.tsx
@@ -21,7 +21,7 @@ export function ContentBlock({ title, content, className }: ContentBlockProps) {
           <Text className="text-grey text-md md:text-2xl">{title}</Text>
         </div>
 
-        <Text className="max-w-full md:max-w-[90%] text-md md:text-2xl leading-[1.2] md:leading-[1.1] tracking-[-0.02em] break-words">
+        <Text className="max-w-full text-md md:text-2xl leading-[1.2] md:leading-[1.1] tracking-[-0.02em] break-words">
           {content}
         </Text>
       </div>


### PR DESCRIPTION
### ✨ What’s Changed?

Reduced padding, spacing and rounding on About us section on landing page to match the look of the other sections on the page.

### 📸 Screenshots (if applicable)
Before: 
<img width="1205" height="839" alt="image" src="https://github.com/user-attachments/assets/cfef89e3-6697-4152-8265-88ca6bf6692b" />

After:
<img width="1230" height="802" alt="image" src="https://github.com/user-attachments/assets/80374a8d-0818-43c4-a1ab-6737926cfced" />



### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [x] I've set the labels, issue, and milestone for the PR
- [ ] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #1122