### PR TITLE
[625] Add constraint to sweden map to keep map in view

### DIFF
--- a/src/components/maps/SwedenMap.tsx
+++ b/src/components/maps/SwedenMap.tsx
@@ -16,6 +16,7 @@ import {
   GeoJsonProperties,
 } from "geojson";
 import { MUNICIPALITY_MAP_COLORS } from "./constants";
+import { calculateGeoBounds } from "./utils/geoBounds";
 import { isMobile } from "react-device-detect";
 import { t } from "i18next";
 import "leaflet/dist/leaflet.css";
@@ -109,6 +110,16 @@ function MapOfSweden({
   });
 
   const mapRef = useRef<L.Map | null>(null);
+
+  // Zoom limits to prevent excessive zooming
+  const MIN_ZOOM = 3;
+  const MAX_ZOOM = 10;
+
+  // Calculate bounds from geoData to constrain map panning
+  const mapBounds = useMemo(
+    () => calculateGeoBounds(geoData, { padding: 0.05 }),
+    [geoData],
+  );
 
   useEffect(() => {
     const handleResize = () => {
@@ -273,15 +284,18 @@ function MapOfSweden({
     );
   };
 
-  const renderZoomControls = () => (
-    <MapZoomControls
-      onZoomIn={handleZoomIn}
-      onZoomOut={handleZoomOut}
-      onReset={handleReset}
-      canZoomIn={true}
-      canZoomOut={true}
-    />
-  );
+  const renderZoomControls = () => {
+    const currentZoom = position.zoom;
+    return (
+      <MapZoomControls
+        onZoomIn={handleZoomIn}
+        onZoomOut={handleZoomOut}
+        onReset={handleReset}
+        canZoomIn={currentZoom < MAX_ZOOM}
+        canZoomOut={currentZoom > MIN_ZOOM}
+      />
+    );
+  };
 
   const onEachFeature = (
     feature: Feature<Geometry, GeoJsonProperties> | undefined,
@@ -352,6 +366,9 @@ function MapOfSweden({
         }}
         zoomControl={false}
         attributionControl={false}
+        maxBounds={mapBounds}
+        minZoom={MIN_ZOOM}
+        maxZoom={MAX_ZOOM}
         ref={mapRef}
         className="rounded-xl"
       >

--- a/src/components/maps/utils/geoBounds.ts
+++ b/src/components/maps/utils/geoBounds.ts
@@ -1,0 +1,116 @@
+import { FeatureCollection, Geometry } from "geojson";
+import L from "leaflet";
+
+/**
+ * Default bounds for Sweden (used as fallback)
+ */
+const DEFAULT_SWEDEN_BOUNDS: [[number, number], [number, number]] = [
+  [55.3, 11.0], // Southwest corner
+  [69.1, 24.2], // Northeast corner
+];
+
+/**
+ * Extracts all coordinates from a GeoJSON geometry
+ */
+function extractCoordinates(
+  geometry: Geometry,
+  allCoordinates: [number, number][],
+): void {
+  switch (geometry.type) {
+    case "Point":
+      allCoordinates.push([geometry.coordinates[1], geometry.coordinates[0]]);
+      break;
+
+    case "LineString":
+      geometry.coordinates.forEach((coord) => {
+        allCoordinates.push([coord[1], coord[0]]);
+      });
+      break;
+
+    case "Polygon":
+      geometry.coordinates.forEach((ring) => {
+        ring.forEach((coord) => {
+          allCoordinates.push([coord[1], coord[0]]);
+        });
+      });
+      break;
+
+    case "MultiPoint":
+      geometry.coordinates.forEach((coord) => {
+        allCoordinates.push([coord[1], coord[0]]);
+      });
+      break;
+
+    case "MultiLineString":
+      geometry.coordinates.forEach((line) => {
+        line.forEach((coord) => {
+          allCoordinates.push([coord[1], coord[0]]);
+        });
+      });
+      break;
+
+    case "MultiPolygon":
+      geometry.coordinates.forEach((polygon) => {
+        polygon.forEach((ring) => {
+          ring.forEach((coord) => {
+            allCoordinates.push([coord[1], coord[0]]);
+          });
+        });
+      });
+      break;
+  }
+}
+
+export interface CalculateBoundsOptions {
+  /**
+   * Padding percentage to add around the bounds (default: 0.05 = 5%)
+   */
+  padding?: number;
+  fallbackBounds?: [[number, number], [number, number]];
+}
+
+/**
+ * @param geoData - The GeoJSON FeatureCollection to calculate bounds from
+ * @param options - Optional configuration for padding and fallback bounds
+ * @returns Leaflet LatLngBounds object
+ */
+export function calculateGeoBounds(
+  geoData: FeatureCollection | null | undefined,
+  options: CalculateBoundsOptions = {},
+): L.LatLngBounds {
+  const { padding = 0.05, fallbackBounds = DEFAULT_SWEDEN_BOUNDS } = options;
+
+  if (!geoData || !geoData.features || geoData.features.length === 0) {
+    return L.latLngBounds(fallbackBounds[0], fallbackBounds[1]);
+  }
+
+  const allCoordinates: [number, number][] = [];
+
+  geoData.features.forEach((feature) => {
+    if (feature.geometry) {
+      extractCoordinates(feature.geometry, allCoordinates);
+    }
+  });
+
+  if (allCoordinates.length === 0) {
+    return L.latLngBounds(fallbackBounds[0], fallbackBounds[1]);
+  }
+
+  // Calculate bounding box
+  const lats = allCoordinates.map((coord) => coord[0]);
+  const lngs = allCoordinates.map((coord) => coord[1]);
+
+  const minLat = Math.min(...lats);
+  const maxLat = Math.max(...lats);
+  const minLng = Math.min(...lngs);
+  const maxLng = Math.max(...lngs);
+
+  // Add padding to allow some panning flexibility
+  const latPadding = (maxLat - minLat) * padding;
+  const lngPadding = (maxLng - minLng) * padding;
+
+  return L.latLngBounds(
+    [minLat - latPadding, minLng - lngPadding],
+    [maxLat + latPadding, maxLng + lngPadding],
+  );
+}


### PR DESCRIPTION
### ✨ What’s Changed?

#### Problem
The map could be panned indefinitely, allowing users to move Sweden completely out of view. There were no pan boundaries or zoom limits.
#### Solution
Added constraints to keep the map within bounds:
- Pan boundaries: calculated from the GeoJSON data to prevent panning outside the geographic area
- Zoom limits: set minZoom={3} and maxZoom={10} to prevent excessive zooming
- Zoom controls: updated to disable at limits
#### Changes
New file: src/components/maps/utils/geoBounds.ts
- Extracted bounds calculation logic into a reusable utility function
- Handles all GeoJSON geometry types (Polygon, MultiPolygon, Point, LineString, etc.)
- Calculates bounding box from coordinates with configurable padding (default 5%)
- Falls back to default Sweden bounds if no geoData is provided

Modified: src/components/maps/SwedenMap.tsx
- Added maxBounds prop to MapContainer to constrain panning
- Added minZoom={3} and maxZoom={10} props
- Updated renderZoomControls() to disable zoom buttons at limits
- Replaced inline bounds calculation (~70 lines) with utility function call

#### Technical Details
- Bounds are calculated dynamically from the geoData FeatureCollection
- Works for both municipality and regional maps
- Padding of 5% allows some panning flexibility while keeping the map visible
- The utility function is reusable for future map components

### 📸 Screenshots (if applicable)

NA, looks the same just can pan away from the map


### 📋 Checklist

- [ ] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [ ] I've verified the change runs locally both on mobile and desktop
- [ ] I've set the labels, issue, and milestone for the PR
- [ ] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #625  <!-- or: Related to #[issue-number] -->