### PR TITLE
[Prod] Minor Version Bump v5.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "klimatkollen",
-  "version": "5.5.2-rc.23",
+  "version": "5.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "klimatkollen",
-      "version": "5.5.2-rc.23",
+      "version": "5.6.0",
       "dependencies": {
         "@fontsource/dm-sans": "^5.2.5",
         "@headlessui/react": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "klimatkollen",
   "private": true,
-  "version": "5.5.2-rc.23",
+  "version": "5.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
# 🚀 Production Release PR

> **Title format:** `[Prod] Major/Minor/Patch Version Bump vX.X.X`

## 📦 Release Type
_Select the appropriate release type by marking with an `x`._

- [ ] Major version bump
- [x] Minor version bump
- [ ] Patch version bump

### Rollback Version
_Note the relevant rollback version to enable quick rollback if necessary._

v5.5.1

## 🔁 Environment Promotion
This release promotes changes **from `stage` to `production`**.

## 📋 What's Being Released
_Provide a summary of the features, fixes, or updates included in this production release._

- padding on corners adjusted across the site (notably on the about us and landing page)
- move units location on top lists page for municipalities
- added regional map view for stage only
- display party logo when available
- company rankings pt 1 --> for stage only introduced page and lists
- typo fix for relatable numbers (added a space)
- update filter translations for sectors
- fix link to preserve language selection
- typo fix on landing page
- fix dead link to a source
- set minimum fraction to 1
- reset typewrite on language change
- fix issue with editor for scope 3
- fix error in calling of hook for sweden map
- company rankings pt 2 --> for stage only introduced visuals
- add method and data guide for relatable numbers
- changed emissions per citizen in relatable numbers to new value
- refactor for ranked list component
- fix for a bug on navigating away from list view
- prep new landing page --> stage only
- update copy and funding details on about page
- add constraint to keep sweden map in view port
- add missing english copy on methods
- update how historic emissions graph handles null data before first >0 data point
- remove dead code

## ✅ Checklist

- [x] Version number is updated correctly
- [x] All relevant changes have been QA-tested in staging
- [x] Rollback version has been updated
- [x] Title follows the required format: `[Prod] Major/Minor/Patch Version Bump vX.X.X`

---

_This template is for versioned production releases only. For other PR types, please select a different template._