### PR TITLE
[1181] Extended hero section to fill up viewport + added chevron down icon

### DIFF
--- a/src/components/layout/ScrollAnimationSection.tsx
+++ b/src/components/layout/ScrollAnimationSection.tsx
@@ -89,7 +89,6 @@ export function ScrollAnimationSection({
 }: ScrollAnimationSectionProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const animationFrameRef = useRef<number | null>(null);
-
   const [dimensions, setDimensions] = useState<Dimensions>({
     headerHeight: 0,
     availableHeight: 400,

--- a/src/hooks/useThrottle.ts
+++ b/src/hooks/useThrottle.ts
@@ -1,0 +1,18 @@
+import { useRef } from "react";
+
+const useThrottle = <T extends (...args: any[]) => any>(
+  callback: T,
+  delay: number,
+) => {
+  const lastRun = useRef<number>(0);
+
+  return (...args: Parameters<T>): void => {
+    const now = Date.now();
+    if (now - lastRun.current >= delay) {
+      callback(...args);
+      lastRun.current = now;
+    }
+  };
+};
+
+export default useThrottle;

--- a/src/pages/LandingPageNew.tsx
+++ b/src/pages/LandingPageNew.tsx
@@ -1,6 +1,6 @@
 // TODO: This is currently a slightly modified copy of the live landing page, all landing page modifications can be made here
 // without worry of impacting prod until we're ready
-import { Building2Icon, TreePineIcon } from "lucide-react";
+import { Building2Icon, ChevronDown, TreePineIcon } from "lucide-react";
 import { TopList, TopListItem } from "@/components/TopList";
 
 import { Typewriter } from "@/components/ui/typewriter";
@@ -10,18 +10,21 @@ import { useCompanies } from "@/hooks/companies/useCompanies";
 import { useMunicipalities } from "@/hooks/municipalities/useMunicipalities";
 import { useTranslation } from "react-i18next";
 import { PageSEO } from "@/components/SEO/PageSEO";
-import { useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useLanguage } from "@/components/LanguageProvider";
 import {
   formatEmissionsAbsolute,
   formatPercentChange,
 } from "@/utils/formatting/localization";
+import useThrottle from "@/hooks/useThrottle";
 
 export function LandingPageNew() {
   const { t } = useTranslation();
   const { companies } = useCompanies();
   const { getTopMunicipalities } = useMunicipalities();
   const { currentLanguage } = useLanguage();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [fadeChevron, setFadeChevron] = useState(false);
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -87,6 +90,31 @@ export function LandingPageNew() {
     </span>
   );
 
+  const handleChevronClick = () => {
+    const element = containerRef.current;
+    if (element) {
+      window.scrollTo({ top: element.offsetTop, behavior: "smooth" });
+    }
+  };
+
+  const handleScroll = () => {
+    if (window.scrollY > 200) {
+      setFadeChevron(true);
+    } else {
+      setFadeChevron(false);
+    }
+  };
+
+  const throttledScroll = useThrottle(handleScroll, 100);
+
+  useEffect(() => {
+    window.addEventListener("scroll", throttledScroll);
+
+    return () => {
+      window.removeEventListener("scroll", throttledScroll);
+    };
+  }, [throttledScroll]);
+
   return (
     <>
       <PageSEO
@@ -95,8 +123,8 @@ export function LandingPageNew() {
         canonicalUrl={canonicalUrl}
         structuredData={structuredData}
       />
-      <div className="flex flex-col">
-        <div className="flex-1 flex flex-col items-center text-center px-4 py-14 md:py-24">
+      <div className="flex flex-col h-screen items-center">
+        <div className="flex-1 flex flex-col items-center text-center px-4 py-44 md:py-56">
           <div className="max-w-lg md:max-w-4xl mx-auto space-y-4">
             <h1 className="text-4xl md:text-7xl font-light tracking-tight">
               {t("landingPage.title")}
@@ -114,13 +142,19 @@ export function LandingPageNew() {
             </div>
           </div>
         </div>
+        <ChevronDown
+          onClick={() => handleChevronClick()}
+          className={`${fadeChevron ? "opacity-0 " : "opacity-50"} mb-32 cursor-pointer animate-bounce animati transition-opacity ease-in duration-750`}
+        />
       </div>
 
       {/* Scroll Animation Section */}
-      <ScrollAnimationSection
-        steps={getLandingPageScrollSteps()}
-        className="bg-black"
-      />
+      <section ref={containerRef}>
+        <ScrollAnimationSection
+          steps={getLandingPageScrollSteps()}
+          className="bg-black"
+        />
+      </section>
 
       <div className="py-8 pt-36 md:py-36">
         <div className="mx-2 sm:mx-8">


### PR DESCRIPTION
### ✨ What’s Changed?

- Extended the hero section to cover entire viewport
- Modified positioning of typewriter to take up more center space on both mobile and desktop
- Tried adding a animated chevron down with autoscroll to animation content(Demo, what do we think of this? Too much?)

### 📸 Screenshots (if applicable)

<img width="395" height="858" alt="image" src="https://github.com/user-attachments/assets/b86f3b76-dfb3-4195-aed3-5279614b32af" />

<img width="1900" height="942" alt="image" src="https://github.com/user-attachments/assets/4ac4c9db-9846-4376-9ab8-435bb8e6493a" />


### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [x] I've set the labels, issue, and milestone for the PR
- [ ] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #1181 