### PR TITLE
[FIX] Add company defunct to frontend

### DIFF
--- a/src/components/companies/edit/CompanyEditDetails.tsx
+++ b/src/components/companies/edit/CompanyEditDetails.tsx
@@ -41,6 +41,7 @@ export function CompanyEditDetails({
   const [baseYearVerified, setBaseYearVerified] = useState(
     isVerified(company.baseYear?.metadata),
   );
+  const [isDefunct, setIsDefunct] = useState(company.isDefunct || false);
 
   const [comment, setComment] = useState<string>("");
   const [source, setSource] = useState<string>("");
@@ -110,6 +111,7 @@ export function CompanyEditDetails({
         company,
         subIndustryCode,
         baseYear,
+        isDefunct,
         comment,
         source,
         industryVerified,
@@ -276,6 +278,40 @@ export function CompanyEditDetails({
             setBaseYearVerified(checked === true);
           }}
         />
+      </div>
+      <div className="mb-6 flex items-center">
+        <span className="min-w-[140px] mr-4 font-medium">Company Status</span>
+        <label className="flex items-center cursor-pointer">
+          <input
+            type="checkbox"
+            checked={isDefunct}
+            onChange={(e) => setIsDefunct(e.target.checked)}
+            className="w-6 h-6 text-blue-5 bg-black-1 border-gray-300 rounded focus:ring-blue-5 focus:ring-2"
+          />
+          <span className="ml-2 text-white">
+            Mark as defunct {isDefunct && "(Company is no longer operating)"}
+          </span>
+        </label>
+        <button
+          type="button"
+          onClick={() => setIsDefunct(company.isDefunct || false)}
+          disabled={isDefunct === (company.isDefunct || false)}
+          className={
+            "ml-2 bg-none border-none p-0 " +
+            (isDefunct === (company.isDefunct || false)
+              ? "cursor-not-allowed"
+              : "cursor-pointer")
+          }
+          aria-label="Undo defunct status change"
+        >
+          <Undo2
+            className={
+              isDefunct === (company.isDefunct || false)
+                ? "text-grey"
+                : "text-white hover:text-orange-3"
+            }
+          />
+        </button>
       </div>
       <div className="w-full ps-4 pe-2 mt-10">
         <textarea

--- a/src/hooks/companies/useCompanyEditDetailsSave.ts
+++ b/src/hooks/companies/useCompanyEditDetailsSave.ts
@@ -1,5 +1,9 @@
 import { useMutation } from "@tanstack/react-query";
-import { updateCompanyIndustry, updateCompanyBaseYear } from "@/lib/api";
+import {
+  updateCompanyIndustry,
+  updateCompanyBaseYear,
+  updateCompanyMetadata,
+} from "@/lib/api";
 import { isVerified } from "@/utils/business/verification";
 import type { CompanyDetails } from "@/types/company";
 
@@ -7,6 +11,7 @@ interface SaveCompanyEditDetailsArgs {
   company: CompanyDetails;
   subIndustryCode: string;
   baseYear: string | number;
+  isDefunct: boolean;
   comment: string;
   source: string;
   industryVerified?: boolean;
@@ -18,6 +23,7 @@ async function saveCompanyEditDetails({
   company,
   subIndustryCode,
   baseYear,
+  isDefunct,
   comment,
   source,
   industryVerified,
@@ -32,6 +38,7 @@ async function saveCompanyEditDetails({
   const originalIndustryVerified = isVerified(company.industry?.metadata);
   const originalBaseYear = String(company.baseYear?.year || "");
   const originalBaseYearVerified = isVerified(company.baseYear?.metadata);
+  const originalIsDefunct = company.isDefunct || false;
 
   // Prepare metadata if populated
   const metadata: Record<string, string> = {};
@@ -67,6 +74,16 @@ async function saveCompanyEditDetails({
       hasMetadata ? metadata : undefined,
       baseYearVerified,
     );
+  }
+
+  if (isDefunct !== originalIsDefunct) {
+    didChange = true;
+    await updateCompanyMetadata(company.wikidataId, {
+      wikidataId: company.wikidataId,
+      name: company.name,
+      isDefunct,
+      metadata: hasMetadata ? metadata : undefined,
+    });
   }
 
   if (didChange && onSave) {

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -242,7 +242,7 @@ export interface paths {
                                         }[];
                                     } | null;
                                     scope1And2: {
-                                        total: number;
+                                        total: number | null;
                                         unit: string;
                                         metadata: {
                                             verifiedBy: {
@@ -312,6 +312,7 @@ export interface paths {
                                 };
                             } | null;
                             tags: string[];
+                            isDefunct?: boolean;
                         }[];
                     };
                 };
@@ -365,226 +366,112 @@ export interface paths {
                                 text: string;
                             }[];
                             reportingPeriods: {
-                                id: string;
                                 startDate: string;
                                 endDate: string;
                                 reportURL: string | null;
+                                emissionsChangeLastTwoYears?: {
+                                    absolute: number | null;
+                                    adjusted: number | null;
+                                };
                                 emissions: {
-                                    id: string;
+                                    calculatedTotalEmissions: number;
                                     scope1: {
-                                        id: string;
                                         total: number | null;
                                         unit: string;
                                         metadata: {
-                                            id: string;
-                                            comment: string | null;
-                                            source: string | null;
-                                            updatedAt: string;
-                                            user: {
-                                                name: string;
-                                            };
                                             verifiedBy: {
                                                 name: string;
                                             } | null;
                                         };
                                     } | null;
                                     scope2: {
-                                        id: string;
                                         mb: number | null;
                                         lb: number | null;
                                         unknown: number | null;
                                         unit: string;
+                                        calculatedTotalEmissions: number;
                                         metadata: {
-                                            id: string;
-                                            comment: string | null;
-                                            source: string | null;
-                                            updatedAt: string;
-                                            user: {
-                                                name: string;
-                                            };
                                             verifiedBy: {
                                                 name: string;
                                             } | null;
                                         };
-                                        calculatedTotalEmissions: number;
                                     } | null;
                                     scope3: {
-                                        id: string;
-                                        categories: {
-                                            id: string;
-                                            category: number;
+                                        calculatedTotalEmissions: number;
+                                        metadata: {
+                                            verifiedBy: {
+                                                name: string;
+                                            } | null;
+                                        };
+                                        statedTotalEmissions: {
                                             total: number | null;
                                             unit: string;
                                             metadata: {
-                                                id: string;
-                                                comment: string | null;
-                                                source: string | null;
-                                                updatedAt: string;
-                                                user: {
-                                                    name: string;
-                                                };
-                                                verifiedBy: {
-                                                    name: string;
-                                                } | null;
-                                            };
-                                        }[];
-                                        statedTotalEmissions?: {
-                                            id: string;
-                                            total: number | null;
-                                            unit: string;
-                                            metadata: {
-                                                id: string;
-                                                comment: string | null;
-                                                source: string | null;
-                                                updatedAt: string;
-                                                user: {
-                                                    name: string;
-                                                };
                                                 verifiedBy: {
                                                     name: string;
                                                 } | null;
                                             };
                                         } | null;
-                                        calculatedTotalEmissions: number;
-                                        metadata: {
-                                            id: string;
-                                            comment: string | null;
-                                            source: string | null;
-                                            updatedAt: string;
-                                            user: {
-                                                name: string;
+                                        categories: {
+                                            category: number;
+                                            total: number | null;
+                                            unit: string;
+                                            metadata: {
+                                                verifiedBy: {
+                                                    name: string;
+                                                } | null;
                                             };
-                                            verifiedBy: {
-                                                name: string;
-                                            } | null;
-                                        };
+                                        }[];
                                     } | null;
                                     scope1And2: {
-                                        id: string;
-                                        total: number;
-                                        unit: string;
-                                        metadata: {
-                                            id: string;
-                                            comment: string | null;
-                                            source: string | null;
-                                            updatedAt: string;
-                                            user: {
-                                                name: string;
-                                            };
-                                            verifiedBy: {
-                                                name: string;
-                                            } | null;
-                                        };
-                                    } | null;
-                                    biogenicEmissions: {
-                                        id: string;
                                         total: number | null;
                                         unit: string;
                                         metadata: {
-                                            id: string;
-                                            comment: string | null;
-                                            source: string | null;
-                                            updatedAt: string;
-                                            user: {
-                                                name: string;
-                                            };
                                             verifiedBy: {
                                                 name: string;
                                             } | null;
                                         };
                                     } | null;
                                     statedTotalEmissions: {
-                                        id: string;
                                         total: number | null;
                                         unit: string;
                                         metadata: {
-                                            id: string;
-                                            comment: string | null;
-                                            source: string | null;
-                                            updatedAt: string;
-                                            user: {
-                                                name: string;
-                                            };
                                             verifiedBy: {
                                                 name: string;
                                             } | null;
                                         };
                                     } | null;
-                                    calculatedTotalEmissions: number;
                                 } | null;
                                 economy: {
-                                    id: string;
-                                    turnover: {
-                                        id: string;
-                                        value: number | null;
-                                        currency: string | null;
-                                        metadata: {
-                                            id: string;
-                                            comment: string | null;
-                                            source: string | null;
-                                            updatedAt: string;
-                                            user: {
-                                                name: string;
-                                            };
-                                            verifiedBy: {
-                                                name: string;
-                                            } | null;
-                                        };
-                                    } | null;
                                     employees: {
-                                        id: string;
                                         value: number | null;
                                         unit: string | null;
                                         metadata: {
-                                            id: string;
-                                            comment: string | null;
-                                            source: string | null;
-                                            updatedAt: string;
-                                            user: {
+                                            verifiedBy: {
                                                 name: string;
-                                            };
+                                            } | null;
+                                        };
+                                    } | null;
+                                    turnover: {
+                                        value: number | null;
+                                        currency: string | null;
+                                        metadata: {
                                             verifiedBy: {
                                                 name: string;
                                             } | null;
                                         };
                                     } | null;
                                 } | null;
-                                emissionsChangeLastTwoYears?: {
-                                    absolute: number | null;
-                                    adjusted: number | null;
-                                };
                             }[];
                             futureEmissionsTrendSlope: number | null;
                             industry: {
-                                id: string;
                                 industryGics: {
                                     sectorCode: string;
                                     groupCode: string;
                                     industryCode: string;
                                     subIndustryCode: string;
-                                    sv: {
-                                        sectorName: string;
-                                        groupName: string;
-                                        industryName: string;
-                                        subIndustryName: string;
-                                        subIndustryDescription: string;
-                                    };
-                                    en: {
-                                        sectorName: string;
-                                        groupName: string;
-                                        industryName: string;
-                                        subIndustryName: string;
-                                        subIndustryDescription: string;
-                                    };
                                 };
                                 metadata: {
-                                    id: string;
-                                    comment: string | null;
-                                    source: string | null;
-                                    updatedAt: string;
-                                    user: {
-                                        name: string;
-                                    };
                                     verifiedBy: {
                                         name: string;
                                     } | null;
@@ -606,6 +493,8 @@ export interface paths {
                                     } | null;
                                 };
                             } | null;
+                            tags: string[];
+                            isDefunct?: boolean;
                             goals: {
                                 id: string;
                                 description: string;
@@ -705,6 +594,7 @@ export interface paths {
                         internalComment?: string;
                         tags?: string[];
                         lei?: string;
+                        isDefunct?: boolean;
                         metadata?: {
                             source?: string;
                             comment?: string;
@@ -934,7 +824,7 @@ export interface paths {
                                         }[];
                                     } | null;
                                     scope1And2: {
-                                        total: number;
+                                        total: number | null;
                                         unit: string;
                                         metadata: {
                                             verifiedBy: {
@@ -1004,6 +894,7 @@ export interface paths {
                                 };
                             } | null;
                             tags: string[];
+                            isDefunct?: boolean;
                         }[];
                     };
                 };
@@ -1078,6 +969,7 @@ export interface paths {
                         "application/json": {
                             name: string;
                             region: string;
+                            logoUrl: string | null;
                             totalTrend: number;
                             totalCarbonLaw: number;
                             historicalEmissionChangePercent: number;
@@ -1148,6 +1040,7 @@ export interface paths {
                         "application/json": {
                             name: string;
                             region: string;
+                            logoUrl: string | null;
                             totalTrend: number;
                             totalCarbonLaw: number;
                             historicalEmissionChangePercent: number;
@@ -1731,7 +1624,7 @@ export interface paths {
                                      */
                                     unit?: "tCO2e" | "tCO2";
                                     verified?: boolean;
-                                };
+                                } | null;
                                 statedTotalEmissions?: {
                                     total?: number | null;
                                     /**

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -127,7 +127,7 @@ export async function downloadMunicipalities(
     params: {
       query: {
         type: format,
-      }
+      },
     },
     parseAs: "blob",
   });
@@ -253,6 +253,24 @@ export async function updateCompanyBaseYear(
       body: { baseYear, metadata, verified },
     },
   );
+  if (error) throw error;
+  return data;
+}
+
+export async function updateCompanyMetadata(
+  wikidataId: string,
+  companyData: {
+    wikidataId: string;
+    name: string;
+    isDefunct?: boolean;
+    metadata?: { source?: string; comment?: string };
+    verified?: boolean;
+  },
+) {
+  const { data, error } = await client.POST("/companies/{wikidataId}", {
+    params: { path: { wikidataId } },
+    body: companyData,
+  });
   if (error) throw error;
   return data;
 }


### PR DESCRIPTION
### ✨ What’s Changed?
Added API function api.ts: 
Created updateCompanyMetadata() function that calls the POST /companies/{wikidataId} endpoint.
This function accepts isDefunct as a boolean parameter along with metadata

Updated Hook useCompanyEditDetailsSave.ts:
Added isDefunct parameter to the SaveCompanyEditDetailsArgs interface
Modified the save logic to detect changes to isDefunct and call the new API function
Only updates when the value actually changes from the original

Updated UI Component CompanyEditDetails.tsx:
Added a new "Company Status" section with a checkbox to mark companies as defunct
Includes an undo button to revert changes
Shows explanatory text when the checkbox is checked

**Related to changes in backend PR: https://github.com/Klimatbyran/garbo/pull/996**

### 📸 Screenshots (if applicable)

<img width="801" height="525" alt="image" src="https://github.com/user-attachments/assets/c6bc40e6-9277-4a84-9a75-3f217ec17188" />

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [ ] I've set the labels, issue, and milestone for the PR
- [ ] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #[issue-number] <!-- or: Related to #[issue-number] -->