### PR TITLE
Avoid showing ranked panel if too few companies

### DIFF
--- a/src/components/companies/rankedList/CompanyInsightsPanel.tsx
+++ b/src/components/companies/rankedList/CompanyInsightsPanel.tsx
@@ -35,9 +35,12 @@ function CompanyInsightsPanel({
     companyData,
     selectedKPI,
     (c) => c[selectedKPI.key],
+    "companies",
   );
 
-  if (!statistics.validData.length) {
+  const minNrOfCompaniesToShowDetails = 10;
+
+  if (statistics.validData.length < minNrOfCompaniesToShowDetails) {
     return (
       <div className="bg-white/5 backdrop-blur-sm rounded-level-2 p-8 h-full flex items-center justify-center">
         <p className="text-white text-lg">
@@ -49,15 +52,13 @@ function CompanyInsightsPanel({
     );
   }
 
-  const sortedData = getSortedEntityKPIValues(companyData, selectedKPI);
-
   // Use statistics.validData which already filters out null/undefined values
   const sortedValidData = getSortedEntityKPIValues(
     statistics.validData,
     selectedKPI,
   );
 
-  const topCompanies = sortedData.slice(0, 5);
+  const topCompanies = sortedValidData.slice(0, 5);
   // For "needs improvement", take the worst 5 from valid data only, excludes unknowns and nulls
   const bottomCompanies = sortedValidData.slice(-5).reverse();
 
@@ -80,7 +81,7 @@ function CompanyInsightsPanel({
 
         {!selectedKPI.isBoolean && (
           <>
-            <InsightsList<CompanyWithKPIs>
+            <InsightsList
               title={t(
                 selectedKPI.higherIsBetter
                   ? "companies.list.insights.topPerformers.titleTop"

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1410,7 +1410,9 @@
           "metric": "No data available for {{metric}}"
         },
         "keyStatistics": {
-          "average": "Average:"
+          "average": "Average:",
+          "distributionAbove": "companies above average",
+          "distributionBelow": "companies below average"
         },
         "topPerformers": {
           "titleTop": "Top Companies",

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -1408,7 +1408,9 @@
           "metric": "Ingen data tillgänglig för {{metric}}"
         },
         "keyStatistics": {
-          "average": "Genomsnitt:"
+          "average": "Genomsnitt:",
+          "distributionAbove": "företag över genomsnittet",
+          "distributionBelow": "företag under genomsnittet"
         },
         "topPerformers": {
           "titleTop": "Toppföretag",

--- a/src/utils/insights/rankedListUtils.ts
+++ b/src/utils/insights/rankedListUtils.ts
@@ -61,6 +61,7 @@ export function calculateEntityStatistics<
   entities: T[],
   selectedKPI: KPI,
   getValue: (entity: T) => unknown,
+  entityType: "municipalities" | "companies" = "municipalities",
 ): EntityStatistics<T> {
   const validData = filterValidData(entities, selectedKPI, getValue);
 
@@ -90,6 +91,9 @@ export function calculateEntityStatistics<
     return value === null || value === undefined;
   }).length;
 
+  const aboveAverageLabel = `${entityType}.list.insights.keyStatistics.distributionAbove`;
+  const belowAverageLabel = `${entityType}.list.insights.keyStatistics.distributionBelow`;
+
   // Create distribution stats
   const distributionStats = [
     {
@@ -97,14 +101,14 @@ export function calculateEntityStatistics<
       colorClass: "text-blue-3",
       label: selectedKPI.isBoolean
         ? selectedKPI.booleanLabels?.true || t("yes")
-        : t("municipalities.list.insights.keyStatistics.distributionAbove"),
+        : t(aboveAverageLabel),
     },
     {
       count: belowAverageCount,
       colorClass: "text-pink-3",
       label: selectedKPI.isBoolean
         ? selectedKPI.booleanLabels?.false || t("no")
-        : t("municipalities.list.insights.keyStatistics.distributionBelow"),
+        : t(belowAverageLabel),
     },
   ];
 


### PR DESCRIPTION
This addresses #1202 that we are showing the same companies in both top and bottom lists. Hide the insights panel if less than ten companies exists in the specific market.

Also address that we reused the labels above and below average from municipalities insights.

### ✨ What’s Changed?

<!-- Describe what this PR changes and why -->

### 📸 Screenshots (if applicable)

<!-- Add before/after images or UI previews -->


### 📋 Checklist

- [ ] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [ ] I've verified the change runs locally both on mobile and desktop
- [ ] I've set the labels, issue, and milestone for the PR
- [ ] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #[issue-number] <!-- or: Related to #[issue-number] -->