### PR TITLE
[Fix] Set minimum fraction digits to 1

### DIFF
--- a/src/utils/formatting/localization.ts
+++ b/src/utils/formatting/localization.ts
@@ -68,7 +68,7 @@ export function formatPercentChange(
 ) {
   return new Intl.NumberFormat(lookupLocale(currentLanguage), {
     style: "percent",
-    minimumFractionDigits: 0,
+    minimumFractionDigits: 1,
     maximumFractionDigits: 1,
     signDisplay: "exceptZero",
   }).format(isAlreadyPercentage ? value : value / 100);


### PR DESCRIPTION
### ✨ What’s Changed?

Sets minimumFractionDigits on formatPercentChange to 1. Will fix percentage showing with one significant digit to little for values ending in 0. Example: 7.0% displays as 7%.

I found this because of issue #1139. But it fixes a general problem.

### 📸 Screenshots (if applicable)

Before:
<img width="672" height="498" alt="image" src="https://github.com/user-attachments/assets/bd6afa17-7caa-4290-a3b7-93558b49882f" />
<img width="595" height="54" alt="image" src="https://github.com/user-attachments/assets/11650f4d-6faf-420a-a9fa-29ab8cb93bc7" />

After:
<img width="678" height="496" alt="image" src="https://github.com/user-attachments/assets/dd373962-b102-4bac-84f1-04ed06dce254" />
<img width="585" height="47" alt="image" src="https://github.com/user-attachments/assets/ef9a4c8e-a7b0-492b-8d99-77ec28cec96c" />


### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #1139