### PR TITLE
Add link to methodology section in new landing page

### DIFF
--- a/src/components/landing/LandingPageScrollSteps.tsx
+++ b/src/components/landing/LandingPageScrollSteps.tsx
@@ -36,6 +36,7 @@ export function useLandingPageScrollStepsWithContent(): ScrollStep[] {
         paragraph={step.paragraph}
         image={step.image}
         imagePosition={step.imagePosition}
+        link={step.link}
       />
     ),
   }));

--- a/src/components/layout/ScrollAnimationStepContent.tsx
+++ b/src/components/layout/ScrollAnimationStepContent.tsx
@@ -1,5 +1,7 @@
-import { ReactNode } from "react";
 import { LucideIcon } from "lucide-react";
+import { ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+import { LocalizedLink } from "../LocalizedLink";
 
 interface ScrollAnimationStepContentProps {
   badge: {
@@ -17,6 +19,10 @@ interface ScrollAnimationStepContentProps {
     gradientTo: string;
   };
   imagePosition?: "left" | "right";
+  link?: {
+    path: string;
+    label: string;
+  };
 }
 
 export function ScrollAnimationStepContent({
@@ -25,7 +31,9 @@ export function ScrollAnimationStepContent({
   paragraph,
   image,
   imagePosition = "right",
+  link,
 }: ScrollAnimationStepContentProps) {
+  const { t } = useTranslation();
   const BadgeIcon = badge.icon;
   const ImageIcon = image.icon;
 
@@ -49,6 +57,14 @@ export function ScrollAnimationStepContent({
         <p className="text-sm md:text-base lg:text-lg xl:text-xl text-gray-300 leading-relaxed">
           {paragraph}
         </p>
+        {link && (
+          <LocalizedLink
+            className="block underline underline-offset-2"
+            to={link.path}
+          >
+            {t(link.label)}
+          </LocalizedLink>
+        )}
       </div>
       <div className={`flex items-center justify-center ${imageOrder}`}>
         <div

--- a/src/hooks/landing/useLandingPageScrollSteps.ts
+++ b/src/hooks/landing/useLandingPageScrollSteps.ts
@@ -26,6 +26,10 @@ export interface ScrollStepData {
     gradientTo: string;
   };
   imagePosition?: "left" | "right";
+  link?: {
+    path: string;
+    label: string;
+  };
 }
 
 export function useLandingPageScrollSteps(): ScrollStepData[] {
@@ -85,6 +89,10 @@ export function useLandingPageScrollSteps(): ScrollStepData[] {
         gradientTo: "to-green-3",
       },
       imagePosition: "right",
+      link: {
+        path: "/methodology",
+        label: "landingPage.scrollSteps.methodology.linkText",
+      },
     },
     {
       id: "impact",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -128,7 +128,8 @@
       "methodology": {
         "badge": "Science-Based Rankings",
         "heading": "Our Methodology",
-        "paragraph": "We use emissions data from official reporting sources to create fair, comparable rankings. Our metrics focus on actual emissions reductions, not just promises or targets. Every ranking is based on real performance data, ensuring that climate leaders are recognized and climate laggards are held accountable."
+        "paragraph": "We use emissions data from official reporting sources to create fair, comparable rankings. Our metrics focus on actual emissions reductions, not just promises or targets. Every ranking is based on real performance data, ensuring that climate leaders are recognized and climate laggards are held accountable.",
+        "linkText": "Read more about our methodology"
       },
       "impact": {
         "badge": "From Data to Action",

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -128,7 +128,8 @@
       "methodology": {
         "badge": "Vetenskapsbaserade rankingar",
         "heading": "Vår metodik",
-        "paragraph": "Vi använder utsläppsdata från officiella rapporteringskällor för att skapa rättvisa, jämförbara rankingar. Våra mätvärden fokuserar på faktiska utsläppsminskningar, inte bara löften eller mål. Varje ranking baseras på verkliga prestationsdata, vilket säkerställer att klimatledare erkänns och klimatfördröjare hålls ansvariga."
+        "paragraph": "Vi använder utsläppsdata från officiella rapporteringskällor för att skapa rättvisa, jämförbara rankingar. Våra mätvärden fokuserar på faktiska utsläppsminskningar, inte bara löften eller mål. Varje ranking baseras på verkliga prestationsdata, vilket säkerställer att klimatledare erkänns och klimatfördröjare hålls ansvariga.",
+        "linkText": "Läs mer om vår metodik"
       },
       "impact": {
         "badge": "Från data till handling",


### PR DESCRIPTION
Add support for showing a link in each section in the new landing page and use that to add a link to methodology in the Methodology section.

Adresses #1183 

### ✨ What’s Changed?

<!-- Describe what this PR changes and why -->

### 📸 Screenshots (if applicable)
<img width="1112" height="543" alt="image" src="https://github.com/user-attachments/assets/4c58c050-73d4-4587-9941-b22e2c8f5146" />

<!-- Add before/after images or UI previews -->


### 📋 Checklist

- [ ] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [ ] I've verified the change runs locally both on mobile and desktop
- [ ] I've set the labels, issue, and milestone for the PR
- [ ] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #[issue-number] <!-- or: Related to #[issue-number] -->