### PR TITLE
[fix] rename region page route

### DIFF
--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -103,10 +103,8 @@ export function AppRoutes() {
           element={<TrendAnalysisDashboard />}
         />
       </Route>
-      <Route
-        path={`${basePath}/regional-overview`}
-        element={<RegionalRankedPage />}
-      />
+      {/* Regions routes */}
+      <Route path={`${basePath}/regions`} element={<RegionalRankedPage />} />
       {/* Municipalities routes */}
       <Route
         path={`${basePath}/municipalities`}


### PR DESCRIPTION
### ✨ What’s Changed?

Rename ranked region page route fron regional-overview to regions, to make it align with company and municipality routes