### PR TITLE
[fix] add space in relatable numbers description

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1499,7 +1499,7 @@
   },
   "relatableNumbers": {
     "title": "How much is that?",
-    "description": "{{companyName}} {{emissionsChangeStatus}} their emissions by <highlightNumber>{{emissionsInTonnes}}({{yearOverYearChange}})</highlightNumber> tCO2e from the previous year. This compares to:",
+    "description": "{{companyName}} {{emissionsChangeStatus}} their emissions by <highlightNumber>{{emissionsInTonnes}} ({{yearOverYearChange}})</highlightNumber> tCO2e from the previous year. This compares to:",
     "prefixFire": "Emissions from a forest fire",
     "prefixEmissions": "The annual emissions of {{count}} Swedes.",
     "increased": "increased",

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -1498,7 +1498,7 @@
   },
   "relatableNumbers": {
     "title": "Hur mycket är det?",
-    "description": "{{companyName}} {{emissionsChangeStatus}} sina utsläpp med <highlightNumber>{{emissionsInTonnes}}({{yearOverYearChange}})</highlightNumber> tCO2e jämfört med föregående år. Detta kan jämföras med:",
+    "description": "{{companyName}} {{emissionsChangeStatus}} sina utsläpp med <highlightNumber>{{emissionsInTonnes}} ({{yearOverYearChange}})</highlightNumber> tCO2e jämfört med föregående år. Detta kan jämföras med:",
     "prefixFire": "Utsläppen motsvarar en skogsbrand",
     "prefixEmissions": "{{count}} svenska invånares årsutsläpp.",
     "increased": "ökade",


### PR DESCRIPTION
### ✨ What’s Changed?

Add a space in relatable numbers description

### 📸 Screenshots (if applicable)

Before
<img width="983" height="255" alt="Screenshot 2025-10-29 at 18 37 48" src="https://github.com/user-attachments/assets/e2c01b68-c430-4557-8a53-e6fb0fa4a81c" />


After
<img width="983" height="255" alt="Screenshot 2025-10-29 at 18 37 55" src="https://github.com/user-attachments/assets/1efec472-e131-4b26-b6bc-d846a5e6cbd6" />


### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)