### PR TITLE
[Fix]Remove Total Emissions on Source Analysis Section

### DIFF
--- a/src/components/companies/sectors/charts/EmissionsTotalDisplay.tsx
+++ b/src/components/companies/sectors/charts/EmissionsTotalDisplay.tsx
@@ -10,6 +10,7 @@ interface EmissionsTotalDisplayProps {
   years: string[];
   onYearChange: (year: string) => void;
   isSectorView?: boolean;
+  hideTotal?: boolean;
 }
 
 const EmissionsTotalDisplay: React.FC<EmissionsTotalDisplayProps> = ({
@@ -18,6 +19,7 @@ const EmissionsTotalDisplay: React.FC<EmissionsTotalDisplayProps> = ({
   years,
   onYearChange,
   isSectorView = false,
+  hideTotal = false,
 }) => {
   const { t } = useTranslation();
   const { isMobile, isTablet } = useScreenSize();
@@ -33,28 +35,30 @@ const EmissionsTotalDisplay: React.FC<EmissionsTotalDisplayProps> = ({
             : "flex items-center gap-4 ml-auto"
       }`}
     >
-      <div
-        className={
-          isMobile
-            ? "w-full"
-            : isTablet
-              ? "text-left"
-              : "flex items-center gap-4"
-        }
-      >
-        <div className="text-sm text-grey">
-          {isSectorView
-            ? t("companiesPage.sectorGraphs.sectorTotal")
-            : t("companiesPage.sectorGraphs.total")}
-          <span className="ml-2 text-xl font-light text-white">
-            {formatEmissionsAbsolute(
-              Math.round(totalEmissions),
-              currentLanguage,
-            )}{" "}
-            {t("emissionsUnit")}
-          </span>
+      {!hideTotal && (
+        <div
+          className={
+            isMobile
+              ? "w-full"
+              : isTablet
+                ? "text-left"
+                : "flex items-center gap-4"
+          }
+        >
+          <div className="text-sm text-grey">
+            {isSectorView
+              ? t("companiesPage.sectorGraphs.sectorTotal")
+              : t("companiesPage.sectorGraphs.total")}
+            <span className="ml-2 text-xl font-light text-white">
+              {formatEmissionsAbsolute(
+                Math.round(totalEmissions),
+                currentLanguage,
+              )}{" "}
+              {t("emissionsUnit")}
+            </span>
+          </div>
         </div>
-      </div>
+      )}
       <select
         value={selectedYear}
         onChange={(e) => onYearChange(e.target.value)}

--- a/src/components/companies/sectors/scopes/EmissionsSourcesAnlaysis.tsx
+++ b/src/components/companies/sectors/scopes/EmissionsSourcesAnlaysis.tsx
@@ -66,6 +66,7 @@ const EmissionsSourcesAnalysis: React.FC<EmissionsSourcesAnalysisProps> = ({
           years={years}
           onYearChange={setSelectedYear}
           isSectorView={effectiveSectors.length > 0}
+          hideTotal={true} // TODO: decide if we want to display the total again, and whether that should be complete total or excluding statedScope3 total
         />
       </div>
 


### PR DESCRIPTION
### ✨ What’s Changed?

The totals on the sectors page were using different logic: total (including stated scope 3) vs total (only from summed scope 3 cat) resulting in two different totals which would be confusing. 

I'm thinking that we don't need this second totals so this PR hides that. If we decide it was better to have it for comparison for the scope totals, then we can add additional language to clarify the difference in the total, or have it include statedScope3Categories.

### 📸 Screenshots (if applicable)

Before
<img width="1126" height="375" alt="Screenshot 2025-11-18 at 08 59 56" src="https://github.com/user-attachments/assets/e7bd288a-8284-40cb-a129-eca1539f82e0" />

After
<img width="871" height="363" alt="Screenshot 2025-11-18 at 08 59 38" src="https://github.com/user-attachments/assets/fa1e8e09-6773-4898-86b3-9a64a04b5a5c" />


### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #[issue-number] <!-- or: Related to #[issue-number] -->