### PR TITLE
[Fix] Update largest emittor text on landing page

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -76,7 +76,7 @@
     "bestPerformers": "Top Lists",
     "bestMunicipalities": "Sweden's best municipalities",
     "municipalitiesDescription": "By average annual reduction in emissions since the Paris Agreement (2015)",
-    "largestEmittor": "Company with the largest emissions",
+    "largestEmittor": "Companies with the largest emissions",
     "companiesDescription": "Emissions from the most recently reported year",
     "aboutUsTitle": "Who are we?",
     "aboutUsContent": "Klimatkollen is a citizen platform that provides climate data and builds support for reducing emissions in line with the Paris Agreement. We believe in the power of simple, engaging data visualisation to enhance knowledge and drive participation in the climate conversation.",


### PR DESCRIPTION
### ✨ What’s Changed?

Changes landing page text from "Company with the largest emissions" to "Companies with the largest emissions".

### 📸 Screenshots (if applicable)

Before:
<img width="610" height="143" alt="image" src="https://github.com/user-attachments/assets/834a93ce-3fdd-4cfa-ae7f-1024bc9227d7" />

After:
<img width="610" height="143" alt="image" src="https://github.com/user-attachments/assets/0fa5cc43-6e22-4be8-a2b3-6d65917a5f2e" />


### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [ ] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #1138