### PR TITLE
[Fix] Reset typewriter on language change

### DIFF
--- a/src/components/ui/typewriter.tsx
+++ b/src/components/ui/typewriter.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { motion, Variants } from "framer-motion";
 import { cn } from "@/lib/utils";
+import i18next from "i18next";
 
 interface TypewriterProps {
   text: string | string[];
@@ -54,6 +55,12 @@ const Typewriter = ({
   const [hasCompletedCycle, setHasCompletedCycle] = useState(false);
 
   const texts = useMemo(() => (Array.isArray(text) ? text : [text]), [text]);
+
+  // Reset display text when language is changed
+  i18next.on('languageChanged', () => {
+    setDisplayText('');
+    setIsDeleting(true);
+  })
 
   useEffect(() => {
     let timeout: NodeJS.Timeout;


### PR DESCRIPTION
### ✨ What’s Changed?

When the language is changed. Reset the typewriter, so it displays the text with the correct language.

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #1136