### PR TITLE
[Fix][bug] issues with edit payload

### DIFF
--- a/src/lib/company/company-edit.ts
+++ b/src/lib/company/company-edit.ts
@@ -41,7 +41,9 @@ export function mapCompanyEditFormToRequestBody(
     const scope1NewVerified = scope1VerifiedChanged
       ? formData.get(scope1CheckboxKey) === "true"
       : undefined;
-    const isVerified = originalScope1?.metadata.verifiedBy?.name ? true : false;
+    const isVerified = originalScope1?.metadata?.verifiedBy?.name
+      ? true
+      : false;
 
     if (scope1ValueChanged) {
       const val = formData.get(scope1ValueKey);
@@ -175,6 +177,7 @@ export function mapCompanyEditFormToRequestBody(
     const statedTotalNewVerified = statedTotalVerifiedChanged
       ? formData.get(statedTotalCheckboxKey) === "true"
       : undefined;
+
     if (statedTotalValueChanged) {
       if (periodUpdate.emissions.scope3 === undefined) {
         periodUpdate.emissions.scope3 = {};
@@ -344,12 +347,17 @@ export function mapCompanyEditFormToRequestBody(
 
     if (hasEmissionsChanges || hasEconomyChanges || hasPeriodChanges) {
       // Create the final update object
+      // startDate and endDate are required by the API, so always include them
       const finalUpdate: any = {
         id: period.id,
         startDate: periodUpdate.startDate,
         endDate: periodUpdate.endDate,
-        reportURL: periodUpdate.reportURL,
       };
+
+      // reportURL is optional, only include if it changed
+      if (periodUpdate.reportURL !== period.reportURL) {
+        finalUpdate.reportURL = periodUpdate.reportURL;
+      }
 
       if (hasEmissionsChanges) {
         finalUpdate.emissions = periodUpdate.emissions;
@@ -362,6 +370,7 @@ export function mapCompanyEditFormToRequestBody(
       periodsUpdate.push(finalUpdate);
     }
   }
+
   const metadata: {
     comment?: string;
     source?: string;


### PR DESCRIPTION
### ✨ What’s Changed?

**Preserve verification state when editing company data fields**
When editing company data fields (scope 2, scope 3 categories, stated totals, 
turnover, employees), the verification state is now correctly preserved from 
the original metadata when only the value changes. Previously, verification 
would default to false when values were updated without explicitly toggling 
the verification checkbox. This ensures that verified data remains marked as verified unless explicitly 
changed by the user.

**Scope 3 verification checkbox clearing field values**
When clicking the verify badge on Scope 3 category fields, the value
was being cleared instead of only updating the verification status.
The issue was in the request body mapping logic - when only the
checkbox changed (not the value), the code was sending an object with
only category and verified fields, omitting the total field.
This caused the API to interpret it as clearing the value.

Now includes the original total value when only verification status
changes, ensuring the field value is preserved.

### 📸 Screenshots (if applicable)

<!-- Add before/after images or UI previews -->


### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [ ] I've verified the change runs locally both on mobile and desktop
- [x] I've set the labels, issue, and milestone for the PR
- [ ] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #[issue-number] <!-- or: Related to #[issue-number] -->