### PR TITLE
[1224] light mode part I

### DIFF
--- a/src/components/MembersGrid.tsx
+++ b/src/components/MembersGrid.tsx
@@ -13,12 +13,12 @@ interface MembersGridProps {
 
 export function MembersGrid({ members }: MembersGridProps) {
   return (
-    <div className="bg-black-2 rounded-level-2 p-4 md:p-16 space-y-8 md:space-y-16">
+    <div className="dark:bg-black-2 bg-white rounded-level-2 p-4 md:p-16 space-y-8 md:space-y-16">
       <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
         {members.map((member) => (
           <div
             key={member.name}
-            className="bg-black-1 rounded-level-2 p-4 md:p-8 space-y-6"
+            className="dark:bg-black-1 bg-grey/10 rounded-level-2 p-4 md:p-8 space-y-6"
           >
             <div className="gap-6">
               <img
@@ -27,8 +27,12 @@ export function MembersGrid({ members }: MembersGridProps) {
                 className="w-16 h-16 rounded-full object-cover mb-2"
               />
               <div>
-                <Text variant="body">{member.name}</Text>
-                <Text variant="body">{member.role}</Text>
+                <Text variant="body" className="dark:text-white text-black-3">
+                  {member.name}
+                </Text>
+                <Text variant="body" className="dark:text-white text-black-3">
+                  {member.role}
+                </Text>
                 <Text className="text-grey mt-4">{member.description}</Text>
               </div>
             </div>

--- a/src/components/MembersGrid.tsx
+++ b/src/components/MembersGrid.tsx
@@ -13,12 +13,12 @@ interface MembersGridProps {
 
 export function MembersGrid({ members }: MembersGridProps) {
   return (
-    <div className="dark:bg-black-2 bg-white rounded-level-2 p-4 md:p-16 space-y-8 md:space-y-16">
+    <div className="bg-black-2 light:bg-white rounded-level-2 p-4 md:p-16 space-y-8 md:space-y-16">
       <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
         {members.map((member) => (
           <div
             key={member.name}
-            className="dark:bg-black-1 bg-grey/10 rounded-level-2 p-4 md:p-8 space-y-6"
+            className="bg-black-1 light:bg-grey/10 rounded-level-2 p-4 md:p-8 space-y-6"
           >
             <div className="gap-6">
               <img
@@ -27,10 +27,10 @@ export function MembersGrid({ members }: MembersGridProps) {
                 className="w-16 h-16 rounded-full object-cover mb-2"
               />
               <div>
-                <Text variant="body" className="dark:text-white text-black-3">
+                <Text variant="body" className="text-white light:text-black-3">
                   {member.name}
                 </Text>
-                <Text variant="body" className="dark:text-white text-black-3">
+                <Text variant="body" className="text-white light:text-black-3">
                   {member.role}
                 </Text>
                 <Text className="text-grey mt-4">{member.description}</Text>

--- a/src/components/TopList.tsx
+++ b/src/components/TopList.tsx
@@ -36,7 +36,12 @@ export function TopList({
   const Icon = icon.component;
 
   return (
-    <div className={cn("bg-black-2 rounded-level-2 p-4 md:p-8", className)}>
+    <div
+      className={cn(
+        "dark:bg-black-2 bg-white rounded-level-2 p-4 md:p-8 border dark:border-transparent border-grey/20",
+        className,
+      )}
+    >
       <div className="flex items-center justify-between mb-2 md:mb-4">
         <Text className="text-2xl md:text-4xl">
           <a href={headingLink}>{title}</a>
@@ -57,7 +62,7 @@ export function TopList({
           <LocalizedLink
             key={item.link}
             to={item.link}
-            className="grid grid-cols-subgrid col-span-full items-center gap-4 hover:bg-black-1 transition-colors rounded-lg"
+            className="grid grid-cols-subgrid col-span-full items-center gap-4 dark:hover:bg-black-1 hover:bg-grey/10 transition-colors rounded-lg"
           >
             <span className={cn("text-2xl sm:text-5xl font-light", rankColor)}>
               {String(index + 1).padStart(2, "0")}

--- a/src/components/TopList.tsx
+++ b/src/components/TopList.tsx
@@ -38,7 +38,7 @@ export function TopList({
   return (
     <div
       className={cn(
-        "dark:bg-black-2 bg-white rounded-level-2 p-4 md:p-8 border dark:border-transparent border-grey/20",
+        "dark:bg-black-2 bg-grey/10 rounded-level-2 p-4 md:p-8 border dark:border-transparent border-grey/20",
         className,
       )}
     >

--- a/src/components/TopList.tsx
+++ b/src/components/TopList.tsx
@@ -38,7 +38,7 @@ export function TopList({
   return (
     <div
       className={cn(
-        "dark:bg-black-2 bg-grey/10 rounded-level-2 p-4 md:p-8 border dark:border-transparent border-grey/20",
+        "bg-black-2 light:bg-grey/10 rounded-level-2 p-4 md:p-8 border border-transparent light:border-grey/20",
         className,
       )}
     >
@@ -62,7 +62,7 @@ export function TopList({
           <LocalizedLink
             key={item.link}
             to={item.link}
-            className="grid grid-cols-subgrid col-span-full items-center gap-4 dark:hover:bg-black-1 hover:bg-grey/10 transition-colors rounded-lg"
+            className="grid grid-cols-subgrid col-span-full items-center gap-4 hover:bg-black-1 light:hover:bg-grey/10 transition-colors rounded-lg"
           >
             <span className={cn("text-2xl sm:text-5xl font-light", rankColor)}>
               {String(index + 1).padStart(2, "0")}

--- a/src/components/charts/ChartYearControls.tsx
+++ b/src/components/charts/ChartYearControls.tsx
@@ -52,7 +52,7 @@ export const ChartYearControls: React.FC<ChartYearControlsProps> = ({
                 variant="outline"
                 size="sm"
                 onClick={() => setChartEndYear(defaultShortYear)}
-                className="bg-black-2 border-black-1 text-white hover:bg-black-1 text-xs px-3 py-1"
+                className="bg-black-2 light:bg-grey/10 border-black-1 light:border-grey text-white light:text-black-3 hover:bg-black-1 light:hover:bg-grey/20 text-xs px-3 py-1"
               >
                 <ChevronLeft className="h-3 w-3 mr-1" />
                 {defaultShortYear}
@@ -63,7 +63,7 @@ export const ChartYearControls: React.FC<ChartYearControlsProps> = ({
                 variant="outline"
                 size="sm"
                 onClick={() => setChartEndYear(defaultLongYear)}
-                className="bg-black-2 border-black-1 text-white hover:bg-black-1 text-xs px-3 py-1"
+                className="bg-black-2 light:bg-grey/10 border-black-1 light:border-grey text-white light:text-black-3 hover:bg-black-1 light:hover:bg-grey/20 text-xs px-3 py-1"
               >
                 {defaultLongYear}
                 <ChevronRight className="h-3 w-3 ml-1" />
@@ -99,7 +99,7 @@ export const ChartYearControls: React.FC<ChartYearControlsProps> = ({
             variant="outline"
             size="sm"
             onClick={() => setChartEndYear(defaultShortYear)}
-            className="bg-black-2 border-black-1 text-white hover:bg-black-1"
+            className="bg-black-2 light:bg-grey/10 border-black-1 light:border-grey text-white light:text-black-3 hover:bg-black-1 light:hover:bg-grey/20"
           >
             <ChevronLeft className="h-4 w-4 mr-1" />
             {defaultShortYear}
@@ -112,7 +112,7 @@ export const ChartYearControls: React.FC<ChartYearControlsProps> = ({
             variant="outline"
             size="sm"
             onClick={() => setChartEndYear(defaultLongYear)}
-            className="bg-black-2 border-black-1 text-white hover:bg-black-1"
+            className="bg-black-2 light:bg-grey/10 border-black-1 light:border-grey text-white light:text-black-3 hover:bg-black-1 light:hover:bg-grey/20"
           >
             {defaultLongYear}
             <ChevronRight className="h-4 w-4 ml-1" />

--- a/src/components/charts/DataViewSelector.tsx
+++ b/src/components/charts/DataViewSelector.tsx
@@ -55,7 +55,7 @@ export const DataViewSelector = <T extends string>({
           value={dataView}
           onValueChange={(value) => setDataView(value as T)}
         >
-          <TabsList className="bg-black-1">
+          <TabsList className="bg-black-1 light:bg-grey/10">
             {availableViews.map((view) => (
               <TabsTrigger
                 key={view.value}
@@ -72,10 +72,10 @@ export const DataViewSelector = <T extends string>({
           value={dataView}
           onValueChange={(value) => setDataView(value as T)}
         >
-          <SelectTrigger className="w-full bg-black-1 text-white border border-gray-600 px-3 py-2 rounded-md">
+          <SelectTrigger className="w-full bg-black-1 light:bg-grey/10 text-white light:text-black-3 border border-gray-600 light:border-grey px-3 py-2 rounded-md">
             <SelectValue placeholder={placeholder} />
           </SelectTrigger>
-          <SelectContent className="bg-black-1 text-white">
+          <SelectContent className="bg-black-1 light:bg-grey/10 text-white light:text-black-3">
             {availableViews.map((view) => (
               <SelectItem
                 key={view.value}

--- a/src/components/charts/historicEmissions/ChartTooltip.tsx
+++ b/src/components/charts/historicEmissions/ChartTooltip.tsx
@@ -165,7 +165,7 @@ export const ChartTooltip: React.FC<ChartTooltipProps> = ({
         className={cn(
           `${entry.dataKey === "total" ? "my-2 font-medium" : "my-0"}`,
           "grid grid-cols-subgrid col-span-2 w-full",
-          "even:bg-black-1 odd:bg-black-2/20 py-0.5",
+          "even:bg-black-1 light:even:bg-grey/10 odd:bg-black-2/20 light:odd:bg-grey/5 py-0.5",
         )}
       >
         <div className="text-grey mr-2">{name}</div>
@@ -188,7 +188,7 @@ export const ChartTooltip: React.FC<ChartTooltipProps> = ({
     <div
       className={cn(
         isMobile ? "max-w-[280px]" : "max-w-[400px]",
-        "bg-black-1 px-4 py-3 rounded-level-2",
+        "bg-black-1 light:bg-grey/10 px-4 py-3 rounded-level-2",
         "grid grid-cols-[1fr_auto] text-xs",
         "z-[60] relative",
       )}

--- a/src/components/charts/historicEmissions/DynamicLegendContainer.tsx
+++ b/src/components/charts/historicEmissions/DynamicLegendContainer.tsx
@@ -49,7 +49,7 @@ export const DynamicLegendContainer: React.FC<DynamicLegendContainerProps> = ({
               <Tooltip key={index}>
                 <TooltipTrigger asChild>
                   <div
-                    className={`flex items-center gap-1 px-2.5 py-1.5 rounded bg-black-2 hover:bg-black-1 transition-colors ${
+                    className={`flex items-center gap-1 px-2.5 py-1.5 rounded bg-black-2 light:bg-grey/10 hover:bg-black-1 light:hover:bg-grey/20 transition-colors ${
                       allowClickToHide ? "cursor-pointer" : "cursor-default"
                     } ${item.isHidden ? "opacity-50" : "opacity-100"}`}
                     onClick={() => {
@@ -65,7 +65,9 @@ export const DynamicLegendContainer: React.FC<DynamicLegendContainerProps> = ({
                         borderColor: item.color,
                       }}
                     />
-                    <span className="text-xs text-white">{item.name}</span>
+                    <span className="text-xs text-white light:text-black-3">
+                      {item.name}
+                    </span>
                     {showMetadata && item.metadata && (
                       <span className="text-xs text-grey/70">
                         {item.metadata.value
@@ -105,7 +107,7 @@ export const DynamicLegendContainer: React.FC<DynamicLegendContainerProps> = ({
               <Tooltip key={index}>
                 <TooltipTrigger asChild>
                   <div
-                    className={`flex items-center gap-1 px-2.5 py-1.5 md:px-2 md:py-1.5 rounded bg-black-2 hover:bg-black-1 transition-colors ${
+                    className={`flex items-center gap-1 px-2.5 py-1.5 md:px-2 md:py-1.5 rounded bg-black-2 light:bg-grey/10 hover:bg-black-1 light:hover:bg-grey/20 transition-colors ${
                       allowClickToHide ? "cursor-pointer" : "cursor-default"
                     } ${item.isHidden ? "opacity-50" : "opacity-100"}`}
                     onClick={() => {
@@ -121,7 +123,7 @@ export const DynamicLegendContainer: React.FC<DynamicLegendContainerProps> = ({
                         borderColor: item.color,
                       }}
                     />
-                    <span className="text-xs md:text-sm text-white">
+                    <span className="text-xs md:text-sm text-white light:text-black-3">
                       {item.name}
                     </span>
                     {showMetadata && item.metadata && (

--- a/src/components/charts/historicEmissions/EnhancedLegend.tsx
+++ b/src/components/charts/historicEmissions/EnhancedLegend.tsx
@@ -21,7 +21,9 @@ export const EnhancedLegend: React.FC<EnhancedLegendProps> = ({
               border: item.isDashed ? `2px solid ${item.color}` : "none",
             }}
           />
-          <span className="text-sm text-white">{item.name}</span>
+          <span className="text-sm text-white light:text-black-3">
+            {item.name}
+          </span>
         </div>
       ))}
     </div>

--- a/src/components/companies/detail/EmissionsBreakdown.tsx
+++ b/src/components/companies/detail/EmissionsBreakdown.tsx
@@ -82,7 +82,7 @@ export function EmissionsBreakdown({
   const scope3Categories = emissions.scope3?.categories || [];
 
   return (
-    <div className={cn("bg-black-2 rounded-level-1", className)}>
+    <div className={cn("bg-black-2 light:bg-white rounded-level-1", className)}>
       {!showOnlyScope3 && (
         <>
           <CardHeader
@@ -95,7 +95,7 @@ export function EmissionsBreakdown({
             {scopeData.map((scope) => (
               <div
                 key={scope.name}
-                className="bg-black-1 rounded-level-2 p-8 space-y-4"
+                className="bg-black-1 light:bg-grey/10 rounded-level-2 p-8 space-y-4"
               >
                 <div className="flex items-center gap-4">
                   <div className={cn("w-3 h-3 rounded-full", scope.color)} />
@@ -109,7 +109,7 @@ export function EmissionsBreakdown({
                   </span>
                 </Text>
 
-                <div className="h-2 bg-black-2 rounded-full overflow-hidden">
+                <div className="h-2 bg-black-2 light:bg-grey/20 rounded-full overflow-hidden">
                   <div
                     className={cn("h-full rounded-full", scope.color)}
                     style={{
@@ -154,9 +154,9 @@ export function EmissionsBreakdown({
                   return (
                     <div
                       key={categoryId}
-                      className="flex items-center gap-6 bg-black-1 rounded-level-2 p-6"
+                      className="flex items-center gap-6 bg-black-1 light:bg-grey/10 rounded-level-2 p-6"
                     >
-                      <div className="w-12 h-12 rounded-full bg-blue-5/30 flex items-center justify-center flex-shrink-0">
+                      <div className="w-12 h-12 rounded-full bg-blue-5/30 light:bg-blue-1 flex items-center justify-center flex-shrink-0">
                         <Icon className="w-6 h-6 text-blue-2" />
                       </div>
                       <div className="flex-1">
@@ -210,9 +210,9 @@ export function EmissionsBreakdown({
                   return (
                     <div
                       key={categoryId}
-                      className="flex items-center gap-6 bg-black-1 rounded-level-2 p-6"
+                      className="flex items-center gap-6 bg-black-1 light:bg-grey/10 rounded-level-2 p-6"
                     >
-                      <div className="w-12 h-12 rounded-full bg-blue-5/30 flex items-center justify-center flex-shrink-0">
+                      <div className="w-12 h-12 rounded-full bg-blue-5/30 light:bg-blue-1 flex items-center justify-center flex-shrink-0">
                         <Icon className="w-6 h-6 text-blue-2" />
                       </div>
                       <div className="flex-1">
@@ -255,7 +255,7 @@ export function EmissionsBreakdown({
       )}
 
       {emissions.biogenicEmissions && (
-        <div className="mt-8 p-6 bg-black-1 rounded-level-2">
+        <div className="mt-8 p-6 bg-black-1 light:bg-grey/10 rounded-level-2">
           <div className="flex items-center gap-2">
             <Text variant="h4">
               {t("emissionsBreakdown.biogenicEmissions")}

--- a/src/components/companies/detail/Scope3Data.tsx
+++ b/src/components/companies/detail/Scope3Data.tsx
@@ -95,7 +95,7 @@ export function Scope3Data({
       </div>
       <Tabs defaultValue="chart" className="space-y-2">
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-4">
-          <TabsList className="bg-black-1 w-full sm:w-auto flex">
+          <TabsList className="bg-black-1 light:bg-grey/10 w-full sm:w-auto flex">
             <TabsTrigger value="chart" className="flex-1 text-center">
               {t("companies.scope3Data.visualisation")}
             </TabsTrigger>

--- a/src/components/companies/detail/Scope3PieLegend.tsx
+++ b/src/components/companies/detail/Scope3PieLegend.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { formatEmissionsAbsolute, formatPercent } from "@/utils/formatting/localization";
+import {
+  formatEmissionsAbsolute,
+  formatPercent,
+} from "@/utils/formatting/localization";
 import { useLanguage } from "@/components/LanguageProvider";
 import {
   Tooltip,
@@ -74,7 +77,7 @@ const Scope3PieLegend: React.FC<PieLegendProps> = ({
             <Tooltip key={`legend-${index}`}>
               <TooltipTrigger asChild>
                 <div
-                  className={`flex items-center gap-2 p-2 rounded-md hover:bg-black-1 transition-colors cursor-pointer ${
+                  className={`flex items-center gap-2 p-2 rounded-md hover:bg-black-1 light:hover:bg-grey/20 transition-colors cursor-pointer ${
                     isFiltered ? "opacity-50" : ""
                   }`}
                   onClick={() => handleLegendItemClick(entry.name)}
@@ -84,7 +87,7 @@ const Scope3PieLegend: React.FC<PieLegendProps> = ({
                     style={{ backgroundColor: color }}
                   />
                   <div className="min-w-0 flex-1">
-                    <div className="text-sm text-white">
+                    <div className="text-sm text-white light:text-black-3">
                       {entry.name || entry.value}
                     </div>
                     <div className="text-xs text-grey flex justify-between">
@@ -106,7 +109,7 @@ const Scope3PieLegend: React.FC<PieLegendProps> = ({
                 </div>
               </TooltipTrigger>
 
-              <TooltipContent className="bg-black-1 text-white">
+              <TooltipContent className="bg-black-1 light:bg-grey/10 text-white light:text-black-3">
                 {t(
                   `companies.scope3Chart.${isFiltered ? "clickToShow" : "clickToFilter"}`,
                 )}

--- a/src/components/companies/detail/emissions-assessment/EmissionsAssessmentDialog.tsx
+++ b/src/components/companies/detail/emissions-assessment/EmissionsAssessmentDialog.tsx
@@ -27,7 +27,7 @@ export function EmissionsAssessmentDialog({
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-3xl bg-black-2 text-white max-h-[90vh] overflow-hidden flex flex-col">
+      <DialogContent className="max-w-3xl bg-black-2 light:bg-white text-white light:text-black-3 max-h-[90vh] overflow-hidden flex flex-col">
         <DialogHeader>
           <DialogTitle className="text-2xl font-light">
             Emissions Assessment
@@ -57,7 +57,10 @@ export function EmissionsAssessmentDialog({
                 <Text className="text-lg font-medium mb-2">Issues Found</Text>
                 <div className="space-y-4">
                   {assessment.issues.map((issue, index) => (
-                    <div key={index} className="bg-black-1 p-4 rounded-lg">
+                    <div
+                      key={index}
+                      className="bg-black-1 light:bg-grey/10 p-4 rounded-lg"
+                    >
                       <div className="flex items-center gap-2 mb-2">
                         <div
                           className={`w-2 h-2 rounded-full ${

--- a/src/components/companies/detail/emissions-assessment/YearSelectionModal.tsx
+++ b/src/components/companies/detail/emissions-assessment/YearSelectionModal.tsx
@@ -30,7 +30,7 @@ export function YearSelectionModal({
 }: YearSelectionModalProps) {
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
-      <DialogContent className="bg-black-2 text-white">
+      <DialogContent className="bg-black-2 light:bg-white text-white light:text-black-3">
         <DialogHeader>
           <DialogTitle className="text-2xl font-light">
             Select Years for Assessment
@@ -53,8 +53,8 @@ export function YearSelectionModal({
                   variant="outline"
                   className={`w-full justify-start transition-colors ${
                     isSelected
-                      ? "bg-blue-5 text-white border-blue-5"
-                      : "text-white border-white"
+                      ? "bg-blue-5 light:bg-blue-4 text-white light:text-white border-blue-5"
+                      : "text-white light:text-black-3 border-white light:border-grey"
                   }`}
                   onClick={() => onYearSelection(year)}
                 >

--- a/src/components/companies/detail/history/explore-mode/CumulativeSummaryBoxes.tsx
+++ b/src/components/companies/detail/history/explore-mode/CumulativeSummaryBoxes.tsx
@@ -35,7 +35,7 @@ export function CumulativeSummaryBoxes({
         <div className="text-green-3 text-xs font-medium mb-1">
           {t("companies.emissionsHistory.parisAlignedPathLabel")}
         </div>
-        <div className="text-white text-sm font-bold">
+        <div className="text-white light:text-black-3 text-sm font-bold">
           {formatEmissionsAbsoluteCompact(
             step5Data.reduce((sum, d) => sum + (d.carbonLaw || 0), 0),
             currentLanguage,
@@ -52,7 +52,7 @@ export function CumulativeSummaryBoxes({
         <div className="text-orange-3 text-xs font-medium mb-1">
           {t("companies.emissionsHistory.companyEmissionsLabel")}
         </div>
-        <div className="text-white text-sm font-bold">
+        <div className="text-white light:text-black-3 text-sm font-bold">
           {formatEmissionsAbsoluteCompact(
             step5Data.reduce((sum, d) => sum + (d.approximated || 0), 0),
             currentLanguage,
@@ -77,7 +77,7 @@ export function CumulativeSummaryBoxes({
         >
           {t("companies.emissionsHistory.budgetStatusLabel")}
         </div>
-        <div className="text-white text-sm font-bold">
+        <div className="text-white light:text-black-3 text-sm font-bold">
           {totalAreaDifference < 0 ? "-" : "+"}
           {formatEmissionsAbsoluteCompact(
             Math.abs(totalAreaDifference),

--- a/src/components/companies/detail/history/explore-mode/ExploreChart.tsx
+++ b/src/components/companies/detail/history/explore-mode/ExploreChart.tsx
@@ -821,7 +821,7 @@ export function ExploreChart({
 
         {/* Information boxes for step 5 */}
         {step === 5 && step5AreaData.length > 0 && !isMobile && (
-          <div className="absolute bottom-0 left-0 right-0 z-10 bg-black-2/80 backdrop-blur-sm">
+          <div className="absolute bottom-0 left-0 right-0 z-10 bg-black-2/80 light:bg-white/80 backdrop-blur-sm">
             <div className="flex flex-col gap-3 p-4">
               <CumulativeSummaryBoxes
                 step5Data={step5AreaData}

--- a/src/components/companies/detail/history/explore-mode/ExploreMode.tsx
+++ b/src/components/companies/detail/history/explore-mode/ExploreMode.tsx
@@ -158,7 +158,7 @@ export function ExploreMode({
 
   return (
     <div
-      className={`flex flex-col w-full bg-black-2 rounded-lg ${isMobile ? "p-3" : "p-6"}`}
+      className={`flex flex-col w-full bg-black-2 light:bg-white rounded-lg ${isMobile ? "p-3" : "p-6"}`}
     >
       {/* Placeholder for animated/segmented chart for each step */}
       <div className="mb-4 text-center">
@@ -169,7 +169,7 @@ export function ExploreMode({
           {isMobile ? (
             <div>
               <button
-                className="bg-black-1 text-white px-3 py-1 rounded-md mt-1 text-sm"
+                className="bg-black-1 light:bg-grey/10 text-white light:text-black-3 px-3 py-1 rounded-md mt-1 text-sm"
                 onClick={() => toggleDescription(exploreStep)}
               >
                 {expandedDescriptions.has(exploreStep)
@@ -220,7 +220,7 @@ export function ExploreMode({
       {isMobile && exploreStep === 4 && (
         <div className="text-center">
           <button
-            className="bg-black-1 text-white px-3 py-1 rounded-md text-sm"
+            className="bg-black-1 light:bg-grey/10 text-white light:text-black-3 px-3 py-1 rounded-md text-sm"
             onClick={toggleCumulativeSummary}
           >
             {showCumulativeSummary

--- a/src/components/companies/detail/overview/CompanyDescription.tsx
+++ b/src/components/companies/detail/overview/CompanyDescription.tsx
@@ -18,7 +18,7 @@ export function CompanyDescription({ description }: CompanyDescriptionProps) {
     return (
       <div>
         <button
-          className="bg-black-1 text-white px-3 py-1 rounded-md mt-1 text-sm"
+          className="bg-black-1 light:bg-grey/10 text-white light:text-black-3 px-3 py-1 rounded-md mt-1 text-sm"
           onClick={() => setShowMore(!showMore)}
         >
           {showMore

--- a/src/components/companies/detail/overview/CompanyOverview.tsx
+++ b/src/components/companies/detail/overview/CompanyOverview.tsx
@@ -108,7 +108,9 @@ export function CompanyOverview({
       <div className="flex items-start justify-between mb-4 md:mb-12">
         <div className="space-y-4">
           <div className="flex items-center gap-4">
-            <Text className="text-4xl lg:text-6xl">{company.name}</Text>
+            <Text className="text-4xl lg:text-6xl text-white light:text-black-3">
+              {company.name}
+            </Text>
             {token && (
               <div className="flex flex-row gap-2 mt-2 md:mt-0 md:ml-4">
                 <Button
@@ -118,7 +120,7 @@ export function CompanyOverview({
                   onClick={() => navigate("edit")}
                 >
                   Edit
-                  <div className="w-5 h-5 rounded-full bg-orange-5/30 text-orange-2 text-xs flex items-center justify-center">
+                  <div className="w-5 h-5 rounded-full bg-orange-5/30 light:bg-orange-1 text-orange-2 text-xs flex items-center justify-center">
                     <Pen />
                   </div>
                 </Button>
@@ -143,10 +145,10 @@ export function CompanyOverview({
           </div>
           <div className="my-4 w-full max-w-[180px]">
             <Select value={selectedYear} onValueChange={onYearSelect}>
-              <SelectTrigger className="w-full bg-black-1 text-white px-3 py-2 rounded-md">
+              <SelectTrigger className="w-full bg-black-1 light:bg-grey/10 text-white light:text-black-3 px-3 py-2 rounded-md">
                 <SelectValue placeholder={t("companies.overview.selectYear")} />
               </SelectTrigger>
-              <SelectContent>
+              <SelectContent className="bg-popover light:bg-white text-popover-foreground light:text-black-3">
                 <SelectItem value="latest">
                   {t("companies.overview.latestYear")}
                 </SelectItem>

--- a/src/components/companies/detail/overview/OverviewStatistics.tsx
+++ b/src/components/companies/detail/overview/OverviewStatistics.tsx
@@ -24,7 +24,7 @@ export function OverviewStatistics({
 }: OverviewStatisticProps) {
   return (
     <div className={className ? `@container ${className}` : "@container"}>
-      <div className="mt-8 @md:mt-12 bg-black-1 rounded-level-2 p-6">
+      <div className="mt-8 @md:mt-12 bg-black-1 light:bg-grey/10 rounded-level-2 p-6">
         <div className="grid grid-cols-1 @md:grid-cols-3 gap-4 @md:gap-8">
           <div>
             <Text className="md:mb-2 font-bold">

--- a/src/components/companies/list/CompanyList.tsx
+++ b/src/components/companies/list/CompanyList.tsx
@@ -42,7 +42,10 @@ export function CompanyList({ companies }: CompanyListProps) {
         latestPeriod?.emissions?.calculatedTotalEmissions || null;
 
       // Calculate emissions change from previous period
-      const emissionsChange = calculateEmissionsChange(latestPeriod, previousPeriod);
+      const emissionsChange = calculateEmissionsChange(
+        latestPeriod,
+        previousPeriod,
+      );
 
       const noSustainabilityReport =
         !latestPeriod ||
@@ -102,7 +105,7 @@ export function CompanyList({ companies }: CompanyListProps) {
             }),
         linkCardDescriptionColor: noSustainabilityReport
           ? "text-pink-3"
-          : "text-green-3",
+          : "dark:text-green-3 text-green-4",
         isFinancialsSector,
       };
     });

--- a/src/components/companies/list/CompanyList.tsx
+++ b/src/components/companies/list/CompanyList.tsx
@@ -105,7 +105,7 @@ export function CompanyList({ companies }: CompanyListProps) {
             }),
         linkCardDescriptionColor: noSustainabilityReport
           ? "text-pink-3"
-          : "dark:text-green-3 text-green-4",
+          : "text-green-3 light:text-green-4",
         isFinancialsSector,
       };
     });

--- a/src/components/companies/list/FilterBadges.tsx
+++ b/src/components/companies/list/FilterBadges.tsx
@@ -25,7 +25,7 @@ export function FilterBadges({ filters, view }: FilterBadgesProps) {
           <Badge
             key={index}
             variant="secondary"
-            className="bg-blue-5/30 text-blue-2 pl-2 pr-1 flex items-center gap-1"
+            className="dark:bg-blue-5/30 bg-blue-1 dark:text-blue-2 text-blue-5 pl-2 pr-1 flex items-center gap-1"
           >
             <span className="text-grey text-xs mr-1">
               {filter.type === "sort"
@@ -41,7 +41,7 @@ export function FilterBadges({ filters, view }: FilterBadgesProps) {
                   e.preventDefault();
                   filter.onRemove?.();
                 }}
-                className="hover:bg-blue-5/50 p-1 rounded-sm transition-colors"
+                className="dark:hover:bg-blue-5/50 hover:bg-blue-2/50 p-1 rounded-sm transition-colors"
               >
                 <X className="w-3 h-3" />
               </button>

--- a/src/components/companies/list/FilterBadges.tsx
+++ b/src/components/companies/list/FilterBadges.tsx
@@ -25,7 +25,7 @@ export function FilterBadges({ filters, view }: FilterBadgesProps) {
           <Badge
             key={index}
             variant="secondary"
-            className="dark:bg-blue-5/30 bg-blue-1 dark:text-blue-2 text-blue-5 pl-2 pr-1 flex items-center gap-1"
+            className="bg-blue-5/30 light:bg-blue-1 text-blue-2 light:text-blue-5 pl-2 pr-1 flex items-center gap-1"
           >
             <span className="text-grey text-xs mr-1">
               {filter.type === "sort"
@@ -41,7 +41,7 @@ export function FilterBadges({ filters, view }: FilterBadgesProps) {
                   e.preventDefault();
                   filter.onRemove?.();
                 }}
-                className="dark:hover:bg-blue-5/50 hover:bg-blue-2/50 p-1 rounded-sm transition-colors"
+                className="hover:bg-blue-5/50 light:hover:bg-blue-2/50 p-1 rounded-sm transition-colors"
               >
                 <X className="w-3 h-3" />
               </button>

--- a/src/components/companies/list/FilterPopover.tsx
+++ b/src/components/companies/list/FilterPopover.tsx
@@ -44,20 +44,20 @@ export function FilterPopover({
         <Button
           variant="outline"
           size="sm"
-          className="dark:bg-black-1 bg-grey/10 dark:border-black-1 border-grey/20 dark:text-grey text-black-3 dark:hover:text-white hover:text-black-3 dark:hover:bg-black-1/80 hover:bg-grey/20 dark:hover:border-black-1 hover:border-grey/30 font-medium text-sm"
+          className="bg-black-1 light:bg-grey/10 border-black-1 light:border-grey/20 text-grey light:text-black-3 hover:text-white light:hover:text-black-3 hover:bg-black-1/80 light:hover:bg-grey/20 hover:border-black-1 light:hover:border-grey/30 font-medium text-sm"
         >
           <Filter className="mr-2 h-4 w-4" />
           {t("companiesPage.filter")}
         </Button>
       </PopoverTrigger>
       <PopoverContent
-        className="w-[300px] p-0 dark:bg-black-2 bg-white dark:border-black-1 border-grey/20"
+        className="w-[300px] p-0 bg-black-2 light:bg-white border-black-1 light:border-grey/20"
         align="end"
       >
         <Command className="bg-transparent">
           <CommandInput
             placeholder={t("companiesPage.searchInFilter")}
-            className="border-b dark:border-black-1 border-grey/20"
+            className="border-b border-black-1 light:border-grey/20"
           />
           <CommandList className="max-h-[300px]">
             <CommandEmpty>{t("companiesPage.noResults")}</CommandEmpty>
@@ -76,7 +76,7 @@ export function FilterPopover({
                       setSectors([...sectors, sector.value]);
                     }
                   }}
-                  className="flex items-center justify-between cursor-pointer dark:text-white text-black-3"
+                  className="flex items-center justify-between cursor-pointer text-white light:text-black-3"
                 >
                   <span>{sector.label}</span>
                   {sectors.includes(sector.value) && (
@@ -86,7 +86,7 @@ export function FilterPopover({
               ))}
             </CommandGroup>
 
-            <CommandSeparator className="dark:bg-black-1 bg-grey/20" />
+            <CommandSeparator className="bg-black-1 light:bg-grey/20" />
             <CommandGroup
               heading={t("companiesPage.filteringOptions.meetsParis")}
             >
@@ -112,7 +112,7 @@ export function FilterPopover({
                       option.value as "all" | "yes" | "no" | "unknown",
                     )
                   }
-                  className="flex items-center justify-between cursor-pointer dark:text-white text-black-3"
+                  className="flex items-center justify-between cursor-pointer text-white light:text-black-3"
                 >
                   <span>{option.label}</span>
                   {meetsParisFilter === option.value && (

--- a/src/components/companies/list/FilterPopover.tsx
+++ b/src/components/companies/list/FilterPopover.tsx
@@ -44,20 +44,20 @@ export function FilterPopover({
         <Button
           variant="outline"
           size="sm"
-          className="bg-black-1 border-black-1 text-grey hover:text-white hover:bg-black-1/80 hover:border-black-1 font-medium text-sm"
+          className="dark:bg-black-1 bg-grey/10 dark:border-black-1 border-grey/20 dark:text-grey text-black-3 dark:hover:text-white hover:text-black-3 dark:hover:bg-black-1/80 hover:bg-grey/20 dark:hover:border-black-1 hover:border-grey/30 font-medium text-sm"
         >
           <Filter className="mr-2 h-4 w-4" />
           {t("companiesPage.filter")}
         </Button>
       </PopoverTrigger>
       <PopoverContent
-        className="w-[300px] p-0 bg-black-2 border-black-1"
+        className="w-[300px] p-0 dark:bg-black-2 bg-white dark:border-black-1 border-grey/20"
         align="end"
       >
         <Command className="bg-transparent">
           <CommandInput
             placeholder={t("companiesPage.searchInFilter")}
-            className="border-b border-black-1"
+            className="border-b dark:border-black-1 border-grey/20"
           />
           <CommandList className="max-h-[300px]">
             <CommandEmpty>{t("companiesPage.noResults")}</CommandEmpty>
@@ -76,7 +76,7 @@ export function FilterPopover({
                       setSectors([...sectors, sector.value]);
                     }
                   }}
-                  className="flex items-center justify-between cursor-pointer"
+                  className="flex items-center justify-between cursor-pointer dark:text-white text-black-3"
                 >
                   <span>{sector.label}</span>
                   {sectors.includes(sector.value) && (
@@ -86,7 +86,7 @@ export function FilterPopover({
               ))}
             </CommandGroup>
 
-            <CommandSeparator className="bg-black-1" />
+            <CommandSeparator className="dark:bg-black-1 bg-grey/20" />
             <CommandGroup
               heading={t("companiesPage.filteringOptions.meetsParis")}
             >
@@ -112,7 +112,7 @@ export function FilterPopover({
                       option.value as "all" | "yes" | "no" | "unknown",
                     )
                   }
-                  className="flex items-center justify-between cursor-pointer"
+                  className="flex items-center justify-between cursor-pointer dark:text-white text-black-3"
                 >
                   <span>{option.label}</span>
                   {meetsParisFilter === option.value && (

--- a/src/components/companies/list/SortPopover.tsx
+++ b/src/components/companies/list/SortPopover.tsx
@@ -43,14 +43,14 @@ export function SortPopover({
         <Button
           variant="outline"
           size="sm"
-          className="bg-black-1 border-black-1 text-grey hover:text-white hover:bg-black-1/80 hover:border-black-1 font-medium text-sm"
+          className="dark:bg-black-1 bg-grey/10 dark:border-black-1 border-grey/20 dark:text-grey text-black-3 dark:hover:text-white hover:text-black-3 dark:hover:bg-black-1/80 hover:bg-grey/20 dark:hover:border-black-1 hover:border-grey/30 font-medium text-sm"
         >
           <ArrowUpDown className="mr-2 h-4 w-4" />
           {t("companiesPage.sort")}
         </Button>
       </PopoverTrigger>
       <PopoverContent
-        className="w-[250px] p-0 bg-black-2 border-black-1"
+        className="w-[250px] p-0 dark:bg-black-2 bg-white dark:border-black-1 border-grey/20"
         align="end"
       >
         <Command className="bg-transparent">
@@ -61,7 +61,7 @@ export function SortPopover({
                 <CommandItem
                   key={option.value}
                   onSelect={() => setSortBy(option.value)}
-                  className="flex items-center justify-between cursor-pointer"
+                  className="flex items-center justify-between cursor-pointer dark:text-white text-black-3"
                 >
                   <span>{option.label}</span>
                   {sortBy === option.value && (
@@ -71,7 +71,7 @@ export function SortPopover({
               ))}
             </CommandGroup>
 
-            <CommandSeparator className="bg-black-1" />
+            <CommandSeparator className="dark:bg-black-1 bg-grey/20" />
             <CommandGroup heading={t("companiesPage.sortDirection.asc")}>
               {[
                 {
@@ -99,7 +99,7 @@ export function SortPopover({
                       setSortDirection(option.value as "asc" | "desc");
                     }
                   }}
-                  className="flex items-center justify-between cursor-pointer"
+                  className="flex items-center justify-between cursor-pointer dark:text-white text-black-3"
                 >
                   <div className="flex items-center gap-2">
                     {option.icon}

--- a/src/components/companies/list/SortPopover.tsx
+++ b/src/components/companies/list/SortPopover.tsx
@@ -43,14 +43,14 @@ export function SortPopover({
         <Button
           variant="outline"
           size="sm"
-          className="dark:bg-black-1 bg-grey/10 dark:border-black-1 border-grey/20 dark:text-grey text-black-3 dark:hover:text-white hover:text-black-3 dark:hover:bg-black-1/80 hover:bg-grey/20 dark:hover:border-black-1 hover:border-grey/30 font-medium text-sm"
+          className="bg-black-1 light:bg-grey/10 border-black-1 light:border-grey/20 text-grey light:text-black-3 hover:text-white light:hover:text-black-3 hover:bg-black-1/80 light:hover:bg-grey/20 hover:border-black-1 light:hover:border-grey/30 font-medium text-sm"
         >
           <ArrowUpDown className="mr-2 h-4 w-4" />
           {t("companiesPage.sort")}
         </Button>
       </PopoverTrigger>
       <PopoverContent
-        className="w-[250px] p-0 dark:bg-black-2 bg-white dark:border-black-1 border-grey/20"
+        className="w-[250px] p-0 bg-black-2 light:bg-white border-black-1 light:border-grey/20"
         align="end"
       >
         <Command className="bg-transparent">
@@ -61,7 +61,7 @@ export function SortPopover({
                 <CommandItem
                   key={option.value}
                   onSelect={() => setSortBy(option.value)}
-                  className="flex items-center justify-between cursor-pointer dark:text-white text-black-3"
+                  className="flex items-center justify-between cursor-pointer text-white light:text-black-3"
                 >
                   <span>{option.label}</span>
                   {sortBy === option.value && (
@@ -71,7 +71,7 @@ export function SortPopover({
               ))}
             </CommandGroup>
 
-            <CommandSeparator className="dark:bg-black-1 bg-grey/20" />
+            <CommandSeparator className="bg-black-1 light:bg-grey/20" />
             <CommandGroup heading={t("companiesPage.sortDirection.asc")}>
               {[
                 {
@@ -99,7 +99,7 @@ export function SortPopover({
                       setSortDirection(option.value as "asc" | "desc");
                     }
                   }}
-                  className="flex items-center justify-between cursor-pointer dark:text-white text-black-3"
+                  className="flex items-center justify-between cursor-pointer text-white light:text-black-3"
                 >
                   <div className="flex items-center gap-2">
                     {option.icon}

--- a/src/components/companies/rankedList/CompanyInsightsPanel.tsx
+++ b/src/components/companies/rankedList/CompanyInsightsPanel.tsx
@@ -22,8 +22,8 @@ function CompanyInsightsPanel({
 }: InsightsPanelProps) {
   if (!companyData?.length) {
     return (
-      <div className="dark:bg-white/5 bg-grey/10 backdrop-blur-sm rounded-level-2 p-8 h-full flex items-center justify-center">
-        <p className="dark:text-white text-black-3 text-lg">
+      <div className="bg-white/5 light:bg-grey/10 backdrop-blur-sm rounded-level-2 p-8 h-full flex items-center justify-center">
+        <p className="text-white light:text-black-3 text-lg">
           {t("companies.list.insights.noData.company")}
         </p>
       </div>
@@ -39,8 +39,8 @@ function CompanyInsightsPanel({
 
   if (!statistics.validData.length) {
     return (
-      <div className="dark:bg-white/5 bg-grey/10 backdrop-blur-sm rounded-level-2 p-8 h-full flex items-center justify-center">
-        <p className="dark:text-white text-black-3 text-lg">
+      <div className="bg-white/5 light:bg-grey/10 backdrop-blur-sm rounded-level-2 p-8 h-full flex items-center justify-center">
+        <p className="text-white light:text-black-3 text-lg">
           {t("companies.list.insights.noData.metric", {
             metric: selectedKPI.label,
           })}
@@ -64,7 +64,7 @@ function CompanyInsightsPanel({
   const sourceLinks = createSourceLinks(selectedKPI);
 
   return (
-    <div className="flex-1 overflow-y-auto min-h-0 pr-2 dark:bg-black-2 bg-grey/10 rounded-level-2 p-6">
+    <div className="flex-1 overflow-y-auto min-h-0 pr-2 bg-black-2 light:bg-grey/10 rounded-level-2 p-6">
       <div
         className={`${!selectedKPI.isBoolean ? "space-y-6 md:space-y-0 md:grid md:grid-cols-3 md:gap-6" : ""} `}
       >

--- a/src/components/companies/rankedList/CompanyInsightsPanel.tsx
+++ b/src/components/companies/rankedList/CompanyInsightsPanel.tsx
@@ -22,8 +22,8 @@ function CompanyInsightsPanel({
 }: InsightsPanelProps) {
   if (!companyData?.length) {
     return (
-      <div className="bg-white/5 backdrop-blur-sm rounded-level-2 p-8 h-full flex items-center justify-center">
-        <p className="text-white text-lg">
+      <div className="dark:bg-white/5 bg-grey/10 backdrop-blur-sm rounded-level-2 p-8 h-full flex items-center justify-center">
+        <p className="dark:text-white text-black-3 text-lg">
           {t("companies.list.insights.noData.company")}
         </p>
       </div>
@@ -39,8 +39,8 @@ function CompanyInsightsPanel({
 
   if (!statistics.validData.length) {
     return (
-      <div className="bg-white/5 backdrop-blur-sm rounded-level-2 p-8 h-full flex items-center justify-center">
-        <p className="text-white text-lg">
+      <div className="dark:bg-white/5 bg-grey/10 backdrop-blur-sm rounded-level-2 p-8 h-full flex items-center justify-center">
+        <p className="dark:text-white text-black-3 text-lg">
           {t("companies.list.insights.noData.metric", {
             metric: selectedKPI.label,
           })}
@@ -64,7 +64,7 @@ function CompanyInsightsPanel({
   const sourceLinks = createSourceLinks(selectedKPI);
 
   return (
-    <div className="flex-1 overflow-y-auto min-h-0 pr-2">
+    <div className="flex-1 overflow-y-auto min-h-0 pr-2 dark:bg-black-2 bg-grey/10 rounded-level-2 p-6">
       <div
         className={`${!selectedKPI.isBoolean ? "space-y-6 md:space-y-0 md:grid md:grid-cols-3 md:gap-6" : ""} `}
       >

--- a/src/components/companies/rankedList/IndustryFilter.tsx
+++ b/src/components/companies/rankedList/IndustryFilter.tsx
@@ -51,7 +51,7 @@ export function IndustryFilter({
           value={selectedSector || undefined}
           onValueChange={(value) => onSectorChange(value)}
         >
-          <SelectTrigger className="w-full bg-black-2 border-black-3 text-white">
+          <SelectTrigger className="w-full dark:bg-black-2 bg-white dark:border-black-3 border-grey/20 dark:text-white text-black-3">
             <SelectValue
               placeholder={t(
                 "companiesRankedPage.selectIndustry",
@@ -61,7 +61,7 @@ export function IndustryFilter({
               {selectedSectorName}
             </SelectValue>
           </SelectTrigger>
-          <SelectContent className="bg-black-1 border-black-3">
+          <SelectContent className="dark:bg-black-1 bg-white dark:border-black-3 border-grey/20">
             {availableSectors.map((sectorCode) => {
               const sectorName =
                 sectorNames[sectorCode as keyof typeof sectorNames] ||
@@ -70,7 +70,7 @@ export function IndustryFilter({
                 <SelectItem
                   key={sectorCode}
                   value={sectorCode}
-                  className="text-white focus:bg-black-2"
+                  className="dark:text-white text-black-3 dark:focus:bg-black-2 focus:bg-grey/10"
                 >
                   {sectorName}
                 </SelectItem>
@@ -103,7 +103,7 @@ export function IndustryFilter({
               "border",
               isSelected
                 ? "bg-blue-5/30 border-blue-4 text-blue-2 hover:bg-blue-5/40"
-                : "bg-black-2 border-black-3 text-grey hover:bg-black-3 hover:border-black-4",
+                : "dark:bg-black-2 bg-grey/10 dark:border-black-3 border-grey/20 text-grey dark:hover:bg-black-3 hover:bg-grey/20 dark:hover:border-black-4 hover:border-grey/30",
             )}
           >
             {sectorName}

--- a/src/components/companies/rankedList/IndustryFilter.tsx
+++ b/src/components/companies/rankedList/IndustryFilter.tsx
@@ -102,7 +102,7 @@ export function IndustryFilter({
               "px-3 py-1.5 rounded-level-1 text-xs font-medium transition-all",
               "border",
               isSelected
-                ? "bg-blue-5/30 border-blue-4 text-blue-2 hover:bg-blue-5/40"
+                ? "bg-blue-5/30 border-blue-4 text-blue-4 hover:bg-blue-5/40"
                 : "bg-black-2 light:bg-grey/10 border-black-3 light:border-grey/20 text-grey hover:bg-black-3 light:hover:bg-grey/20 hover:border-black-4 light:hover:border-grey/30",
             )}
           >

--- a/src/components/companies/rankedList/IndustryFilter.tsx
+++ b/src/components/companies/rankedList/IndustryFilter.tsx
@@ -51,7 +51,7 @@ export function IndustryFilter({
           value={selectedSector || undefined}
           onValueChange={(value) => onSectorChange(value)}
         >
-          <SelectTrigger className="w-full dark:bg-black-2 bg-white dark:border-black-3 border-grey/20 dark:text-white text-black-3">
+          <SelectTrigger className="w-full bg-black-2 light:bg-white border-black-3 light:border-grey/20 text-white light:text-black-3">
             <SelectValue
               placeholder={t(
                 "companiesRankedPage.selectIndustry",
@@ -61,7 +61,7 @@ export function IndustryFilter({
               {selectedSectorName}
             </SelectValue>
           </SelectTrigger>
-          <SelectContent className="dark:bg-black-1 bg-white dark:border-black-3 border-grey/20">
+          <SelectContent className="bg-black-1 light:bg-white border-black-3 light:border-grey/20">
             {availableSectors.map((sectorCode) => {
               const sectorName =
                 sectorNames[sectorCode as keyof typeof sectorNames] ||
@@ -70,7 +70,7 @@ export function IndustryFilter({
                 <SelectItem
                   key={sectorCode}
                   value={sectorCode}
-                  className="dark:text-white text-black-3 dark:focus:bg-black-2 focus:bg-grey/10"
+                  className="text-white light:text-black-3 focus:bg-black-2 light:focus:bg-grey/10"
                 >
                   {sectorName}
                 </SelectItem>
@@ -103,7 +103,7 @@ export function IndustryFilter({
               "border",
               isSelected
                 ? "bg-blue-5/30 border-blue-4 text-blue-2 hover:bg-blue-5/40"
-                : "dark:bg-black-2 bg-grey/10 dark:border-black-3 border-grey/20 text-grey dark:hover:bg-black-3 hover:bg-grey/20 dark:hover:border-black-4 hover:border-grey/30",
+                : "bg-black-2 light:bg-grey/10 border-black-3 light:border-grey/20 text-grey hover:bg-black-3 light:hover:bg-grey/20 hover:border-black-4 light:hover:border-grey/30",
             )}
           >
             {sectorName}

--- a/src/components/companies/sectors/SectorGraphs.tsx
+++ b/src/components/companies/sectors/SectorGraphs.tsx
@@ -20,8 +20,8 @@ const SectorGraphs: React.FC<SectorGraphsProps> = ({
   const sectorNames = useSectorNames();
 
   return (
-    <div className="bg-black">
-      <div className="bg-black-2 rounded-lg border p-6">
+    <div className="bg-black light:bg-white">
+      <div className="bg-black-2 light:bg-grey/10 rounded-lg border border-transparent light:border-grey/20 p-6">
         <SectorEmissionsChart
           companies={companies}
           selectedSectors={

--- a/src/components/companies/sectors/charts/ChartHeader.tsx
+++ b/src/components/companies/sectors/charts/ChartHeader.tsx
@@ -46,7 +46,7 @@ const ChartHeader: React.FC<ChartHeaderProps> = ({
           {selectedSector && (
             <button
               onClick={onSectorClear}
-              className="flex items-center gap-2 px-4 py-2 rounded-lg text-grey hover:text-white focus:outline-none transition-colors"
+              className="flex items-center gap-2 px-4 py-2 rounded-lg text-grey hover:text-white light:hover:text-black-3 focus:outline-none transition-colors"
             >
               <ArrowLeft className="h-4 w-4" />
               <span className="text-sm font-medium">
@@ -63,8 +63,8 @@ const ChartHeader: React.FC<ChartHeaderProps> = ({
               onClick={() => onChartTypeChange("pie")}
               className={`flex items-center gap-2 px-4 py-2 rounded-lg focus:outline-none transition-colors ${
                 chartType === "pie"
-                  ? "bg-black-1 text-white"
-                  : "text-grey hover:text-white"
+                  ? "bg-black-1 light:bg-grey/20 text-white light:text-black-3"
+                  : "text-grey hover:text-white light:hover:text-black-3"
               }`}
             >
               <PieChart className="h-4 w-4" />
@@ -76,8 +76,8 @@ const ChartHeader: React.FC<ChartHeaderProps> = ({
               onClick={() => onChartTypeChange("stacked-total")}
               className={`flex items-center gap-2 px-4 py-2 rounded-lg focus:outline-none transition-colors ${
                 chartType === "stacked-total"
-                  ? "bg-black-1 text-white"
-                  : "text-grey hover:text-white"
+                  ? "bg-black-1 light:bg-grey/20 text-white light:text-black-3"
+                  : "text-grey hover:text-white light:hover:text-black-3"
               }`}
             >
               <BarChart3 className="h-4 w-4" />

--- a/src/components/companies/sectors/charts/EmissionsTotalDisplay.tsx
+++ b/src/components/companies/sectors/charts/EmissionsTotalDisplay.tsx
@@ -49,7 +49,7 @@ const EmissionsTotalDisplay: React.FC<EmissionsTotalDisplayProps> = ({
             {isSectorView
               ? t("companiesPage.sectorGraphs.sectorTotal")
               : t("companiesPage.sectorGraphs.total")}
-            <span className="ml-2 text-xl font-light text-white">
+            <span className="ml-2 text-xl font-light text-white light:text-black-3">
               {formatEmissionsAbsolute(
                 Math.round(totalEmissions),
                 currentLanguage,
@@ -62,7 +62,7 @@ const EmissionsTotalDisplay: React.FC<EmissionsTotalDisplayProps> = ({
       <select
         value={selectedYear}
         onChange={(e) => onYearChange(e.target.value)}
-        className={`bg-black-2 border border-black-1 rounded-lg px-4 py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-orange-3 transition-shadow ${
+        className={`bg-black-2 light:bg-grey/10 border border-black-1 light:border-grey/20 rounded-lg px-4 py-2 text-sm text-white light:text-black-3 focus:outline-none focus:ring-2 focus:ring-orange-3 transition-shadow ${
           isMobile ? "w-full" : ""
         }`}
       >

--- a/src/components/companies/sectors/charts/SectorPieLegend.tsx
+++ b/src/components/companies/sectors/charts/SectorPieLegend.tsx
@@ -76,7 +76,7 @@ const SectorPieLegend: React.FC<PieLegendProps> = ({
             <Tooltip key={`legend-${index}`}>
               <TooltipTrigger asChild>
                 <div
-                  className={`flex items-center gap-2 p-2 rounded bg-black-2 hover:bg-black-1 transition-colors cursor-pointer ${
+                  className={`flex items-center gap-2 p-2 rounded bg-black-2 light:bg-grey/10 hover:bg-black-1 light:hover:bg-grey/20 transition-colors cursor-pointer border border-transparent light:border-grey/20 ${
                     selectedLabel ? "hover:ring-1 hover:ring-black-1" : ""
                   }`}
                   onClick={() => handleItemClick(entry)}
@@ -86,7 +86,7 @@ const SectorPieLegend: React.FC<PieLegendProps> = ({
                     style={{ backgroundColor: color }}
                   />
                   <div className="min-w-0 flex-1">
-                    <div className="text-sm text-white truncate">
+                    <div className="text-sm text-white light:text-black-3 truncate">
                       {entry.name || entry.value}
                     </div>
                     <div className="text-xs text-grey flex justify-between">
@@ -102,7 +102,7 @@ const SectorPieLegend: React.FC<PieLegendProps> = ({
                   </div>
                 </div>
               </TooltipTrigger>
-              <TooltipContent className="bg-black-1 text-white">
+              <TooltipContent className="bg-black-1 light:bg-grey/20 text-white light:text-black-3">
                 {selectedLabel
                   ? t("companiesPage.sectorGraphs.pieLegendCompany")
                   : t("companiesPage.sectorGraphs.pieLegendSector")}

--- a/src/components/companies/sectors/scopes/EmissionsSourcesAnlaysis.tsx
+++ b/src/components/companies/sectors/scopes/EmissionsSourcesAnlaysis.tsx
@@ -53,7 +53,7 @@ const EmissionsSourcesAnalysis: React.FC<EmissionsSourcesAnalysisProps> = ({
               : "flex items-center gap-2"
           }`}
         >
-          <h2 className="text-xl font-light text-white">
+          <h2 className="text-xl font-light text-white light:text-black-3">
             {t("companiesPage.sectorGraphs.emissionsSourcesAnalysis")}
           </h2>
           <span className="text-sm text-grey">

--- a/src/components/companies/sectors/scopes/KeyInsights.tsx
+++ b/src/components/companies/sectors/scopes/KeyInsights.tsx
@@ -69,8 +69,8 @@ const KeyInsights: React.FC<KeyInsightsProps> = ({
   ];
 
   return (
-    <div className="bg-black-1 border border-black-2 rounded-lg p-6">
-      <h3 className="text-lg font-light text-white mb-4">
+    <div className="bg-black-1 light:bg-grey/20 border border-black-2 light:border-grey/20 rounded-lg p-6">
+      <h3 className="text-lg font-light text-white light:text-black-3 mb-4">
         {t("companiesPage.sectorGraphs.keyInsights")}
       </h3>
       <div className="space-y-4">
@@ -87,7 +87,7 @@ const KeyInsights: React.FC<KeyInsightsProps> = ({
                 <Icon className={`h-4 w-4 ${insight.iconColor}`} />
               </div>
               <div>
-                <div className="text-sm font-medium text-white">
+                <div className="text-sm font-medium text-white light:text-black-3">
                   {insight.title}
                 </div>
                 <div className="text-sm text-grey">

--- a/src/components/companies/sectors/scopes/ScopeCard.tsx
+++ b/src/components/companies/sectors/scopes/ScopeCard.tsx
@@ -50,14 +50,16 @@ const ScopeCard: React.FC<ScopeCardProps> = ({
 
   return (
     <div
-      className="bg-black-2 rounded-lg p-6 space-y-4 cursor-pointer hover:scale-105 transition-transform duration-200"
+      className="bg-black-2 light:bg-grey/10 rounded-lg p-6 space-y-4 cursor-pointer hover:scale-105 transition-transform duration-200 border border-transparent light:border-grey/20"
       onClick={handleCardClick}
     >
       <div className="flex items-center gap-3 mb-2">
         <div className={`rounded-full p-2 ${color}`}>
           <Icon className="h-5 w-5 text-white" />
         </div>
-        <h3 className="text-lg font-light text-white">{title}</h3>
+        <h3 className="text-lg font-light text-white light:text-black-3">
+          {title}
+        </h3>
         {showCategoryInfo && (
           <InfoTooltip
             ariaLabel={t("companiesPage.sectorGraphs.scope3CategoryInfoLabel")}
@@ -87,7 +89,7 @@ const ScopeCard: React.FC<ScopeCardProps> = ({
           <div className="text-sm text-grey">
             {t("companiesPage.sectorGraphs.companiesReporting")}
           </div>
-          <div className="text-sm text-white">
+          <div className="text-sm text-white light:text-black-3">
             {companies} {t("companiesPage.sectorGraphs.companies")}
           </div>
         </div>
@@ -101,7 +103,7 @@ const ScopeCard: React.FC<ScopeCardProps> = ({
           </div>
         </div>
 
-        <div className="h-2 bg-black-1 rounded-full overflow-hidden">
+        <div className="h-2 bg-black-1 light:bg-grey/20 rounded-full overflow-hidden">
           <div
             className={`h-full transition-all duration-500 ease-out ${color}`}
             style={{ width: `${percent * 100}%` }}

--- a/src/components/companies/sectors/scopes/ScopeModal.tsx
+++ b/src/components/companies/sectors/scopes/ScopeModal.tsx
@@ -117,13 +117,15 @@ const ScopeModal: React.FC<ScopeModalProps> = ({
   const { currentLanguage } = useLanguage();
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-80 backdrop-blur-sm flex items-center justify-center z-50">
-      <div className="bg-black-2 border border-black-1 rounded-xl shadow-xl w-full max-w-4xl mx-4 max-h-[90vh] flex flex-col">
-        <div className="flex justify-between items-center p-6 border-b border-black-1">
-          <h3 className="text-xl font-light text-white">{title}</h3>
+    <div className="fixed inset-0 bg-black bg-opacity-80 light:bg-black/60 backdrop-blur-sm flex items-center justify-center z-50">
+      <div className="bg-black-2 light:bg-white border border-black-1 light:border-grey/20 rounded-xl shadow-xl w-full max-w-4xl mx-4 max-h-[90vh] flex flex-col">
+        <div className="flex justify-between items-center p-6 border-b border-black-1 light:border-grey/20">
+          <h3 className="text-xl font-light text-white light:text-black-3">
+            {title}
+          </h3>
           <button
             onClick={onClose}
-            className="text-grey hover:text-white focus:outline-none transition-colors"
+            className="text-grey hover:text-white light:hover:text-black-3 focus:outline-none transition-colors"
           >
             <X className="h-5 w-5" />
           </button>
@@ -138,7 +140,7 @@ const ScopeModal: React.FC<ScopeModalProps> = ({
               return (
                 <div
                   key={sector.sectorCode}
-                  className="bg-black-3 rounded-lg p-6"
+                  className="bg-black-3 light:bg-grey/10 rounded-lg p-6 border border-transparent light:border-grey/20"
                 >
                   <div className="flex items-center justify-between mb-4">
                     <div>
@@ -182,8 +184,8 @@ const ScopeModal: React.FC<ScopeModalProps> = ({
                           to={`/companies/${wikidataId}`}
                           className="block"
                         >
-                          <div className="bg-black-2 rounded-lg p-4 flex items-center justify-between group hover:bg-opacity-60 transition-colors cursor-pointer">
-                            <div className="text-sm font-medium text-white hover:scale-105 transition-transform">
+                          <div className="bg-black-2 light:bg-grey/10 rounded-lg p-4 flex items-center justify-between group hover:bg-opacity-60 light:hover:bg-grey/20 transition-colors cursor-pointer border border-transparent light:border-grey/20">
+                            <div className="text-sm font-medium text-white light:text-black-3 hover:scale-105 transition-transform">
                               {company.name}
                             </div>
                             <div className="text-right">
@@ -210,9 +212,9 @@ const ScopeModal: React.FC<ScopeModalProps> = ({
                       ) : (
                         <div
                           key={company.name}
-                          className="bg-black-2 rounded-lg p-4 flex items-center justify-between"
+                          className="bg-black-2 light:bg-grey/10 rounded-lg p-4 flex items-center justify-between border border-transparent light:border-grey/20"
                         >
-                          <div className="text-sm font-medium text-white">
+                          <div className="text-sm font-medium text-white light:text-black-3">
                             {company.name}
                           </div>
                           <div className="text-right">

--- a/src/components/companies/sectors/scopes/ValueChainOverview.tsx
+++ b/src/components/companies/sectors/scopes/ValueChainOverview.tsx
@@ -64,8 +64,8 @@ const ValueChainOverview: React.FC = () => {
 
   if (isMobile) {
     return (
-      <div className="bg-black-2 rounded-lg p-4">
-        <h3 className="text-base font-light text-white mb-3">
+      <div className="bg-black-2 light:bg-grey/10 rounded-lg p-4 border border-transparent light:border-grey/20">
+        <h3 className="text-base font-light text-white light:text-black-3 mb-3">
           {t("companiesPage.sectorGraphs.valueChainOverview")}
         </h3>
 
@@ -79,15 +79,19 @@ const ValueChainOverview: React.FC = () => {
                 <button
                   onClick={() => setSelectedStage(isSelected ? null : index)}
                   className={`w-full flex items-center justify-between p-3 rounded-lg transition-colors ${
-                    isSelected ? "bg-black-1" : "bg-black-1/50 hover:bg-black-1"
+                    isSelected
+                      ? "bg-black-1 light:bg-grey/20"
+                      : "bg-black-1/50 light:bg-grey/10 hover:bg-black-1 light:hover:bg-grey/20"
                   }`}
                 >
                   <div className="flex items-center gap-3">
-                    <div className={`rounded-full p-2 bg-black-2`}>
+                    <div
+                      className={`rounded-full p-2 bg-black-2 light:bg-grey/20`}
+                    >
                       <Icon className={`h-4 w-4 ${stage.color}`} />
                     </div>
                     <div className="text-left">
-                      <div className="text-sm font-medium text-white">
+                      <div className="text-sm font-medium text-white light:text-black-3">
                         {stage.title}
                       </div>
                       <div className="text-xs text-grey">
@@ -107,7 +111,7 @@ const ValueChainOverview: React.FC = () => {
                     {stage.details.map((detail, i) => (
                       <div
                         key={i}
-                        className="text-xs text-grey flex items-center gap-2 p-2 bg-black-2 rounded"
+                        className="text-xs text-grey flex items-center gap-2 p-2 bg-black-2 light:bg-grey/20 rounded"
                       >
                         <div
                           className={`w-1 h-1 rounded-full ${stage.color.replace(
@@ -136,8 +140,8 @@ const ValueChainOverview: React.FC = () => {
 
   if (isTablet) {
     return (
-      <div className="bg-black-2 rounded-lg p-6">
-        <h3 className="text-lg font-light text-white mb-4">
+      <div className="bg-black-2 light:bg-grey/10 rounded-lg p-6 border border-transparent light:border-grey/20">
+        <h3 className="text-lg font-light text-white light:text-black-3 mb-4">
           {t("companiesPage.sectorGraphs.valueChainOverview")}
         </h3>
         <div className="flex flex-col space-y-4">
@@ -147,13 +151,15 @@ const ValueChainOverview: React.FC = () => {
 
             return (
               <div key={index} className="relative">
-                <div className="bg-black-1 rounded-lg p-4">
+                <div className="bg-black-1 light:bg-grey/20 rounded-lg p-4 border border-transparent light:border-grey/20">
                   <div className="flex items-center gap-3 mb-3">
-                    <div className={`rounded-full p-2 bg-black-2 shrink-0`}>
+                    <div
+                      className={`rounded-full p-2 bg-black-2 light:bg-grey/20 shrink-0`}
+                    >
                       <Icon className={`h-5 w-5 ${stage.color}`} />
                     </div>
                     <div>
-                      <div className="text-sm font-medium text-white">
+                      <div className="text-sm font-medium text-white light:text-black-3">
                         {stage.title}
                       </div>
                       <div className="text-xs text-grey">
@@ -189,8 +195,8 @@ const ValueChainOverview: React.FC = () => {
   }
 
   return (
-    <div className="bg-black-2 rounded-lg p-6">
-      <h3 className="text-lg font-light text-white mb-4">
+    <div className="bg-black-2 light:bg-grey/10 rounded-lg p-6 border border-transparent light:border-grey/20">
+      <h3 className="text-lg font-light text-white light:text-black-3 mb-4">
         {t("companiesPage.sectorGraphs.valueChainOverview")}
       </h3>
       <div className="grid grid-cols-3 gap-4">
@@ -200,13 +206,15 @@ const ValueChainOverview: React.FC = () => {
 
           return (
             <div key={index} className="relative">
-              <div className="bg-black-1 rounded-lg p-4 h-full">
+              <div className="bg-black-1 light:bg-grey/20 rounded-lg p-4 h-full border border-transparent light:border-grey/20">
                 <div className="flex items-center gap-2 mb-3">
-                  <div className={`rounded-full p-2 bg-black-2 shrink-0`}>
+                  <div
+                    className={`rounded-full p-2 bg-black-2 light:bg-grey/20 shrink-0`}
+                  >
                     <Icon className={`h-5 w-5 ${stage.color}`} />
                   </div>
                   <div>
-                    <div className="text-sm font-medium text-white">
+                    <div className="text-sm font-medium text-white light:text-black-3">
                       {stage.title}
                     </div>
                     <div className="text-xs text-grey">{stage.description}</div>

--- a/src/components/companies/sectors/trends/EmissionsTrendAnalysis.tsx
+++ b/src/components/companies/sectors/trends/EmissionsTrendAnalysis.tsx
@@ -28,7 +28,7 @@ const EmissionsTrendAnalysis: React.FC<EmissionsTrendAnalysisProps> = ({
           screenSize.isMobile ? "flex-col" : "items-center"
         } gap-2`}
       >
-        <h2 className="text-xl font-light text-white">
+        <h2 className="text-xl font-light text-white light:text-black-3">
           {t("companiesPage.sectorGraphs.emissionsTrendAnalysis")}
         </h2>
         <span className="text-sm text-grey">

--- a/src/components/companies/sectors/trends/TrendCard.tsx
+++ b/src/components/companies/sectors/trends/TrendCard.tsx
@@ -33,7 +33,7 @@ const TrendCard: React.FC<TrendCardProps> = ({
     >
       <div
         className={`
-        bg-black-2 rounded-lg p-6
+        bg-black-2 light:bg-grey/10 rounded-lg p-6 border border-transparent light:border-grey/20
         transition-all duration-300 ease-in-out
         ${isSelected ? "h-full overflow-hidden" : "flex flex-col items-center"}
       `}
@@ -45,7 +45,9 @@ const TrendCard: React.FC<TrendCardProps> = ({
                 <div className={`rounded-full p-2 ${info.color}`}>
                   <Icon className={`h-5 w-5 ${info.textColor}`} />
                 </div>
-                <h3 className="text-xl font-light text-white">{info.title}</h3>
+                <h3 className="text-xl font-light text-white light:text-black-3">
+                  {info.title}
+                </h3>
                 <span className="text-sm text-grey">({data.length})</span>
               </div>
               <button
@@ -53,7 +55,7 @@ const TrendCard: React.FC<TrendCardProps> = ({
                   e.stopPropagation();
                   onClose();
                 }}
-                className="text-grey hover:text-white transition-colors"
+                className="text-grey hover:text-white light:hover:text-black-3 transition-colors"
               >
                 <X className="h-5 w-5" />
               </button>
@@ -65,7 +67,7 @@ const TrendCard: React.FC<TrendCardProps> = ({
             <div className={`rounded-full p-3 ${info.color} mb-4`}>
               <Icon className={`h-6 w-6 ${info.textColor}`} />
             </div>
-            <h3 className="text-2xl font-light text-white mb-2">
+            <h3 className="text-2xl font-light text-white light:text-black-3 mb-2">
               {data.length}
             </h3>
             <p className="text-sm text-grey text-center">{info.title}</p>

--- a/src/components/companies/sectors/trends/TrendCompanyList.tsx
+++ b/src/components/companies/sectors/trends/TrendCompanyList.tsx
@@ -42,11 +42,11 @@ const TrendCompanyList: React.FC<TrendCompanyListProps> = ({
             return (
               <div
                 key={company.wikidataId}
-                className="bg-black-1 rounded-lg px-4 py-3 text-sm"
+                className="bg-black-1 light:bg-grey/20 rounded-lg px-4 py-3 text-sm border border-transparent light:border-grey/20"
               >
                 <div className="flex justify-between items-start mb-2">
                   <Link to={`/companies/${company.wikidataId}`}>
-                    <div className="font-medium text-white hover:scale-105">
+                    <div className="font-medium text-white light:text-black-3 hover:scale-105">
                       {company.name}
                     </div>
                   </Link>
@@ -68,12 +68,12 @@ const TrendCompanyList: React.FC<TrendCompanyListProps> = ({
             return (
               <div
                 key={company.wikidataId}
-                className="bg-black-1 rounded-lg px-4 py-3 text-sm"
+                className="bg-black-1 light:bg-grey/20 rounded-lg px-4 py-3 text-sm border border-transparent light:border-grey/20"
               >
                 {" "}
                 <Link to={`/companies/${company.wikidataId}`}>
                   <div className="flex justify-between items-start mb-2">
-                    <div className="font-medium text-white hover:scale-105">
+                    <div className="font-medium text-white light:text-black-3 hover:scale-105">
                       {company.name}
                     </div>
 

--- a/src/components/landing/FlipCard.tsx
+++ b/src/components/landing/FlipCard.tsx
@@ -66,7 +66,7 @@ export function FlipCard({
         {/* Front of card */}
         <div
           className={cn(
-            "absolute inset-0 dark:bg-black-2 bg-grey/5 rounded-level-2 p-4 md:p-6 border-2 flex flex-col",
+            "absolute inset-0 bg-black-2 light:bg-grey/5 rounded-level-2 p-4 md:p-6 border-2 flex flex-col",
             borderColor,
           )}
           style={{
@@ -118,10 +118,10 @@ export function FlipCard({
         >
           <div className="flex flex-col items-center justify-center h-full text-center">
             <Icon
-              className="h-8 w-8 md:h-12 md:w-12 dark:text-white text-black-3 mb-4 md:mb-6"
+              className="h-8 w-8 md:h-12 md:w-12 text-white light:text-black-3 mb-4 md:mb-6"
               strokeWidth={1.5}
             />
-            <Text className="text-sm md:text-base dark:text-white text-black-3 leading-relaxed max-w-md">
+            <Text className="text-sm md:text-base text-white light:text-black-3 leading-relaxed max-w-md">
               {description}
             </Text>
           </div>

--- a/src/components/landing/FlipCard.tsx
+++ b/src/components/landing/FlipCard.tsx
@@ -118,10 +118,10 @@ export function FlipCard({
         >
           <div className="flex flex-col items-center justify-center h-full text-center">
             <Icon
-              className="h-8 w-8 md:h-12 md:w-12 text-white mb-4 md:mb-6"
+              className="h-8 w-8 md:h-12 md:w-12 dark:text-white text-black-3 mb-4 md:mb-6"
               strokeWidth={1.5}
             />
-            <Text className="text-sm md:text-base text-white leading-relaxed max-w-md">
+            <Text className="text-sm md:text-base dark:text-white text-black-3 leading-relaxed max-w-md">
               {description}
             </Text>
           </div>

--- a/src/components/landing/FlipCard.tsx
+++ b/src/components/landing/FlipCard.tsx
@@ -66,7 +66,7 @@ export function FlipCard({
         {/* Front of card */}
         <div
           className={cn(
-            "absolute inset-0 bg-black-2 rounded-level-2 p-4 md:p-6 border-2 flex flex-col",
+            "absolute inset-0 dark:bg-black-2 bg-grey/5 rounded-level-2 p-4 md:p-6 border-2 flex flex-col",
             borderColor,
           )}
           style={{

--- a/src/components/landing/LandingPageCTA.tsx
+++ b/src/components/landing/LandingPageCTA.tsx
@@ -36,7 +36,7 @@ export function LandingPageCTA() {
   return (
     <LandingSection innerClassName="flex flex-col items-center max-w-4xl mx-auto space-y-8">
       {/* Heading */}
-      <h2 className="text-4xl md:text-5xl font-light tracking-tight text-white">
+      <h2 className="text-4xl md:text-5xl font-light tracking-tight dark:text-white text-black-3">
         {t("landingPage.ctaSection.title")}
       </h2>
 

--- a/src/components/landing/LandingPageCTA.tsx
+++ b/src/components/landing/LandingPageCTA.tsx
@@ -36,7 +36,7 @@ export function LandingPageCTA() {
   return (
     <LandingSection innerClassName="flex flex-col items-center max-w-4xl mx-auto space-y-8">
       {/* Heading */}
-      <h2 className="text-4xl md:text-5xl font-light tracking-tight dark:text-white text-black-3">
+      <h2 className="text-4xl md:text-5xl font-light tracking-tight text-white light:text-black-3">
         {t("landingPage.ctaSection.title")}
       </h2>
 

--- a/src/components/landing/LandingSection.tsx
+++ b/src/components/landing/LandingSection.tsx
@@ -15,7 +15,7 @@ export function LandingSection({
   return (
     <section
       className={cn(
-        "flex flex-col min-h-screen items-center justify-center bg-white dark:bg-black text-center px-4 py-16",
+        "flex flex-col min-h-screen items-center justify-center bg-black light:bg-white text-center px-4 py-16",
         className,
       )}
     >

--- a/src/components/landing/LandingSection.tsx
+++ b/src/components/landing/LandingSection.tsx
@@ -15,7 +15,7 @@ export function LandingSection({
   return (
     <section
       className={cn(
-        "flex flex-col min-h-screen items-center justify-center bg-black text-center px-4 py-16",
+        "flex flex-col min-h-screen items-center justify-center bg-white dark:bg-black text-center px-4 py-16",
         className,
       )}
     >

--- a/src/components/landing/SiteFeatures.tsx
+++ b/src/components/landing/SiteFeatures.tsx
@@ -64,7 +64,7 @@ const SiteFeatures = () => {
           return (
             <div
               key={index}
-              className="flex flex-col bg-black-2 rounded-level-2 h-48 md:min-h-64 p-4 items-center justify-center"
+              className="flex flex-col dark:bg-black-2 bg-grey/5 rounded-level-2 h-48 md:min-h-64 p-4 items-center justify-center border dark:border-transparent border-grey/10"
             >
               <span
                 className={`${feature.iconBgColor} w-10 h-10 md:w-16 md:h-16 rounded-full flex items-center justify-center mb-2 md:mb-4`}

--- a/src/components/landing/SiteFeatures.tsx
+++ b/src/components/landing/SiteFeatures.tsx
@@ -64,7 +64,7 @@ const SiteFeatures = () => {
           return (
             <div
               key={index}
-              className="flex flex-col dark:bg-black-2 bg-grey/5 rounded-level-2 h-48 md:min-h-64 p-4 items-center justify-center border dark:border-transparent border-grey/10"
+              className="flex flex-col bg-black-2 light:bg-grey/5 rounded-level-2 h-48 md:min-h-64 p-4 items-center justify-center border border-transparent light:border-grey/10"
             >
               <span
                 className={`${feature.iconBgColor} w-10 h-10 md:w-16 md:h-16 rounded-full flex items-center justify-center mb-2 md:mb-4`}

--- a/src/components/layout/AccordionGroup.tsx
+++ b/src/components/layout/AccordionGroup.tsx
@@ -18,8 +18,8 @@ export function AccordionGroup({
 }: AccordionGroupProps) {
   return (
     <AccordionItem value={value} className="border-none">
-      <AccordionTrigger className="dark:bg-black-2 bg-grey/10 rounded-level-2 p-8 hover:no-underline dark:hover:bg-black-1 hover:bg-grey/20 data-[state=open]:dark:bg-black-1 data-[state=open]:bg-grey/20">
-        <Text variant="h4" className="dark:text-white text-black-3">
+      <AccordionTrigger className="bg-black-2 light:bg-grey/10 rounded-level-2 p-8 hover:no-underline hover:bg-black-1 light:hover:bg-grey/20 data-[state=open]:bg-black-1 data-[state=open]:bg-grey/20">
+        <Text variant="h4" className="text-white light:text-black-3">
           {title}
         </Text>
       </AccordionTrigger>

--- a/src/components/layout/AccordionGroup.tsx
+++ b/src/components/layout/AccordionGroup.tsx
@@ -18,7 +18,7 @@ export function AccordionGroup({
 }: AccordionGroupProps) {
   return (
     <AccordionItem value={value} className="border-none">
-      <AccordionTrigger className="dark:bg-black-2 bg-white rounded-level-2 p-8 hover:no-underline dark:hover:bg-black-1 hover:bg-grey/10 data-[state=open]:dark:bg-black-1 data-[state=open]:bg-grey/10">
+      <AccordionTrigger className="dark:bg-black-2 bg-grey/10 rounded-level-2 p-8 hover:no-underline dark:hover:bg-black-1 hover:bg-grey/20 data-[state=open]:dark:bg-black-1 data-[state=open]:bg-grey/20">
         <Text variant="h4" className="dark:text-white text-black-3">
           {title}
         </Text>

--- a/src/components/layout/AccordionGroup.tsx
+++ b/src/components/layout/AccordionGroup.tsx
@@ -18,8 +18,10 @@ export function AccordionGroup({
 }: AccordionGroupProps) {
   return (
     <AccordionItem value={value} className="border-none">
-      <AccordionTrigger className="bg-black-2 rounded-level-2 p-8 hover:no-underline hover:bg-black-1 data-[state=open]:bg-black-1">
-        <Text variant="h4">{title}</Text>
+      <AccordionTrigger className="dark:bg-black-2 bg-white rounded-level-2 p-8 hover:no-underline dark:hover:bg-black-1 hover:bg-grey/10 data-[state=open]:dark:bg-black-1 data-[state=open]:bg-grey/10">
+        <Text variant="h4" className="dark:text-white text-black-3">
+          {title}
+        </Text>
       </AccordionTrigger>
       <AccordionContent className="p-4 md:p-8">{children}</AccordionContent>
     </AccordionItem>

--- a/src/components/layout/CardInfo.tsx
+++ b/src/components/layout/CardInfo.tsx
@@ -29,7 +29,7 @@ export function CardInfo({
 
   return (
     <div className="space-y-2">
-      <div className="flex items-center gap-2 dark:text-grey text-black-1 mb-2 text-lg">
+      <div className="flex items-center gap-2 text-grey light:text-black-1 mb-2 text-lg">
         {icon}
         <span>{title}</span>
         {suffix}
@@ -44,7 +44,7 @@ export function CardInfo({
           <span className={cn(textColor)}>
             {value}
             {unit && (
-              <span className="text-lg dark:text-grey text-black-1 ml-1">
+              <span className="text-lg text-grey light:text-black-1 ml-1">
                 {unit}
               </span>
             )}
@@ -55,7 +55,7 @@ export function CardInfo({
             )}
           </span>
         ) : (
-          <span className="dark:text-grey text-black-1">
+          <span className="text-grey light:text-black-1">
             {t("companies.card.noData")}
           </span>
         )}

--- a/src/components/layout/CardInfo.tsx
+++ b/src/components/layout/CardInfo.tsx
@@ -29,7 +29,7 @@ export function CardInfo({
 
   return (
     <div className="space-y-2">
-      <div className="flex items-center gap-2 text-grey mb-2 text-lg">
+      <div className="flex items-center gap-2 dark:text-grey text-black-1 mb-2 text-lg">
         {icon}
         <span>{title}</span>
         {suffix}
@@ -43,7 +43,11 @@ export function CardInfo({
         {value ? (
           <span className={cn(textColor)}>
             {value}
-            {unit && <span className="text-lg text-grey ml-1">{unit}</span>}
+            {unit && (
+              <span className="text-lg dark:text-grey text-black-1 ml-1">
+                {unit}
+              </span>
+            )}
             {isAIGenerated && (
               <span className="ml-2 absolute">
                 <AiIcon size="sm" className="absolute top-0" />
@@ -51,7 +55,9 @@ export function CardInfo({
             )}
           </span>
         ) : (
-          <span className="text-grey">{t("companies.card.noData")}</span>
+          <span className="dark:text-grey text-black-1">
+            {t("companies.card.noData")}
+          </span>
         )}
       </div>
     </div>

--- a/src/components/layout/ContentCard.tsx
+++ b/src/components/layout/ContentCard.tsx
@@ -94,7 +94,7 @@ export function ContentCard({ item, basePath }: ContentCardProps) {
         href={link}
         target="_blank"
         rel="noopener noreferrer"
-        className="group dark:bg-black-2 bg-white rounded-level-2 overflow-hidden transition-all duration-300 hover:scale-[1.02] hover:shadow-[0_0_30px_rgba(153,207,255,0.15)] dark:hover:bg-[#1a1a1a] hover:bg-grey/5 border dark:border-transparent border-grey/20"
+        className="group bg-black-2 light:bg-white rounded-level-2 overflow-hidden transition-all duration-300 hover:scale-[1.02] hover:shadow-[0_0_30px_rgba(153,207,255,0.15)] hover:bg-[#1a1a1a] light:hover:bg-grey/5 border border-transparent light:border-grey/20"
       >
         {cardContent}
       </a>

--- a/src/components/layout/ContentCard.tsx
+++ b/src/components/layout/ContentCard.tsx
@@ -94,7 +94,7 @@ export function ContentCard({ item, basePath }: ContentCardProps) {
         href={link}
         target="_blank"
         rel="noopener noreferrer"
-        className="group bg-black-2 rounded-level-2 overflow-hidden transition-all duration-300 hover:scale-[1.02] hover:shadow-[0_0_30px_rgba(153,207,255,0.15)] hover:bg-[#1a1a1a]"
+        className="group dark:bg-black-2 bg-white rounded-level-2 overflow-hidden transition-all duration-300 hover:scale-[1.02] hover:shadow-[0_0_30px_rgba(153,207,255,0.15)] dark:hover:bg-[#1a1a1a] hover:bg-grey/5 border dark:border-transparent border-grey/20"
       >
         {cardContent}
       </a>

--- a/src/components/layout/DataSelector.tsx
+++ b/src/components/layout/DataSelector.tsx
@@ -47,9 +47,9 @@ export function DataSelector<T>({
   };
 
   return (
-    <div className="bg-black-2 rounded-2xl p-4 mb-6">
+    <div className="dark:bg-black-2 bg-grey/10 rounded-2xl p-4 mb-6">
       <div className="flex flex-col gap-2">
-        <div className="flex items-center gap-2 text-xs text-gray-500 px-2 pb-2">
+        <div className="flex items-center gap-2 text-xs dark:text-gray-500 text-grey px-2 pb-2">
           {icon}
           <label className="font-medium">{label}</label>
         </div>
@@ -57,18 +57,18 @@ export function DataSelector<T>({
         <div className="relative" ref={dropdownRef}>
           <button
             onClick={() => setIsOpen(!isOpen)}
-            className="w-full flex items-center justify-between p-3 rounded-xl bg-black-1 text-white transition-colors"
+            className="w-full flex items-center justify-between p-3 rounded-xl dark:bg-black-1 bg-grey/10 dark:text-white text-black-3 transition-colors"
           >
             <span className="text-left font-medium">
               {getItemLabel(selectedItem)}
             </span>
             <ChevronDown
-              className={`w-5 h-5 text-white transition-transform ${isOpen ? "rotate-180" : ""}`}
+              className={`w-5 h-5 dark:text-white text-black-3 transition-transform ${isOpen ? "rotate-180" : ""}`}
             />
           </button>
 
           {isOpen && (
-            <div className="absolute z-50 w-full mt-2 bg-black-1 rounded-xl shadow-lg overflow-hidden backdrop-blur-sm">
+            <div className="absolute z-50 w-full mt-2 dark:bg-black-1 bg-white rounded-xl shadow-lg overflow-hidden backdrop-blur-sm border dark:border-white/10 border-grey/20">
               {items.map((item) => {
                 const isSelected =
                   getItemKey(item) === getItemKey(selectedItem);
@@ -78,13 +78,13 @@ export function DataSelector<T>({
                     onClick={() => handleItemSelect(item)}
                     className={`w-full text-left px-4 py-3 text-sm transition-colors ${
                       isSelected
-                        ? "bg-gray-700/80 text-blue-300"
-                        : "text-white hover:bg-gray-700/80"
+                        ? "dark:bg-gray-700/80 bg-blue-5/20 dark:text-blue-300 text-blue-2"
+                        : "dark:text-white text-black-3 dark:hover:bg-gray-700/80 hover:bg-grey/10"
                     }`}
                   >
                     <span className="font-medium">{getItemLabel(item)}</span>
                     {getItemDescription?.(item) && (
-                      <p className="text-xs text-white/50 mt-1">
+                      <p className="text-xs dark:text-white/50 text-black-3/50 mt-1">
                         {getItemDescription(item)}
                       </p>
                     )}
@@ -96,7 +96,7 @@ export function DataSelector<T>({
         </div>
 
         {getItemDetailedDescription?.(selectedItem) && (
-          <p className="leading-relaxed text-sm px-2 py-1 text-gray-500">
+          <p className="leading-relaxed text-sm px-2 py-1 dark:text-gray-500 text-grey">
             {getItemDetailedDescription(selectedItem)}
           </p>
         )}

--- a/src/components/layout/DataSelector.tsx
+++ b/src/components/layout/DataSelector.tsx
@@ -78,7 +78,7 @@ export function DataSelector<T>({
                     onClick={() => handleItemSelect(item)}
                     className={`w-full text-left px-4 py-3 text-sm transition-colors ${
                       isSelected
-                        ? "bg-gray-700/80 light:bg-blue-5/20 text-blue-300 light:text-blue-2"
+                        ? "bg-gray-700/80 light:bg-blue-5/20 text-blue-300 light:text-blue-4"
                         : "text-white light:text-black-3 hover:bg-gray-700/80 light:hover:bg-grey/10"
                     }`}
                   >

--- a/src/components/layout/DataSelector.tsx
+++ b/src/components/layout/DataSelector.tsx
@@ -47,9 +47,9 @@ export function DataSelector<T>({
   };
 
   return (
-    <div className="dark:bg-black-2 bg-grey/10 rounded-2xl p-4 mb-6">
+    <div className="bg-black-2 light:bg-grey/10 rounded-2xl p-4 mb-6">
       <div className="flex flex-col gap-2">
-        <div className="flex items-center gap-2 text-xs dark:text-gray-500 text-grey px-2 pb-2">
+        <div className="flex items-center gap-2 text-xs text-gray-500 light:text-grey px-2 pb-2">
           {icon}
           <label className="font-medium">{label}</label>
         </div>
@@ -57,18 +57,18 @@ export function DataSelector<T>({
         <div className="relative" ref={dropdownRef}>
           <button
             onClick={() => setIsOpen(!isOpen)}
-            className="w-full flex items-center justify-between p-3 rounded-xl dark:bg-black-1 bg-grey/10 dark:text-white text-black-3 transition-colors"
+            className="w-full flex items-center justify-between p-3 rounded-xl bg-black-1 light:bg-grey/10 text-white light:text-black-3 transition-colors"
           >
             <span className="text-left font-medium">
               {getItemLabel(selectedItem)}
             </span>
             <ChevronDown
-              className={`w-5 h-5 dark:text-white text-black-3 transition-transform ${isOpen ? "rotate-180" : ""}`}
+              className={`w-5 h-5 text-white light:text-black-3 transition-transform ${isOpen ? "rotate-180" : ""}`}
             />
           </button>
 
           {isOpen && (
-            <div className="absolute z-50 w-full mt-2 dark:bg-black-1 bg-white rounded-xl shadow-lg overflow-hidden backdrop-blur-sm border dark:border-white/10 border-grey/20">
+            <div className="absolute z-50 w-full mt-2 bg-black-1 light:bg-white rounded-xl shadow-lg overflow-hidden backdrop-blur-sm border border-white/10 light:border-grey/20">
               {items.map((item) => {
                 const isSelected =
                   getItemKey(item) === getItemKey(selectedItem);
@@ -78,13 +78,13 @@ export function DataSelector<T>({
                     onClick={() => handleItemSelect(item)}
                     className={`w-full text-left px-4 py-3 text-sm transition-colors ${
                       isSelected
-                        ? "dark:bg-gray-700/80 bg-blue-5/20 dark:text-blue-300 text-blue-2"
-                        : "dark:text-white text-black-3 dark:hover:bg-gray-700/80 hover:bg-grey/10"
+                        ? "bg-gray-700/80 light:bg-blue-5/20 text-blue-300 light:text-blue-2"
+                        : "text-white light:text-black-3 hover:bg-gray-700/80 light:hover:bg-grey/10"
                     }`}
                   >
                     <span className="font-medium">{getItemLabel(item)}</span>
                     {getItemDescription?.(item) && (
-                      <p className="text-xs dark:text-white/50 text-black-3/50 mt-1">
+                      <p className="text-xs text-white/50 light:text-black-3/50 mt-1">
                         {getItemDescription(item)}
                       </p>
                     )}
@@ -96,7 +96,7 @@ export function DataSelector<T>({
         </div>
 
         {getItemDetailedDescription?.(selectedItem) && (
-          <p className="leading-relaxed text-sm px-2 py-1 dark:text-gray-500 text-grey">
+          <p className="leading-relaxed text-sm px-2 py-1 text-gray-500 light:text-grey">
             {getItemDetailedDescription(selectedItem)}
           </p>
         )}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -17,18 +17,18 @@ function SocialLinks() {
           href={href}
           target="_blank"
           rel="noopener noreferrer"
-          className="p-2 md:p-3 dark:bg-black-1 bg-grey/10 rounded-full dark:hover:bg-black-1/80 hover:bg-grey/20 transition-colors"
+          className="p-2 md:p-3 bg-black-1 light:bg-grey/10 rounded-full hover:bg-black-1/80 light:hover:bg-grey/20 transition-colors"
           title={title}
         >
           {typeof Icon === "string" ? (
             <img
               src={Icon}
               alt={title}
-              className="w-5 h-5 md:w-6 md:h-6 dark:brightness-100 brightness-0"
+              className="w-5 h-5 md:w-6 md:h-6 brightness-100 light:brightness-0"
             />
           ) : (
             <Icon
-              className="w-5 h-5 md:w-6 md:h-6 dark:text-white text-black-2"
+              className="w-5 h-5 md:w-6 md:h-6 text-white light:text-black-2"
               aria-label={title}
             />
           )}
@@ -71,7 +71,7 @@ function PartnerLogos({ prefersReducedMotion, isMobile }: PartnerLogoProps) {
           className="flex items-center justify-center"
         >
           <img
-            className="w-28 h-12 object-contain dark:brightness-100 brightness-0"
+            className="w-28 h-12 object-contain brightness-100 light:brightness-0"
             src={src}
             alt={alt}
           />
@@ -89,24 +89,24 @@ export function Footer() {
   const { isMobile } = useScreenSize();
 
   return (
-    <footer className="relative w-full z-10 dark:bg-black-2 bg-grey/10 border-t dark:border-transparent border-grey/20 py-4 md:py-8">
+    <footer className="relative w-full z-10 bg-black-2 light:bg-grey/10 border-t border-transparent light:border-grey/20 py-4 md:py-8">
       <div className="container mx-auto px-4 space-y-4 md:space-y-8 flex flex-col w-screen items-center text-center">
         {/* Contact Section */}
         <div className="space-y-2 md:space-y-4">
           <Text
             variant="h6"
-            className="dark:text-grey text-black-2 md:text-base"
+            className="text-grey light:text-black-2 md:text-base"
           >
             {t("footer.contactUs")}
           </Text>
           <SocialLinks />
-          <div className="text-sm md:text-base max-w-full md:max-w-2xl font-light dark:text-grey text-black-2">
+          <div className="text-sm md:text-base max-w-full md:max-w-2xl font-light text-grey light:text-black-2">
             <Trans
               i18nKey="footer.description"
               components={[
                 <a
                   title="Klimatkollen's Github"
-                  className="underline dark:hover:text-white hover:text-black-3 dark:text-grey text-black-2 transition-colors"
+                  className="underline hover:text-white light:hover:text-black-3 text-grey light:text-black-2 transition-colors"
                   href="https://github.com/Klimatbyran/"
                   target="_blank"
                   rel="noopener noreferrer"
@@ -122,34 +122,34 @@ export function Footer() {
             {t("footer.supporters")}
           </Text>
           {prefersReducedMotion || isMobile ? null : (
-            <div className="absolute left-20 md:left-0 top-0 bottom-0 w-24 md:w-16 bg-gradient-to-r  dark:from-[var(--black-2)] to-transparent pointer-events-none z-10" />
+            <div className="absolute left-20 md:left-0 top-0 bottom-0 w-24 md:w-16 bg-gradient-to-r  from-[var(--black-2)] to-transparent pointer-events-none z-10" />
           )}
           <PartnerLogos
             prefersReducedMotion={prefersReducedMotion}
             isMobile={isMobile}
           />
           {prefersReducedMotion || isMobile ? null : (
-            <div className="absolute right-20 md:right-0 top-0 bottom-0 w-24 md:w-16 bg-gradient-to-l dark:from-[var(--black-2)] to-transparent pointer-events-none z-10" />
+            <div className="absolute right-20 md:right-0 top-0 bottom-0 w-24 md:w-16 bg-gradient-to-l from-[var(--black-2)] to-transparent pointer-events-none z-10" />
           )}
         </div>
 
         {/* Footer Links */}
-        <div className="flex flex-col md:flex-row gap-4 md:gap-8 dark:text-grey text-black-2 items-center">
+        <div className="flex flex-col md:flex-row gap-4 md:gap-8 text-grey light:text-black-2 items-center">
           <a
             href="/privacy"
-            className="dark:hover:text-white hover:text-black-3 transition-colors"
+            className="hover:text-white light:hover:text-black-3 transition-colors"
           >
             {t("footer.privacyTerms")}
           </a>
           <a
             href="/license"
-            className="dark:hover:text-white hover:text-black-3 transition-colors"
+            className="hover:text-white light:hover:text-black-3 transition-colors"
           >
             {t("footer.internationalLicense")}
           </a>
           <a
             href="https://creativecommons.org/licenses/by-sa/4.0/"
-            className="dark:hover:text-white hover:text-black-3 transition-colors"
+            className="hover:text-white light:hover:text-black-3 transition-colors"
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -158,7 +158,7 @@ export function Footer() {
           {!token && (
             <a
               onClick={() => login()}
-              className="dark:hover:text-white hover:text-black-3 transition-colors cursor-pointer"
+              className="hover:text-white light:hover:text-black-3 transition-colors cursor-pointer"
             >
               {t("footer.login")}
             </a>
@@ -169,13 +169,13 @@ export function Footer() {
                 logout();
                 navigate("/");
               }}
-              className="dark:hover:text-white hover:text-black-3 cursor-pointer transition-colors"
+              className="hover:text-white light:hover:text-black-3 cursor-pointer transition-colors"
             >
               {t("footer.logout")}
             </a>
           )}
           {token && user && (
-            <div className="dark:hover:text-white hover:text-black-3 ms-auto flex items-center dark:text-grey text-black-2">
+            <div className="hover:text-white light:hover:text-black-3 ms-auto flex items-center text-grey light:text-black-2">
               <span>
                 {t("footer.welcome")}, {user?.name ?? ""}
               </span>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -82,17 +82,20 @@ export function Footer() {
       <div className="container mx-auto px-4 space-y-4 md:space-y-8 flex flex-col w-screen items-center text-center">
         {/* Contact Section */}
         <div className="space-y-2 md:space-y-4">
-          <Text variant="h6" className="text-grey md:text-base">
+          <Text
+            variant="h6"
+            className="dark:text-grey text-black-2 md:text-base"
+          >
             {t("footer.contactUs")}
           </Text>
           <SocialLinks />
-          <div className="text-sm md:text-base max-w-full md:max-w-2xl font-light text-grey">
+          <div className="text-sm md:text-base max-w-full md:max-w-2xl font-light dark:text-grey text-black-2">
             <Trans
               i18nKey="footer.description"
               components={[
                 <a
                   title="Klimatkollen's Github"
-                  className="underline dark:hover:text-white hover:text-black-3 transition-colors"
+                  className="underline dark:hover:text-white hover:text-black-3 dark:text-grey text-black-2 transition-colors"
                   href="https://github.com/Klimatbyran/"
                   target="_blank"
                   rel="noopener noreferrer"
@@ -120,7 +123,7 @@ export function Footer() {
         </div>
 
         {/* Footer Links */}
-        <div className="flex flex-col md:flex-row gap-4 md:gap-8 text-grey items-center">
+        <div className="flex flex-col md:flex-row gap-4 md:gap-8 dark:text-grey text-black-2 items-center">
           <a
             href="/privacy"
             className="dark:hover:text-white hover:text-black-3 transition-colors"
@@ -161,7 +164,7 @@ export function Footer() {
             </a>
           )}
           {token && user && (
-            <div className="dark:hover:text-white hover:text-black-3 ms-auto flex items-center">
+            <div className="dark:hover:text-white hover:text-black-3 ms-auto flex items-center dark:text-grey text-black-2">
               <span>
                 {t("footer.welcome")}, {user?.name ?? ""}
               </span>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -78,7 +78,7 @@ export function Footer() {
   const { isMobile } = useScreenSize();
 
   return (
-    <footer className="relative w-full z-10 dark:bg-black-2 bg-white border-t dark:border-transparent border-grey/20 py-4 md:py-8">
+    <footer className="relative w-full z-10 dark:bg-black-2 bg-grey/10 border-t dark:border-transparent border-grey/20 py-4 md:py-8">
       <div className="container mx-auto px-4 space-y-4 md:space-y-8 flex flex-col w-screen items-center text-center">
         {/* Contact Section */}
         <div className="space-y-2 md:space-y-4">

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -122,14 +122,14 @@ export function Footer() {
             {t("footer.supporters")}
           </Text>
           {prefersReducedMotion || isMobile ? null : (
-            <div className="absolute left-20 md:left-0 top-0 bottom-0 w-24 md:w-16 bg-gradient-to-r from-[var(--black-2)] to-transparent pointer-events-none z-10" />
+            <div className="absolute left-20 md:left-0 top-0 bottom-0 w-24 md:w-16 bg-gradient-to-r  dark:from-[var(--black-2)] to-transparent pointer-events-none z-10" />
           )}
           <PartnerLogos
             prefersReducedMotion={prefersReducedMotion}
             isMobile={isMobile}
           />
           {prefersReducedMotion || isMobile ? null : (
-            <div className="absolute right-20 md:right-0 top-0 bottom-0 w-24 md:w-16 bg-gradient-to-l from-[var(--black-2)] to-transparent pointer-events-none z-10" />
+            <div className="absolute right-20 md:right-0 top-0 bottom-0 w-24 md:w-16 bg-gradient-to-l dark:from-[var(--black-2)] to-transparent pointer-events-none z-10" />
           )}
         </div>
 

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -122,14 +122,14 @@ export function Footer() {
             {t("footer.supporters")}
           </Text>
           {prefersReducedMotion || isMobile ? null : (
-            <div className="absolute left-20 md:left-0 top-0 bottom-0 w-24 md:w-16 bg-gradient-to-r  from-[var(--black-2)] to-transparent pointer-events-none z-10" />
+            <div className="absolute left-20 md:left-0 top-0 bottom-0 w-24 md:w-16 bg-gradient-to-r from-[var(--black-2)] light:from-transparent to-transparent pointer-events-none z-10" />
           )}
           <PartnerLogos
             prefersReducedMotion={prefersReducedMotion}
             isMobile={isMobile}
           />
           {prefersReducedMotion || isMobile ? null : (
-            <div className="absolute right-20 md:right-0 top-0 bottom-0 w-24 md:w-16 bg-gradient-to-l from-[var(--black-2)] to-transparent pointer-events-none z-10" />
+            <div className="absolute right-20 md:right-0 top-0 bottom-0 w-24 md:w-16 bg-gradient-to-l from-[var(--black-2)] light:from-transparent to-transparent pointer-events-none z-10" />
           )}
         </div>
 

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -17,7 +17,7 @@ function SocialLinks() {
           href={href}
           target="_blank"
           rel="noopener noreferrer"
-          className="p-2 md:p-3 bg-black-1 rounded-full hover:bg-black-1/80 transition-colors"
+          className="p-2 md:p-3 dark:bg-black-1 bg-grey/10 rounded-full dark:hover:bg-black-1/80 hover:bg-grey/20 transition-colors"
           title={title}
         >
           {typeof Icon === "string" ? (
@@ -78,7 +78,7 @@ export function Footer() {
   const { isMobile } = useScreenSize();
 
   return (
-    <footer className="relative w-full z-10 bg-black-2 py-4 md:py-8">
+    <footer className="relative w-full z-10 dark:bg-black-2 bg-white border-t dark:border-transparent border-grey/20 py-4 md:py-8">
       <div className="container mx-auto px-4 space-y-4 md:space-y-8 flex flex-col w-screen items-center text-center">
         {/* Contact Section */}
         <div className="space-y-2 md:space-y-4">
@@ -92,7 +92,7 @@ export function Footer() {
               components={[
                 <a
                   title="Klimatkollen's Github"
-                  className="underline hover:text-white transition-colors"
+                  className="underline dark:hover:text-white hover:text-black-3 transition-colors"
                   href="https://github.com/Klimatbyran/"
                   target="_blank"
                   rel="noopener noreferrer"
@@ -121,15 +121,21 @@ export function Footer() {
 
         {/* Footer Links */}
         <div className="flex flex-col md:flex-row gap-4 md:gap-8 text-grey items-center">
-          <a href="/privacy" className="hover:text-white transition-colors">
+          <a
+            href="/privacy"
+            className="dark:hover:text-white hover:text-black-3 transition-colors"
+          >
             {t("footer.privacyTerms")}
           </a>
-          <a href="/license" className="hover:text-white transition-colors">
+          <a
+            href="/license"
+            className="dark:hover:text-white hover:text-black-3 transition-colors"
+          >
             {t("footer.internationalLicense")}
           </a>
           <a
             href="https://creativecommons.org/licenses/by-sa/4.0/"
-            className="hover:text-white transition-colors"
+            className="dark:hover:text-white hover:text-black-3 transition-colors"
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -138,7 +144,7 @@ export function Footer() {
           {!token && (
             <a
               onClick={() => login()}
-              className="hover:text-white transition-colors cursor-pointer"
+              className="dark:hover:text-white hover:text-black-3 transition-colors cursor-pointer"
             >
               {t("footer.login")}
             </a>
@@ -149,13 +155,13 @@ export function Footer() {
                 logout();
                 navigate("/");
               }}
-              className="hover:text-white cursor-pointer transition-colors"
+              className="dark:hover:text-white hover:text-black-3 cursor-pointer transition-colors"
             >
               {t("footer.logout")}
             </a>
           )}
           {token && user && (
-            <div className="hover:text-white ms-auto flex items-center">
+            <div className="dark:hover:text-white hover:text-black-3 ms-auto flex items-center">
               <span>
                 {t("footer.welcome")}, {user?.name ?? ""}
               </span>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -21,9 +21,16 @@ function SocialLinks() {
           title={title}
         >
           {typeof Icon === "string" ? (
-            <img src={Icon} alt={title} className="w-5 h-5 md:w-6 md:h-6" />
+            <img
+              src={Icon}
+              alt={title}
+              className="w-5 h-5 md:w-6 md:h-6 dark:brightness-100 brightness-0"
+            />
           ) : (
-            <Icon className="w-5 h-5 md:w-6 md:h-6" aria-label={title} />
+            <Icon
+              className="w-5 h-5 md:w-6 md:h-6 dark:text-white text-black-2"
+              aria-label={title}
+            />
           )}
         </a>
       ))}
@@ -63,7 +70,11 @@ function PartnerLogos({ prefersReducedMotion, isMobile }: PartnerLogoProps) {
           rel="noreferrer"
           className="flex items-center justify-center"
         >
-          <img className="w-28 h-12 object-contain" src={src} alt={alt} />
+          <img
+            className="w-28 h-12 object-contain dark:brightness-100 brightness-0"
+            src={src}
+            alt={alt}
+          />
         </a>
       ))}
     </Wrapper>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -313,7 +313,8 @@ export function Header() {
           </NavigationMenuList>
           <div className="ml-4 h-full flex items-center">
             <HeaderSearchButton className="mx-2" />
-            <ThemeToggle className="hidden md:flex mx-2" />
+            {/* SHOW MODE TOGGLE */}
+            {/* <ThemeToggle className="hidden md:flex mx-2" /> */}
             <LanguageButtons className={"hidden md:flex mx-4 "} />
             <NewsletterPopover
               isOpen={isSignUpOpen}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -134,7 +134,7 @@ const SubLinksMenu = ({ sublinks }: { sublinks: NavSubLink[] }) => {
       {sublinks.map((sublink) => (
         <li
           key={sublink.path}
-          className="hover:bg-black-1 dark:hover:bg-black-1 hover:bg-grey/10 px-2 py-1.5 text-sm dark:text-white text-black-3"
+          className="hover:bg-black-1 light:hover:bg-grey/10 px-2 py-1.5 text-sm text-white light:text-black-3"
         >
           {sublink.path.startsWith("https://") ? (
             <a
@@ -215,17 +215,17 @@ export function Header() {
         onClick={() => changeLanguage("en")}
         className={cn(
           currentLanguage === "en" &&
-            "bg-black-1 dark:bg-black-1 bg-grey/20 rounded-full px-1",
+            "bg-black-1 light:bg-grey/20 rounded-full px-1",
         )}
       >
         🇬🇧
       </button>
-      <span className="text-grey dark:text-grey">|</span>
+      <span className="text-grey">|</span>
       <button
         onClick={() => changeLanguage("sv")}
         className={cn(
           currentLanguage === "sv" &&
-            "bg-black-1 dark:bg-black-1 bg-grey/20 rounded-full px-1",
+            "bg-black-1 light:bg-grey/20 rounded-full px-1",
         )}
       >
         🇸🇪
@@ -236,14 +236,14 @@ export function Header() {
   return (
     <header
       className={cn(
-        "fixed top-0 left-0 w-screen flex items-center justify-between dark:bg-black-2 bg-white border-b dark:border-black-1 border-grey/20 z-50",
+        "fixed top-0 left-0 w-screen flex items-center justify-between bg-black-2 light:bg-white border-b border-black-1 light:border-grey/20 z-50",
         "h-10 lg:h-12",
       )}
     >
       <div className="container lg:mx-auto px-4 flex justify-between">
         <LocalizedLink
           to="/"
-          className="flex items-center gap-2 text-base font-medium dark:text-white text-black-3"
+          className="flex items-center gap-2 text-base font-medium text-white light:text-black-3"
         >
           Klimatkollen
         </LocalizedLink>
@@ -260,19 +260,19 @@ export function Header() {
                   <NavigationMenuTrigger
                     className={cn(
                       "flex gap-2 p-3",
-                      "dark:data-[state=open]:bg-black-1 data-[state=open]:bg-grey/10 data-[state=closed]:bg-transparent",
-                      "focus:!text-black-3 dark:focus:!text-white",
+                      "data-[state=open]:bg-black-1 light:data-[state=open]:bg-grey/10 data-[state=closed]:bg-transparent",
+                      "light:focus:!text-black-3 focus:!text-white",
                       location.pathname.startsWith(
                         localizedPath(currentLanguage, item.path),
                       )
-                        ? "dark:text-white text-black-3"
-                        : "text-grey dark:hover:text-white hover:text-black-3",
+                        ? "text-white light:text-black-3"
+                        : "text-grey hover:text-white light:hover:text-black-3",
                     )}
                   >
                     {item.icon}
                     {t(item.label)}
                   </NavigationMenuTrigger>
-                  <NavigationMenuContent className="min-w-56 w-full p-3 top-12 dark:bg-black-2 bg-white">
+                  <NavigationMenuContent className="min-w-56 w-full p-3 top-12 bg-black-2 light:bg-white">
                     <SubLinksMenu sublinks={item.sublinks} />
                   </NavigationMenuContent>
                 </NavigationMenuItem>
@@ -284,8 +284,8 @@ export function Header() {
                     location.pathname.startsWith(
                       localizedPath(currentLanguage, item.path),
                     )
-                      ? "dark:text-white text-black-3"
-                      : "text-grey dark:hover:text-white hover:text-black-3",
+                      ? "text-white light:text-black-3"
+                      : "text-grey hover:text-white light:hover:text-black-3",
                   )}
                 >
                   <NavigationMenuLink asChild>
@@ -302,7 +302,7 @@ export function Header() {
             )}
             {user && (
               <NavigationMenuItem>
-                <NavigationMenuTrigger className="flex items-center gap-2 px-3 py-3 h-full transition-all text-sm cursor-pointer text-grey dark:hover:text-white hover:text-black-3">
+                <NavigationMenuTrigger className="flex items-center gap-2 px-3 py-3 h-full transition-all text-sm cursor-pointer text-grey hover:text-white light:hover:text-black-3">
                   <span>Internal</span>
                 </NavigationMenuTrigger>
                 <NavigationMenuContent>
@@ -331,14 +331,14 @@ export function Header() {
         )}
 
         <button
-          className="lg:hidden dark:text-white text-black-3"
+          className="lg:hidden text-white light:text-black-3"
           onClick={toggleMenu}
           aria-label={menuOpen ? "Close menu" : "Open menu"}
         >
           {menuOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
         </button>
         {menuOpen && (
-          <div className="fixed inset-0 w-full h-full z-100 flex p-8 mt-10 dark:bg-black-2 bg-white">
+          <div className="fixed inset-0 w-full h-full z-100 flex p-8 mt-10 bg-black-2 light:bg-white">
             <div className="flex flex-col gap-6 text-lg w-full">
               <HeaderSearchButton
                 className="w-full"
@@ -353,7 +353,7 @@ export function Header() {
                   <LocalizedLink
                     to={link.path}
                     onClick={toggleMenu}
-                    className="flex items-center gap-2 cursor-pointer dark:text-white text-black-3"
+                    className="flex items-center gap-2 cursor-pointer text-white light:text-black-3"
                   >
                     {link.icon}
                     {t(link.label)}
@@ -364,7 +364,7 @@ export function Header() {
                         sublink.path.startsWith("https://") ? (
                           <a
                             href={sublink.path}
-                            className="flex items-center gap-2 text-sm text-grey dark:text-grey"
+                            className="flex items-center gap-2 text-sm text-grey"
                             target="_blank"
                             key={sublink.path}
                             onClick={toggleMenu}
@@ -376,7 +376,7 @@ export function Header() {
                             key={sublink.path}
                             to={sublink.path}
                             onClick={toggleMenu}
-                            className="flex items-center gap-2 text-sm text-grey dark:text-grey"
+                            className="flex items-center gap-2 text-sm text-grey"
                           >
                             {t(sublink.label)}
                           </LocalizedLink>
@@ -392,7 +392,7 @@ export function Header() {
                   setMenuOpen(false); // Close the menu
                   setIsSignUpOpen(true); // Open the newsletter popover
                 }}
-                className="flex items-center gap-2 text-blue-3 dark:text-blue-3"
+                className="flex items-center gap-2 text-blue-3"
               >
                 <Mail className="w-4 h-4" />
                 {t("header.newsletter")}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -261,6 +261,7 @@ export function Header() {
                     className={cn(
                       "flex gap-2 p-3",
                       "dark:data-[state=open]:bg-black-1 data-[state=open]:bg-grey/10 data-[state=closed]:bg-transparent",
+                      "focus:!text-black-3 dark:focus:!text-white",
                       location.pathname.startsWith(
                         localizedPath(currentLanguage, item.path),
                       )

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -19,6 +19,7 @@ import {
   NavigationMenuTrigger,
 } from "../ui/navigation-menu";
 import { stagingFeatureFlagEnabled } from "@/utils/ui/featureFlags";
+import { ThemeToggle } from "../ui/theme-toggle";
 
 interface NavSubLink {
   label: string;
@@ -131,7 +132,10 @@ const SubLinksMenu = ({ sublinks }: { sublinks: NavSubLink[] }) => {
   return (
     <ul>
       {sublinks.map((sublink) => (
-        <li key={sublink.path} className="hover:bg-black-1 px-2 py-1.5 text-sm">
+        <li
+          key={sublink.path}
+          className="hover:bg-black-1 dark:hover:bg-black-1 hover:bg-grey/10 px-2 py-1.5 text-sm dark:text-white text-black-3"
+        >
           {sublink.path.startsWith("https://") ? (
             <a
               href={sublink.path}
@@ -210,16 +214,18 @@ export function Header() {
       <button
         onClick={() => changeLanguage("en")}
         className={cn(
-          currentLanguage === "en" && "bg-black-1 rounded-full px-1",
+          currentLanguage === "en" &&
+            "bg-black-1 dark:bg-black-1 bg-grey/20 rounded-full px-1",
         )}
       >
         🇬🇧
       </button>
-      <span className="text-grey">|</span>
+      <span className="text-grey dark:text-grey">|</span>
       <button
         onClick={() => changeLanguage("sv")}
         className={cn(
-          currentLanguage === "sv" && "bg-black-1 rounded-full px-1",
+          currentLanguage === "sv" &&
+            "bg-black-1 dark:bg-black-1 bg-grey/20 rounded-full px-1",
         )}
       >
         🇸🇪
@@ -230,14 +236,14 @@ export function Header() {
   return (
     <header
       className={cn(
-        "fixed top-0 left-0 w-screen flex items-center justify-between bg-black-2 z-50",
+        "fixed top-0 left-0 w-screen flex items-center justify-between dark:bg-black-2 bg-white border-b dark:border-black-1 border-grey/20 z-50",
         "h-10 lg:h-12",
       )}
     >
       <div className="container lg:mx-auto px-4 flex justify-between">
         <LocalizedLink
           to="/"
-          className="flex items-center gap-2 text-base font-medium"
+          className="flex items-center gap-2 text-base font-medium dark:text-white text-black-3"
         >
           Klimatkollen
         </LocalizedLink>
@@ -254,18 +260,18 @@ export function Header() {
                   <NavigationMenuTrigger
                     className={cn(
                       "flex gap-2 p-3",
-                      "data-[state=open]:bg-black-1 data-[state=closed]:bg-transparent",
+                      "dark:data-[state=open]:bg-black-1 data-[state=open]:bg-grey/10 data-[state=closed]:bg-transparent",
                       location.pathname.startsWith(
                         localizedPath(currentLanguage, item.path),
                       )
-                        ? "text-white"
-                        : "text-grey hover:text-white",
+                        ? "dark:text-white text-black-3"
+                        : "text-grey dark:hover:text-white hover:text-black-3",
                     )}
                   >
                     {item.icon}
                     {t(item.label)}
                   </NavigationMenuTrigger>
-                  <NavigationMenuContent className="min-w-56 w-full p-3 top-12 bg-black-2">
+                  <NavigationMenuContent className="min-w-56 w-full p-3 top-12 dark:bg-black-2 bg-white">
                     <SubLinksMenu sublinks={item.sublinks} />
                   </NavigationMenuContent>
                 </NavigationMenuItem>
@@ -277,8 +283,8 @@ export function Header() {
                     location.pathname.startsWith(
                       localizedPath(currentLanguage, item.path),
                     )
-                      ? "text-white"
-                      : "text-grey hover:text-white",
+                      ? "dark:text-white text-black-3"
+                      : "text-grey dark:hover:text-white hover:text-black-3",
                   )}
                 >
                   <NavigationMenuLink asChild>
@@ -295,7 +301,7 @@ export function Header() {
             )}
             {user && (
               <NavigationMenuItem>
-                <NavigationMenuTrigger className="flex items-center gap-2 px-3 py-3 h-full transition-all text-sm cursor-pointer text-grey hover:text-white">
+                <NavigationMenuTrigger className="flex items-center gap-2 px-3 py-3 h-full transition-all text-sm cursor-pointer text-grey dark:hover:text-white hover:text-black-3">
                   <span>Internal</span>
                 </NavigationMenuTrigger>
                 <NavigationMenuContent>
@@ -306,6 +312,7 @@ export function Header() {
           </NavigationMenuList>
           <div className="ml-4 h-full flex items-center">
             <HeaderSearchButton className="mx-2" />
+            <ThemeToggle className="hidden md:flex mx-2" />
             <LanguageButtons className={"hidden md:flex mx-4 "} />
             <NewsletterPopover
               isOpen={isSignUpOpen}
@@ -323,26 +330,29 @@ export function Header() {
         )}
 
         <button
-          className="lg:hidden text-white"
+          className="lg:hidden dark:text-white text-black-3"
           onClick={toggleMenu}
           aria-label={menuOpen ? "Close menu" : "Open menu"}
         >
           {menuOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
         </button>
         {menuOpen && (
-          <div className="fixed inset-0 w-full h-full z-100 flex p-8 mt-10 bg-black-2">
+          <div className="fixed inset-0 w-full h-full z-100 flex p-8 mt-10 dark:bg-black-2 bg-white">
             <div className="flex flex-col gap-6 text-lg w-full">
               <HeaderSearchButton
                 className="w-full"
                 onSearchResultClick={toggleMenu}
               />
-              <LanguageButtons />
+              <div className="flex items-center gap-4">
+                <ThemeToggle />
+                <LanguageButtons />
+              </div>
               {filteredNavLinks.map((link) => (
                 <div key={link.path} className="flex flex-col">
                   <LocalizedLink
                     to={link.path}
                     onClick={toggleMenu}
-                    className="flex items-center gap-2 cursor-pointer"
+                    className="flex items-center gap-2 cursor-pointer dark:text-white text-black-3"
                   >
                     {link.icon}
                     {t(link.label)}
@@ -353,7 +363,7 @@ export function Header() {
                         sublink.path.startsWith("https://") ? (
                           <a
                             href={sublink.path}
-                            className="flex items-center gap-2 text-sm text-gray-400"
+                            className="flex items-center gap-2 text-sm text-grey dark:text-grey"
                             target="_blank"
                             key={sublink.path}
                             onClick={toggleMenu}
@@ -365,7 +375,7 @@ export function Header() {
                             key={sublink.path}
                             to={sublink.path}
                             onClick={toggleMenu}
-                            className="flex items-center gap-2 text-sm text-gray-400"
+                            className="flex items-center gap-2 text-sm text-grey dark:text-grey"
                           >
                             {t(sublink.label)}
                           </LocalizedLink>
@@ -381,7 +391,7 @@ export function Header() {
                   setMenuOpen(false); // Close the menu
                   setIsSignUpOpen(true); // Open the newsletter popover
                 }}
-                className="flex items-center gap-2 text-blue-3"
+                className="flex items-center gap-2 text-blue-3 dark:text-blue-3"
               >
                 <Mail className="w-4 h-4" />
                 {t("header.newsletter")}

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -18,7 +18,7 @@ export function Layout({ children }: LayoutProps) {
   }, [location.pathname]);
 
   return (
-    <div className="min-h-screen w-full overflow-x-hidden bg-black-3 flex flex-col">
+    <div className="min-h-screen w-full overflow-x-hidden bg-black-3 dark:bg-black-3 bg-white flex flex-col">
       <Header />
       <main className="flex-1 container mx-auto px-4 pt-24 pb-12 min-h-0">
         {children}

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -18,7 +18,7 @@ export function Layout({ children }: LayoutProps) {
   }, [location.pathname]);
 
   return (
-    <div className="min-h-screen w-full overflow-x-hidden bg-black-3 dark:bg-black-3 bg-white flex flex-col">
+    <div className="min-h-screen w-full overflow-x-hidden bg-black-3 light:bg-white flex flex-col">
       <Header />
       <main className="flex-1 container mx-auto px-4 pt-24 pb-12 min-h-0">
         {children}

--- a/src/components/layout/LinkButton.tsx
+++ b/src/components/layout/LinkButton.tsx
@@ -11,17 +11,17 @@ export function LinkButton({ title, text, link }: LinkButtonProps) {
   return (
     <a
       href={link}
-      className="block dark:bg-black-1 bg-grey/10 rounded-level-2 p-6 dark:hover:bg-blue-5/30 hover:bg-blue-1/50 transition-colors dark:text-white text-black-3 dark:hover:text-blue-2 hover:text-blue-3"
+      className="block bg-black-1 light:bg-grey/10 rounded-level-2 p-6 hover:bg-blue-5/30 light:hover:bg-blue-1/50 transition-colors text-white light:text-black-3 hover:text-blue-2 light:hover:text-blue-3"
       target="_blank"
       rel="noopener noreferrer"
     >
       <div className="flex items-center justify-between mb-2">
-        <Text className="font-bold underline dark:text-white text-black-3">
+        <Text className="font-bold underline text-white light:text-black-3">
           {title}
         </Text>
-        <ArrowUpRight className="w-5 h-5 md:w-6 md:h-6 flex-shrink-0 dark:text-white text-black-3" />
+        <ArrowUpRight className="w-5 h-5 md:w-6 md:h-6 flex-shrink-0 text-white light:text-black-3" />
       </div>
-      <Text className="text-sm sm:text-base md:text-lg dark:text-white text-black-3">
+      <Text className="text-sm sm:text-base md:text-lg text-white light:text-black-3">
         {text}
       </Text>
     </a>

--- a/src/components/layout/LinkButton.tsx
+++ b/src/components/layout/LinkButton.tsx
@@ -11,15 +11,19 @@ export function LinkButton({ title, text, link }: LinkButtonProps) {
   return (
     <a
       href={link}
-      className="block bg-black-1 rounded-level-2 p-6 hover:bg-blue-5/30 transition-colors text-white hover:text-blue-2"
+      className="block dark:bg-black-1 bg-grey/10 rounded-level-2 p-6 dark:hover:bg-blue-5/30 hover:bg-blue-1/50 transition-colors dark:text-white text-black-3 dark:hover:text-blue-2 hover:text-blue-3"
       target="_blank"
       rel="noopener noreferrer"
     >
       <div className="flex items-center justify-between mb-2">
-        <Text className="font-bold underline">{title}</Text>
-        <ArrowUpRight className="w-5 h-5 md:w-6 md:h-6 flex-shrink-0" />
+        <Text className="font-bold underline dark:text-white text-black-3">
+          {title}
+        </Text>
+        <ArrowUpRight className="w-5 h-5 md:w-6 md:h-6 flex-shrink-0 dark:text-white text-black-3" />
       </div>
-      <Text className="text-sm sm:text-base md:text-lg">{text}</Text>
+      <Text className="text-sm sm:text-base md:text-lg dark:text-white text-black-3">
+        {text}
+      </Text>
     </a>
   );
 }

--- a/src/components/layout/ListCard.tsx
+++ b/src/components/layout/ListCard.tsx
@@ -65,14 +65,16 @@ export function ListCard({
     <div className="relative rounded-level-2 @container">
       <LocalizedLink
         to={linkTo}
-        className="block dark:bg-black-2 bg-white rounded-level-2 p-8 space-y-8 transition-all duration-300 hover:shadow-[0_0_10px_rgba(153,207,255,0.15)] dark:hover:bg-[#1a1a1a] hover:bg-grey/5 border dark:border-transparent border-grey/20"
+        className="block dark:bg-black-2 bg-grey/10 rounded-level-2 p-8 space-y-8 transition-all duration-300 hover:shadow-[0_0_10px_rgba(153,207,255,0.15)] dark:hover:bg-[#1a1a1a] hover:bg-grey/15 border dark:border-transparent border-grey/20"
       >
         {/* Header section */}
         <div className="space-y-2">
           <div className="flex justify-between">
             <div className="flex flex-col">
-              <h2 className="text-3xl font-light">{name}</h2>
-              <p className="text-grey text-sm line-clamp-2 min-h-[40px]">
+              <h2 className="text-3xl font-light dark:text-white text-black-3">
+                {name}
+              </h2>
+              <p className="dark:text-grey text-black-1 text-sm line-clamp-2 min-h-[40px]">
                 {description}
               </p>
             </div>
@@ -80,14 +82,14 @@ export function ListCard({
           </div>
 
           {/* Meets Paris section */}
-          <div className="flex items-center gap-2 text-grey mb-2 text-lg h-[40px]">
+          <div className="flex items-center gap-2 dark:text-grey text-black-1 mb-2 text-lg h-[40px]">
             {t(meetsParisTranslationKey, { name })}
           </div>
           <div
             className={cn(
               "text-3xl font-light",
               meetsParis === true
-                ? "text-green-3"
+                ? "dark:text-green-3 text-green-4"
                 : meetsParis === false
                   ? "text-pink-3"
                   : "text-grey",

--- a/src/components/layout/ListCard.tsx
+++ b/src/components/layout/ListCard.tsx
@@ -65,7 +65,7 @@ export function ListCard({
     <div className="relative rounded-level-2 @container">
       <LocalizedLink
         to={linkTo}
-        className="block bg-black-2 rounded-level-2 p-8 space-y-8 transition-all duration-300 hover:shadow-[0_0_10px_rgba(153,207,255,0.15)] hover:bg-[#1a1a1a]"
+        className="block dark:bg-black-2 bg-white rounded-level-2 p-8 space-y-8 transition-all duration-300 hover:shadow-[0_0_10px_rgba(153,207,255,0.15)] dark:hover:bg-[#1a1a1a] hover:bg-grey/5 border dark:border-transparent border-grey/20"
       >
         {/* Header section */}
         <div className="space-y-2">
@@ -102,7 +102,7 @@ export function ListCard({
         </div>
 
         {/* Emissions and change rate section */}
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 pt-4 border-t border-black-1">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 pt-4 border-t dark:border-black-1 border-grey/20">
           {/* Emissions */}
           <CardInfo
             title={

--- a/src/components/layout/ListCard.tsx
+++ b/src/components/layout/ListCard.tsx
@@ -65,16 +65,16 @@ export function ListCard({
     <div className="relative rounded-level-2 @container">
       <LocalizedLink
         to={linkTo}
-        className="block dark:bg-black-2 bg-grey/10 rounded-level-2 p-8 space-y-8 transition-all duration-300 hover:shadow-[0_0_10px_rgba(153,207,255,0.15)] dark:hover:bg-[#1a1a1a] hover:bg-grey/15 border dark:border-transparent border-grey/20"
+        className="block bg-black-2 light:bg-grey/10 rounded-level-2 p-8 space-y-8 transition-all duration-300 hover:shadow-[0_0_10px_rgba(153,207,255,0.15)] hover:bg-[#1a1a1a] light:hover:bg-grey/15 border border-transparent light:border-grey/20"
       >
         {/* Header section */}
         <div className="space-y-2">
           <div className="flex justify-between">
             <div className="flex flex-col">
-              <h2 className="text-3xl font-light dark:text-white text-black-3">
+              <h2 className="text-3xl font-light text-white light:text-black-3">
                 {name}
               </h2>
-              <p className="dark:text-grey text-black-1 text-sm line-clamp-2 min-h-[40px]">
+              <p className="text-grey light:text-black-1 text-sm line-clamp-2 min-h-[40px]">
                 {description}
               </p>
             </div>
@@ -82,14 +82,14 @@ export function ListCard({
           </div>
 
           {/* Meets Paris section */}
-          <div className="flex items-center gap-2 dark:text-grey text-black-1 mb-2 text-lg h-[40px]">
+          <div className="flex items-center gap-2 text-grey light:text-black-1 mb-2 text-lg h-[40px]">
             {t(meetsParisTranslationKey, { name })}
           </div>
           <div
             className={cn(
               "text-3xl font-light",
               meetsParis === true
-                ? "dark:text-green-3 text-green-4"
+                ? "text-green-3 light:text-green-4"
                 : meetsParis === false
                   ? "text-pink-3"
                   : "text-grey",
@@ -104,7 +104,7 @@ export function ListCard({
         </div>
 
         {/* Emissions and change rate section */}
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 pt-4 border-t dark:border-black-1 border-grey/20">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 pt-4 border-t border-black-1 light:border-grey/20">
           {/* Emissions */}
           <CardInfo
             title={

--- a/src/components/layout/PageHeader.tsx
+++ b/src/components/layout/PageHeader.tsx
@@ -17,7 +17,9 @@ export function PageHeader({
   return (
     <>
       <div className={cn("max-w-[1200px] mx-auto p-4 mb-4 md:mb-8", className)}>
-        <h1 className="text-3xl font-light mb-2">{title}</h1>
+        <h1 className="text-3xl font-light mb-2 dark:text-white text-black-3">
+          {title}
+        </h1>
         {description && <p className="text-sm text-grey">{description}</p>}
         {children && <div className="flex flex-wrap gap-2">{children}</div>}
       </div>

--- a/src/components/layout/PageHeader.tsx
+++ b/src/components/layout/PageHeader.tsx
@@ -17,7 +17,7 @@ export function PageHeader({
   return (
     <>
       <div className={cn("max-w-[1200px] mx-auto p-4 mb-4 md:mb-8", className)}>
-        <h1 className="text-3xl font-light mb-2 dark:text-white text-black-3">
+        <h1 className="text-3xl font-light mb-2 text-white light:text-black-3">
           {title}
         </h1>
         {description && <p className="text-sm text-grey">{description}</p>}

--- a/src/components/layout/ScrollAnimationSection.tsx
+++ b/src/components/layout/ScrollAnimationSection.tsx
@@ -44,7 +44,7 @@ function ActionButton({
       animate={{ opacity: 1 }}
       exit={{ opacity: 0 }}
       onClick={onClick}
-      className="absolute top-4 right-4 inline-flex items-center justify-center rounded-full h-10 px-6 py-2 text-sm font-light dark:bg-black-2 bg-grey/10 dark:text-white text-black-3 hover:opacity-80 active:ring-1 dark:active:ring-white active:ring-black-3 transition-colors focus-visible:outline-none focus-visible:ring-1 dark:focus-visible:ring-white focus-visible:ring-black-3 z-10"
+      className="absolute top-4 right-4 inline-flex items-center justify-center rounded-full h-10 px-6 py-2 text-sm font-light bg-black-2 light:bg-grey/10 text-white light:text-black-3 hover:opacity-80 active:ring-1 active:ring-white light:active:ring-black-3 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white light:focus-visible:ring-black-3 z-10"
       aria-label={label}
     >
       {children}
@@ -71,10 +71,10 @@ function ProgressIndicator({
           key={index}
           className={`h-1 rounded-full transition-all duration-300 ${
             index === currentIndex
-              ? "w-8 bg-black-3 dark:bg-white"
+              ? "w-8 bg-white light:bg-black-3"
               : index < currentIndex
-                ? "w-8 bg-black-3/60 dark:bg-white/60"
-                : "w-1 bg-black-3/30 dark:bg-white/30"
+                ? "w-8 bg-white/60 light:bg-black-3/60"
+                : "w-1 bg-white/30 light:bg-black-3/30"
           }`}
         />
       ))}

--- a/src/components/layout/ScrollAnimationSection.tsx
+++ b/src/components/layout/ScrollAnimationSection.tsx
@@ -71,10 +71,10 @@ function ProgressIndicator({
           key={index}
           className={`h-1 rounded-full transition-all duration-300 ${
             index === currentIndex
-              ? "w-8 bg-white"
+              ? "w-8 bg-black-3 dark:bg-white"
               : index < currentIndex
-                ? "w-8 bg-white/60"
-                : "w-1 bg-white/30"
+                ? "w-8 bg-black-3/60 dark:bg-white/60"
+                : "w-1 bg-black-3/30 dark:bg-white/30"
           }`}
         />
       ))}

--- a/src/components/layout/ScrollAnimationSection.tsx
+++ b/src/components/layout/ScrollAnimationSection.tsx
@@ -44,7 +44,7 @@ function ActionButton({
       animate={{ opacity: 1 }}
       exit={{ opacity: 0 }}
       onClick={onClick}
-      className="absolute top-4 right-4 inline-flex items-center justify-center rounded-full h-10 px-6 py-2 text-sm font-light bg-black-2 text-white hover:opacity-80 active:ring-1 active:ring-white transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white z-10"
+      className="absolute top-4 right-4 inline-flex items-center justify-center rounded-full h-10 px-6 py-2 text-sm font-light dark:bg-black-2 bg-grey/10 dark:text-white text-black-3 hover:opacity-80 active:ring-1 dark:active:ring-white active:ring-black-3 transition-colors focus-visible:outline-none focus-visible:ring-1 dark:focus-visible:ring-white focus-visible:ring-black-3 z-10"
       aria-label={label}
     >
       {children}

--- a/src/components/layout/ScrollAnimationStepContent.tsx
+++ b/src/components/layout/ScrollAnimationStepContent.tsx
@@ -43,10 +43,10 @@ export function ScrollAnimationStepContent({
             {badge.text}
           </span>
         </div>
-        <h2 className="text-2xl md:text-4xl lg:text-6xl xl:text-7xl font-light dark:text-white text-black-3 leading-tight">
+        <h2 className="text-2xl md:text-4xl lg:text-6xl xl:text-7xl font-light text-white light:text-black-3 leading-tight">
           {heading}
         </h2>
-        <p className="text-sm md:text-base lg:text-lg xl:text-xl dark:text-gray-300 text-black-3/70 leading-relaxed">
+        <p className="text-sm md:text-base lg:text-lg xl:text-xl text-gray-300 light:text-black-3/70 leading-relaxed">
           {paragraph}
         </p>
       </div>

--- a/src/components/layout/ScrollAnimationStepContent.tsx
+++ b/src/components/layout/ScrollAnimationStepContent.tsx
@@ -43,10 +43,10 @@ export function ScrollAnimationStepContent({
             {badge.text}
           </span>
         </div>
-        <h2 className="text-2xl md:text-4xl lg:text-6xl xl:text-7xl font-light text-white leading-tight">
+        <h2 className="text-2xl md:text-4xl lg:text-6xl xl:text-7xl font-light dark:text-white text-black-3 leading-tight">
           {heading}
         </h2>
-        <p className="text-sm md:text-base lg:text-lg xl:text-xl text-gray-300 leading-relaxed">
+        <p className="text-sm md:text-base lg:text-lg xl:text-xl dark:text-gray-300 text-black-3/70 leading-relaxed">
           {paragraph}
         </p>
       </div>

--- a/src/components/layout/ScrollToTop.tsx
+++ b/src/components/layout/ScrollToTop.tsx
@@ -29,7 +29,7 @@ export function ScrollToTop() {
       {isVisible && (
         <button
           onClick={scrollToTop}
-          className="fixed bottom-6 right-6 p-3 bg-black-1 hover:bg-black-2 text-white rounded-full shadow-lg transition-colors duration-200 z-[35]"
+          className="fixed bottom-6 right-6 p-3 dark:bg-black-1 bg-grey/20 dark:hover:bg-black-2 hover:bg-grey/30 dark:text-white text-black-3 rounded-full shadow-lg transition-colors duration-200 z-[35]"
           aria-label="Scroll to top"
         >
           <ChevronUp size={24} />

--- a/src/components/layout/ScrollToTop.tsx
+++ b/src/components/layout/ScrollToTop.tsx
@@ -29,7 +29,7 @@ export function ScrollToTop() {
       {isVisible && (
         <button
           onClick={scrollToTop}
-          className="fixed bottom-6 right-6 p-3 dark:bg-black-1 bg-grey/20 dark:hover:bg-black-2 hover:bg-grey/30 dark:text-white text-black-3 rounded-full shadow-lg transition-colors duration-200 z-[35]"
+          className="fixed bottom-6 right-6 p-3 bg-black-1 light:bg-grey/20 hover:bg-black-2 light:hover:bg-grey/30 text-white light:text-black-3 rounded-full shadow-lg transition-colors duration-200 z-[35]"
           aria-label="Scroll to top"
         >
           <ChevronUp size={24} />

--- a/src/components/layout/SuggestEdit.tsx
+++ b/src/components/layout/SuggestEdit.tsx
@@ -12,7 +12,7 @@ export function SuggestEdit() {
       <Popover.Root>
         <Popover.Trigger asChild>
           <button
-            className="fixed bottom-6 left-6 p-3 bg-black-1 hover:bg-black-1 sm:hover:bg-black-2 text-white rounded-full shadow-lg transition-colors duration-200 z-[35]"
+            className="fixed bottom-6 left-6 p-3 dark:bg-black-1 bg-grey/20 dark:hover:bg-black-1 sm:dark:hover:bg-black-2 hover:bg-grey/30 dark:text-white text-black-3 rounded-full shadow-lg transition-colors duration-200 z-[35]"
             aria-label="Suggest an edit"
           >
             <MessageSquareText />
@@ -20,16 +20,17 @@ export function SuggestEdit() {
         </Popover.Trigger>
         <Popover.Portal>
           <Popover.Content
-            className="ml-6 rounded-xl bg-black-1 p-4 shadow-[0_10px_38px_-10px_hsla(206,22%,7%,.35),0_10px_20px_-15px_hsla(206,22%,7%,.2)]
+            className="ml-6 rounded-xl dark:bg-black-1 bg-white p-4 shadow-[0_10px_38px_-10px_hsla(206,22%,7%,.35),0_10px_20px_-15px_hsla(206,22%,7%,.2)]
               will-change-[transform,opacity] focus:shadow-[0_10px_38px_-10px_hsla(206,22%,7%,.35),0_10px_20px_-15px_hsla(206,22%,7%,.2),0_0_0_2px_theme(colors.violet7)]
               data-[state=open]:data-[side=bottom]:animate-slideUpAndFade data-[state=open]:data-[side=left]:animate-slideRightAndFade
-              data-[state=open]:data-[side=right]:animate-slideLeftAndFade data-[state=open]:data-[side=top]:animate-slideDownAndFade z-[35]"
+              data-[state=open]:data-[side=right]:animate-slideLeftAndFade data-[state=open]:data-[side=top]:animate-slideDownAndFade z-[35] border dark:border-transparent border-grey/20"
             sideOffset={5}
           >
-
             {/* Suggestion form start */}
-            <Form.Root className="w-[260px]" onSubmit={(e) => {
-              // on submit question
+            <Form.Root
+              className="w-[260px]"
+              onSubmit={(e) => {
+                // on submit question
                 e.preventDefault();
                 const formData = new FormData(e.currentTarget);
                 const questionValue = formData.get("question");
@@ -37,12 +38,15 @@ export function SuggestEdit() {
                 const encodedSubject = encodeURIComponent(emailSubject);
                 const encodedBody = encodeURIComponent(questionValue);
                 window.location.href = `mailto:hej@klimatkollen.se?subject=${emailSubject}&body=${questionValue}`;
-            }}>
-              <Title className="text-[22px] mb-2">{t("landingPage.reportCorrection")}</Title>
+              }}
+            >
+              <Title className="text-[22px] mb-2">
+                {t("landingPage.reportCorrection")}
+              </Title>
               <Form.Field className="mb-2.5 grid" name="question">
                 <div className="flex items-baseline justify-between">
                   <Form.Message
-                    className="text-[13px] text-white opacity-80"
+                    className="text-[13px] dark:text-white text-black-3 opacity-80"
                     match="valueMissing"
                   >
                     {t("landingPage.questionMissing")}
@@ -50,7 +54,7 @@ export function SuggestEdit() {
                 </div>
                 <Form.Control asChild>
                   <textarea
-                    className="box-border block w-full min-h-[200px] p-3 appearance-none items-center justify-center rounded-lg bg-blackA2 text-[16px] leading-none text-black-2 shadow-[0_0_0_1px] shadow-blackA6 outline-none selection:bg-blackA6 selection:text-black-2 hover:shadow-[black-2] focus:shadow-[0_0_0_2px_black-2]"
+                    className="box-border block w-full min-h-[200px] p-3 appearance-none items-center justify-center rounded-lg dark:bg-blackA2 bg-grey/10 text-[16px] leading-none dark:text-black-2 text-black-3 shadow-[0_0_0_1px] dark:shadow-blackA6 shadow-grey/20 outline-none selection:bg-blackA6 selection:text-black-2 hover:shadow-[black-2] focus:shadow-[0_0_0_2px_black-2]"
                     placeholder={t("landingPage.questionPlaceholder")}
                     required
                   />

--- a/src/components/layout/SuggestEdit.tsx
+++ b/src/components/layout/SuggestEdit.tsx
@@ -12,7 +12,7 @@ export function SuggestEdit() {
       <Popover.Root>
         <Popover.Trigger asChild>
           <button
-            className="fixed bottom-6 left-6 p-3 dark:bg-black-1 bg-grey/20 dark:hover:bg-black-1 sm:dark:hover:bg-black-2 hover:bg-grey/30 dark:text-white text-black-3 rounded-full shadow-lg transition-colors duration-200 z-[35]"
+            className="fixed bottom-6 left-6 p-3 bg-black-1 light:bg-grey/20 hover:bg-black-1 sm:hover:bg-black-2 light:hover:bg-grey/30 text-white light:text-black-3 rounded-full shadow-lg transition-colors duration-200 z-[35]"
             aria-label="Suggest an edit"
           >
             <MessageSquareText />
@@ -20,10 +20,10 @@ export function SuggestEdit() {
         </Popover.Trigger>
         <Popover.Portal>
           <Popover.Content
-            className="ml-6 rounded-xl dark:bg-black-1 bg-white p-4 shadow-[0_10px_38px_-10px_hsla(206,22%,7%,.35),0_10px_20px_-15px_hsla(206,22%,7%,.2)]
+            className="ml-6 rounded-xl bg-black-1 light:bg-white p-4 shadow-[0_10px_38px_-10px_hsla(206,22%,7%,.35),0_10px_20px_-15px_hsla(206,22%,7%,.2)]
               will-change-[transform,opacity] focus:shadow-[0_10px_38px_-10px_hsla(206,22%,7%,.35),0_10px_20px_-15px_hsla(206,22%,7%,.2),0_0_0_2px_theme(colors.violet7)]
               data-[state=open]:data-[side=bottom]:animate-slideUpAndFade data-[state=open]:data-[side=left]:animate-slideRightAndFade
-              data-[state=open]:data-[side=right]:animate-slideLeftAndFade data-[state=open]:data-[side=top]:animate-slideDownAndFade z-[35] border dark:border-transparent border-grey/20"
+              data-[state=open]:data-[side=right]:animate-slideLeftAndFade data-[state=open]:data-[side=top]:animate-slideDownAndFade z-[35] border border-transparent light:border-grey/20"
             sideOffset={5}
           >
             {/* Suggestion form start */}
@@ -46,7 +46,7 @@ export function SuggestEdit() {
               <Form.Field className="mb-2.5 grid" name="question">
                 <div className="flex items-baseline justify-between">
                   <Form.Message
-                    className="text-[13px] dark:text-white text-black-3 opacity-80"
+                    className="text-[13px] text-white light:text-black-3 opacity-80"
                     match="valueMissing"
                   >
                     {t("landingPage.questionMissing")}
@@ -54,7 +54,7 @@ export function SuggestEdit() {
                 </div>
                 <Form.Control asChild>
                   <textarea
-                    className="box-border block w-full min-h-[200px] p-3 appearance-none items-center justify-center rounded-lg dark:bg-blackA2 bg-grey/10 text-[16px] leading-none dark:text-black-2 text-black-3 shadow-[0_0_0_1px] dark:shadow-blackA6 shadow-grey/20 outline-none selection:bg-blackA6 selection:text-black-2 hover:shadow-[black-2] focus:shadow-[0_0_0_2px_black-2]"
+                    className="box-border block w-full min-h-[200px] p-3 appearance-none items-center justify-center rounded-lg bg-blackA2 light:bg-grey/10 text-[16px] leading-none text-black-2 light:text-black-3 shadow-[0_0_0_1px] shadow-blackA6 light:shadow-grey/20 outline-none selection:bg-blackA6 selection:text-black-2 hover:shadow-[black-2] focus:shadow-[0_0_0_2px_black-2]"
                     placeholder={t("landingPage.questionPlaceholder")}
                     required
                   />

--- a/src/components/newsletters/NewsletterPopover.tsx
+++ b/src/components/newsletters/NewsletterPopover.tsx
@@ -100,7 +100,7 @@ export function NewsletterPopover({
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
-        <Button className="bg-blue-5 text-white rounded-lg hover:bg-blue-6 transition px-4 py-1 font-medium">
+        <Button className="!bg-blue-5 !text-white rounded-lg hover:!bg-blue-6 transition px-4 py-1 font-medium">
           {buttonText}
         </Button>
       </PopoverTrigger>
@@ -148,7 +148,7 @@ export function NewsletterPopover({
                     disabled={status === "success"}
                   />
                   <Button
-                    className="bg-blue-5 text-white w-full"
+                    className="!bg-blue-5 !text-white w-full"
                     type="submit"
                     disabled={status === "success"}
                   >

--- a/src/components/pageStates/Loading.tsx
+++ b/src/components/pageStates/Loading.tsx
@@ -1,6 +1,6 @@
 export const PageLoading = () => (
   <div className="animate-pulse space-y-16">
-    <div className="h-12 w-1/3 bg-black-1 rounded" />
-    <div className="h-96 bg-black-1 rounded-level-1" />
+    <div className="h-12 w-1/3 dark:bg-black-1 bg-grey/10 rounded" />
+    <div className="h-96 dark:bg-black-1 bg-grey/10 rounded-level-1" />
   </div>
 );

--- a/src/components/pageStates/Loading.tsx
+++ b/src/components/pageStates/Loading.tsx
@@ -1,6 +1,6 @@
 export const PageLoading = () => (
   <div className="animate-pulse space-y-16">
-    <div className="h-12 w-1/3 dark:bg-black-1 bg-grey/10 rounded" />
-    <div className="h-96 dark:bg-black-1 bg-grey/10 rounded-level-1" />
+    <div className="h-12 w-1/3 bg-black-1 light:bg-grey/10 rounded" />
+    <div className="h-96 bg-black-1 light:bg-grey/10 rounded-level-1" />
   </div>
 );

--- a/src/components/products/DownloadCard.tsx
+++ b/src/components/products/DownloadCard.tsx
@@ -72,12 +72,14 @@ export function DownloadCard({
   };
 
   return (
-    <div className="block bg-black-2 rounded-level-2 p-8 space-y-8 transition-all duration-300 hover:shadow-[0_0_10px_rgba(153,207,255,0.15)] hover:bg-[#1a1a1a] flex flex-col h-full">
+    <div className="block dark:bg-black-2 bg-white rounded-level-2 p-8 space-y-8 transition-all duration-300 hover:shadow-[0_0_10px_rgba(153,207,255,0.15)] dark:hover:bg-[#1a1a1a] hover:bg-grey/5 flex flex-col h-full border dark:border-transparent border-grey/20">
       <div className="flex items-center gap-3 mb-6">
-        <div className="rounded-lg bg-black-2 p-3 border border-black-1">
-          <Icon className="h-6 w-6 text-white" />
+        <div className="rounded-lg dark:bg-black-2 bg-grey/10 p-3 border dark:border-black-1 border-grey/20">
+          <Icon className="h-6 w-6 dark:text-white text-black-3" />
         </div>
-        <h3 className="text-xl font-light text-white">{title}</h3>
+        <h3 className="text-xl font-light dark:text-white text-black-3">
+          {title}
+        </h3>
       </div>
       <p className="text-grey mb-8 min-h-[96px] md:min-h-[120px] flex-grow">
         {description}
@@ -85,7 +87,7 @@ export function DownloadCard({
       <button
         onClick={handleDownload}
         disabled={isLoading}
-        className="inline-flex items-center justify-center gap-2 rounded-md bg-black-2 px-6 py-3 text-base font-medium text-blue-2 shadow-lg hover:bg-black-1 w-full transition-all border border-black-1 disabled:opacity-50 disabled:cursor-not-allowed"
+        className="inline-flex items-center justify-center gap-2 rounded-md dark:bg-black-2 bg-grey/10 px-6 py-3 text-base font-medium text-blue-2 shadow-lg dark:hover:bg-black-1 hover:bg-grey/20 w-full transition-all border dark:border-black-1 border-grey/20 disabled:opacity-50 disabled:cursor-not-allowed"
       >
         <Download className="h-5 w-5" />
         {isLoading ? t("common.loading") : t(`downloadsPage.download`)}

--- a/src/components/products/DownloadCard.tsx
+++ b/src/components/products/DownloadCard.tsx
@@ -72,12 +72,12 @@ export function DownloadCard({
   };
 
   return (
-    <div className="block dark:bg-black-2 bg-white rounded-level-2 p-8 space-y-8 transition-all duration-300 hover:shadow-[0_0_10px_rgba(153,207,255,0.15)] dark:hover:bg-[#1a1a1a] hover:bg-grey/5 flex flex-col h-full border dark:border-transparent border-grey/20">
+    <div className="block bg-black-2 light:bg-white rounded-level-2 p-8 space-y-8 transition-all duration-300 hover:shadow-[0_0_10px_rgba(153,207,255,0.15)] hover:bg-[#1a1a1a] light:hover:bg-grey/5 flex flex-col h-full border border-transparent light:border-grey/20">
       <div className="flex items-center gap-3 mb-6">
-        <div className="rounded-lg dark:bg-black-2 bg-grey/10 p-3 border dark:border-black-1 border-grey/20">
-          <Icon className="h-6 w-6 dark:text-white text-black-3" />
+        <div className="rounded-lg bg-black-2 light:bg-grey/10 p-3 border border-black-1 light:border-grey/20">
+          <Icon className="h-6 w-6 text-white light:text-black-3" />
         </div>
-        <h3 className="text-xl font-light dark:text-white text-black-3">
+        <h3 className="text-xl font-light text-white light:text-black-3">
           {title}
         </h3>
       </div>
@@ -87,7 +87,7 @@ export function DownloadCard({
       <button
         onClick={handleDownload}
         disabled={isLoading}
-        className="inline-flex items-center justify-center gap-2 rounded-md dark:bg-black-2 bg-grey/10 px-6 py-3 text-base font-medium text-blue-2 shadow-lg dark:hover:bg-black-1 hover:bg-grey/20 w-full transition-all border dark:border-black-1 border-grey/20 disabled:opacity-50 disabled:cursor-not-allowed"
+        className="inline-flex items-center justify-center gap-2 rounded-md bg-black-2 light:bg-grey/10 px-6 py-3 text-base font-medium text-blue-2 shadow-lg hover:bg-black-1 light:hover:bg-grey/20 w-full transition-all border border-black-1 light:border-grey/20 disabled:opacity-50 disabled:cursor-not-allowed"
       >
         <Download className="h-5 w-5" />
         {isLoading ? t("common.loading") : t(`downloadsPage.download`)}

--- a/src/components/ranked/InsightsList.tsx
+++ b/src/components/ranked/InsightsList.tsx
@@ -26,8 +26,8 @@ function InsightsList<T>({
   nameKey,
 }: InsightsListProps<T>) {
   return (
-    <div className="dark:bg-white/10 bg-grey/20 rounded-level-2 p-4 md:p-6">
-      <h3 className="dark:text-white text-black-3 text-lg font-semibold mb-2">
+    <div className="bg-white/10 light:bg-grey/20 rounded-level-2 p-4 md:p-6">
+      <h3 className="text-white light:text-black-3 text-lg font-semibold mb-2">
         {title}
       </h3>
       {entities.map((entity, index) => {
@@ -38,7 +38,7 @@ function InsightsList<T>({
           <div className="flex items-center justify-between p-2">
             <div className="flex items-center gap-2">
               <span className="text-orange-2">{position}</span>
-              <span className="dark:text-white text-black-3">{name}</span>
+              <span className="text-white light:text-black-3">{name}</span>
             </div>
             <span className={`${textColor} font-semibold`}>
               {entity[dataPointKey] != null
@@ -53,7 +53,7 @@ function InsightsList<T>({
             <LocalizedLink
               key={name}
               to={`/${entityType}/${name}`}
-              className="block transition-colors dark:hover:bg-white/5 hover:bg-grey/30 rounded-lg"
+              className="block transition-colors hover:bg-white/5 light:hover:bg-grey/30 rounded-lg"
             >
               {content}
             </LocalizedLink>
@@ -67,7 +67,7 @@ function InsightsList<T>({
               <LocalizedLink
                 key={name}
                 to={`/${entityType}/${companyId}`}
-                className="block transition-colors dark:hover:bg-white/5 hover:bg-grey/30 rounded-lg"
+                className="block transition-colors hover:bg-white/5 light:hover:bg-grey/30 rounded-lg"
               >
                 {content}
               </LocalizedLink>
@@ -78,7 +78,7 @@ function InsightsList<T>({
         return (
           <div
             key={name}
-            className="block transition-colors dark:hover:bg-white/5 hover:bg-grey/30 rounded-lg"
+            className="block transition-colors hover:bg-white/5 light:hover:bg-grey/30 rounded-lg"
           >
             {content}
           </div>

--- a/src/components/ranked/InsightsList.tsx
+++ b/src/components/ranked/InsightsList.tsx
@@ -26,8 +26,10 @@ function InsightsList<T>({
   nameKey,
 }: InsightsListProps<T>) {
   return (
-    <div className="bg-white/10 rounded-level-2 p-4 md:p-6">
-      <h3 className="text-white text-lg font-semibold mb-2">{title}</h3>
+    <div className="dark:bg-white/10 bg-grey/20 rounded-level-2 p-4 md:p-6">
+      <h3 className="dark:text-white text-black-3 text-lg font-semibold mb-2">
+        {title}
+      </h3>
       {entities.map((entity, index) => {
         const position = isBottomRanking ? totalCount - index : index + 1;
         const name = String(entity[nameKey]);
@@ -36,7 +38,7 @@ function InsightsList<T>({
           <div className="flex items-center justify-between p-2">
             <div className="flex items-center gap-2">
               <span className="text-orange-2">{position}</span>
-              <span>{name}</span>
+              <span className="dark:text-white text-black-3">{name}</span>
             </div>
             <span className={`${textColor} font-semibold`}>
               {entity[dataPointKey] != null
@@ -51,7 +53,7 @@ function InsightsList<T>({
             <LocalizedLink
               key={name}
               to={`/${entityType}/${name}`}
-              className="block transition-colors hover:bg-white/5 rounded-lg"
+              className="block transition-colors dark:hover:bg-white/5 hover:bg-grey/30 rounded-lg"
             >
               {content}
             </LocalizedLink>
@@ -65,7 +67,7 @@ function InsightsList<T>({
               <LocalizedLink
                 key={name}
                 to={`/${entityType}/${companyId}`}
-                className="block transition-colors hover:bg-white/5 rounded-lg"
+                className="block transition-colors dark:hover:bg-white/5 hover:bg-grey/30 rounded-lg"
               >
                 {content}
               </LocalizedLink>
@@ -76,7 +78,7 @@ function InsightsList<T>({
         return (
           <div
             key={name}
-            className="block transition-colors hover:bg-white/5 rounded-lg"
+            className="block transition-colors dark:hover:bg-white/5 hover:bg-grey/30 rounded-lg"
           >
             {content}
           </div>

--- a/src/components/ranked/KPIDetailsPanel.tsx
+++ b/src/components/ranked/KPIDetailsPanel.tsx
@@ -35,7 +35,7 @@ export default function KPIDetailsPanel({
   className = "",
 }: KPIDetailsPanelProps) {
   const sourceSection = sourceLinks.length > 0 && (
-    <p className="dark:text-gray-400 text-grey text-sm dark:border-gray-700/50 border-grey/30 italic">
+    <p className="text-gray-400 light:text-grey text-sm border-gray-700/50 light:border-grey/30 italic">
       {t("municipalities.list.source")}{" "}
       {sourceLinks.map((link, index) => (
         <Fragment key={link.url}>
@@ -44,7 +44,7 @@ export default function KPIDetailsPanel({
             href={link.url}
             target="_blank"
             rel="noopener noreferrer"
-            className="underline dark:hover:text-gray-300 hover:text-black-3 transition-colors duration-200"
+            className="underline hover:text-gray-300 light:hover:text-black-3 transition-colors duration-200"
             title={t(link.label)}
           >
             {t(link.label)}
@@ -61,21 +61,21 @@ export default function KPIDetailsPanel({
 
   return (
     <div
-      className={`p-6 space-y-4 dark:bg-white/5 bg-grey/20 rounded-level-2 shadow-lg ${className}`}
+      className={`p-6 space-y-4 bg-white/5 light:bg-grey/20 rounded-level-2 shadow-lg ${className}`}
     >
-      <h2 className="text-2xl font-semibold tracking-tight mb-4 dark:text-white text-black-3">
+      <h2 className="text-2xl font-semibold tracking-tight mb-4 text-white light:text-black-3">
         {title}
       </h2>
-      <div className="mt-4 p-4 dark:bg-white/10 bg-grey/30 rounded-level-2 space-y-2">
+      <div className="mt-4 p-4 bg-white/10 light:bg-grey/30 rounded-level-2 space-y-2">
         {averageValue !== undefined && (
-          <p className="flex items-center flex-wrap gap-2 text-lg dark:text-white text-black-3">
+          <p className="flex items-center flex-wrap gap-2 text-lg text-white light:text-black-3">
             {averageLabel}{" "}
             <span className="text-orange-2 font-medium">{averageValue}</span>
           </p>
         )}
 
         {distributionStats.map((stat, index) => (
-          <p key={index} className="dark:text-white text-black-3">
+          <p key={index} className="text-white light:text-black-3">
             <span className={`font-medium ${stat.colorClass}`}>
               {stat.count}{" "}
             </span>
@@ -86,7 +86,7 @@ export default function KPIDetailsPanel({
         {typeof missingDataCount === "number" &&
           missingDataCount > 0 &&
           missingDataLabel && (
-            <p className="dark:text-gray-400 text-grey text-sm italic">
+            <p className="text-gray-400 light:text-grey text-sm italic">
               {missingDataCount} {lowercaseFirstLetter(missingDataLabel)}
             </p>
           )}

--- a/src/components/ranked/KPIDetailsPanel.tsx
+++ b/src/components/ranked/KPIDetailsPanel.tsx
@@ -35,7 +35,7 @@ export default function KPIDetailsPanel({
   className = "",
 }: KPIDetailsPanelProps) {
   const sourceSection = sourceLinks.length > 0 && (
-    <p className="text-gray-400 text-sm border-gray-700/50 italic">
+    <p className="dark:text-gray-400 text-grey text-sm dark:border-gray-700/50 border-grey/30 italic">
       {t("municipalities.list.source")}{" "}
       {sourceLinks.map((link, index) => (
         <Fragment key={link.url}>
@@ -44,7 +44,7 @@ export default function KPIDetailsPanel({
             href={link.url}
             target="_blank"
             rel="noopener noreferrer"
-            className="underline hover:text-gray-300 transition-colors duration-200"
+            className="underline dark:hover:text-gray-300 hover:text-black-3 transition-colors duration-200"
             title={t(link.label)}
           >
             {t(link.label)}
@@ -61,19 +61,21 @@ export default function KPIDetailsPanel({
 
   return (
     <div
-      className={`p-6 space-y-4 bg-white/5 rounded-level-2 shadow-lg ${className}`}
+      className={`p-6 space-y-4 dark:bg-white/5 bg-grey/20 rounded-level-2 shadow-lg ${className}`}
     >
-      <h2 className="text-2xl font-semibold tracking-tight mb-4">{title}</h2>
-      <div className="mt-4 p-4 bg-white/10 rounded-level-2 space-y-2">
+      <h2 className="text-2xl font-semibold tracking-tight mb-4 dark:text-white text-black-3">
+        {title}
+      </h2>
+      <div className="mt-4 p-4 dark:bg-white/10 bg-grey/30 rounded-level-2 space-y-2">
         {averageValue !== undefined && (
-          <p className="flex items-center flex-wrap gap-2 text-lg">
+          <p className="flex items-center flex-wrap gap-2 text-lg dark:text-white text-black-3">
             {averageLabel}{" "}
             <span className="text-orange-2 font-medium">{averageValue}</span>
           </p>
         )}
 
         {distributionStats.map((stat, index) => (
-          <p key={index}>
+          <p key={index} className="dark:text-white text-black-3">
             <span className={`font-medium ${stat.colorClass}`}>
               {stat.count}{" "}
             </span>
@@ -84,7 +86,7 @@ export default function KPIDetailsPanel({
         {typeof missingDataCount === "number" &&
           missingDataCount > 0 &&
           missingDataLabel && (
-            <p className="text-gray-400 text-sm italic">
+            <p className="dark:text-gray-400 text-grey text-sm italic">
               {missingDataCount} {lowercaseFirstLetter(missingDataLabel)}
             </p>
           )}

--- a/src/components/ranked/RankedList.tsx
+++ b/src/components/ranked/RankedList.tsx
@@ -111,16 +111,16 @@ export function RankedList<T extends Record<string, unknown>>({
     <button
       key={String(index)}
       onClick={() => onItemClick?.(item)}
-      className="w-full p-4 hover:bg-black/40 transition-colors flex items-center justify-between group"
+      className="w-full p-4 dark:hover:bg-black/40 hover:bg-grey/10 transition-colors flex items-center justify-between group"
     >
       <div className="flex items-center gap-4">
-        <span className="text-white/30 text-sm w-8">
+        <span className="dark:text-white/30 text-black-3/30 text-sm w-8">
           {selectedDataPoint.isBoolean
             ? /* Empty span to maintain indentation for boolean KPIs */
               ""
             : startIndex + index + 1}
         </span>
-        <span className="text-white/90 text-sm md:text-base text-left">
+        <span className="dark:text-white/90 text-black-3/90 text-sm md:text-base text-left">
           {String(item[searchKey])}
         </span>
       </div>
@@ -132,11 +132,11 @@ export function RankedList<T extends Record<string, unknown>>({
 
   return (
     <div
-      className={`bg-black-2 rounded-2xl flex flex-col border border-white/10 ${className}`}
+      className={`dark:bg-black-2 bg-white rounded-2xl flex flex-col border dark:border-white/10 border-grey/20 ${className}`}
     >
-      <div className="p-4 border-b border-white/10">
+      <div className="p-4 border-b dark:border-white/10 border-grey/20">
         <div className="relative">
-          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-white/50 w-5 h-5" />
+          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 dark:text-white/50 text-black-3/50 w-5 h-5" />
           <input
             type="text"
             placeholder={searchPlaceholder}
@@ -145,7 +145,7 @@ export function RankedList<T extends Record<string, unknown>>({
               setSearchTerm(e.target.value);
               setCurrentPage(1);
             }}
-            className="w-full pl-10 pr-4 py-2 bg-black-3 text-white rounded-xl placeholder-white/50 focus:outline-none focus:ring-2 focus:ring-white/20"
+            className="w-full pl-10 pr-4 py-2 dark:bg-black-3 bg-grey/10 dark:text-white text-black-3 rounded-xl dark:placeholder-white/50 placeholder-black-3/50 focus:outline-none focus:ring-2 dark:focus:ring-white/20 focus:ring-black-3/20"
           />
         </div>
         {selectedDataPoint.unit && (
@@ -156,7 +156,7 @@ export function RankedList<T extends Record<string, unknown>>({
         )}
       </div>
       <div className="flex-1 overflow-y-auto ranked-list-items min-h-[570px]">
-        <div className="divide-y divide-white/10">
+        <div className="divide-y dark:divide-white/10 divide-grey/20">
           {paginatedData.map((item, index) =>
             renderItem
               ? renderItem(item, index, startIndex)

--- a/src/components/ranked/RankedList.tsx
+++ b/src/components/ranked/RankedList.tsx
@@ -132,7 +132,7 @@ export function RankedList<T extends Record<string, unknown>>({
 
   return (
     <div
-      className={`dark:bg-black-2 bg-white rounded-2xl flex flex-col border dark:border-white/10 border-grey/20 ${className}`}
+      className={`dark:bg-black-2 bg-grey/10 rounded-2xl flex flex-col border dark:border-white/10 border-grey/20 ${className}`}
     >
       <div className="p-4 border-b dark:border-white/10 border-grey/20">
         <div className="relative">

--- a/src/components/ranked/RankedList.tsx
+++ b/src/components/ranked/RankedList.tsx
@@ -111,16 +111,16 @@ export function RankedList<T extends Record<string, unknown>>({
     <button
       key={String(index)}
       onClick={() => onItemClick?.(item)}
-      className="w-full p-4 dark:hover:bg-black/40 hover:bg-grey/10 transition-colors flex items-center justify-between group"
+      className="w-full p-4 hover:bg-black/40 light:hover:bg-grey/10 transition-colors flex items-center justify-between group"
     >
       <div className="flex items-center gap-4">
-        <span className="dark:text-white/30 text-black-3/30 text-sm w-8">
+        <span className="text-white/30 light:text-black-3/30 text-sm w-8">
           {selectedDataPoint.isBoolean
             ? /* Empty span to maintain indentation for boolean KPIs */
               ""
             : startIndex + index + 1}
         </span>
-        <span className="dark:text-white/90 text-black-3/90 text-sm md:text-base text-left">
+        <span className="text-white/90 light:text-black-3/90 text-sm md:text-base text-left">
           {String(item[searchKey])}
         </span>
       </div>
@@ -132,11 +132,11 @@ export function RankedList<T extends Record<string, unknown>>({
 
   return (
     <div
-      className={`dark:bg-black-2 bg-grey/10 rounded-2xl flex flex-col border dark:border-white/10 border-grey/20 ${className}`}
+      className={`bg-black-2 light:bg-grey/10 rounded-2xl flex flex-col border border-white/10 light:border-grey/20 ${className}`}
     >
-      <div className="p-4 border-b dark:border-white/10 border-grey/20">
+      <div className="p-4 border-b border-white/10 light:border-grey/20">
         <div className="relative">
-          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 dark:text-white/50 text-black-3/50 w-5 h-5" />
+          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-white/50 light:text-black-3/50 w-5 h-5" />
           <input
             type="text"
             placeholder={searchPlaceholder}
@@ -145,7 +145,7 @@ export function RankedList<T extends Record<string, unknown>>({
               setSearchTerm(e.target.value);
               setCurrentPage(1);
             }}
-            className="w-full pl-10 pr-4 py-2 dark:bg-black-3 bg-grey/10 dark:text-white text-black-3 rounded-xl dark:placeholder-white/50 placeholder-black-3/50 focus:outline-none focus:ring-2 dark:focus:ring-white/20 focus:ring-black-3/20"
+            className="w-full pl-10 pr-4 py-2 bg-black-3 light:bg-grey/10 text-white light:text-black-3 rounded-xl placeholder-white/50 light:placeholder-black-3/50 focus:outline-none focus:ring-2 focus:ring-white/20 light:focus:ring-black-3/20"
           />
         </div>
         {selectedDataPoint.unit && (
@@ -156,7 +156,7 @@ export function RankedList<T extends Record<string, unknown>>({
         )}
       </div>
       <div className="flex-1 overflow-y-auto ranked-list-items min-h-[570px]">
-        <div className="divide-y dark:divide-white/10 divide-grey/20">
+        <div className="divide-y divide-white/10 light:divide-grey/20">
           {paginatedData.map((item, index) =>
             renderItem
               ? renderItem(item, index, startIndex)

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -16,7 +16,7 @@ const AlertDialogOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 dark:bg-black/80 bg-black/40 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className,
     )}
     {...props}
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border dark:bg-black-2 bg-white p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}
@@ -77,7 +77,10 @@ const AlertDialogTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Title
     ref={ref}
-    className={cn("text-lg font-semibold", className)}
+    className={cn(
+      "text-lg font-semibold dark:text-white text-black-3",
+      className,
+    )}
     {...props}
   />
 ));

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -16,7 +16,7 @@ const AlertDialogOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 dark:bg-black/80 bg-black/40 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-black/80 light:bg-black/40 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className,
     )}
     {...props}
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border dark:bg-black-2 bg-white p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-black-2 light:bg-white p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}
@@ -78,7 +78,7 @@ const AlertDialogTitle = React.forwardRef<
   <AlertDialogPrimitive.Title
     ref={ref}
     className={cn(
-      "text-lg font-semibold dark:text-white text-black-3",
+      "text-lg font-semibold text-white light:text-black-3",
       className,
     )}
     {...props}

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -10,7 +10,7 @@ const alertVariants = cva(
       variant: {
         default: "bg-background text-foreground",
         destructive:
-          "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+          "border-destructive/50 text-destructive border-destructive [&>svg]:text-destructive",
       },
     },
     defaultVariants: {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -4,17 +4,17 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center rounded-full text-sm font-light transition-colors focus-visible:outline-none focus-visible:ring-1 dark:focus-visible:ring-white focus-visible:ring-black-3 disabled:pointer-events-none",
+  "inline-flex items-center justify-center rounded-full text-sm font-light transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white light:focus-visible:ring-black-3 disabled:pointer-events-none",
   {
     variants: {
       variant: {
         default:
-          "dark:bg-black-2 bg-grey/10 dark:text-white text-black-3 hover:opacity-80 active:ring-1 dark:active:ring-white active:ring-black-3 disabled:opacity-50",
+          "bg-black-2 light:bg-grey/10 text-white light:text-black-3 hover:opacity-80 active:ring-1 active:ring-white light:active:ring-black-3 disabled:opacity-50",
         outline:
-          "border dark:border-white border-black-3 bg-transparent hover:opacity-80 active:ring-1 dark:active:ring-white active:ring-black-3 disabled:opacity-50",
+          "border border-white light:border-black-3 bg-transparent hover:opacity-80 active:ring-1 active:ring-white light:active:ring-black-3 disabled:opacity-50",
         ghost:
-          "bg-transparent dark:hover:bg-white/10 hover:bg-black-3/10 active:ring-1 dark:active:ring-white active:ring-black-3 disabled:opacity-50",
-        icon: "h-10 w-10 rounded-full dark:bg-black-2 bg-grey/10 hover:opacity-80 active:ring-1 dark:active:ring-white active:ring-black-3 disabled:opacity-50",
+          "bg-transparent hover:bg-white/10 light:hover:bg-black-3/10 active:ring-1 active:ring-white light:active:ring-black-3 disabled:opacity-50",
+        icon: "h-10 w-10 rounded-full bg-black-2 light:bg-grey/10 hover:opacity-80 active:ring-1 active:ring-white light:active:ring-black-3 disabled:opacity-50",
       },
       size: {
         default: "h-10 px-6 py-2",

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -4,17 +4,17 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center rounded-full text-sm font-light transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white disabled:pointer-events-none",
+  "inline-flex items-center justify-center rounded-full text-sm font-light transition-colors focus-visible:outline-none focus-visible:ring-1 dark:focus-visible:ring-white focus-visible:ring-black-3 disabled:pointer-events-none",
   {
     variants: {
       variant: {
         default:
-          "bg-black-2 text-white hover:opacity-80 active:ring-1 active:ring-white disabled:opacity-50",
+          "dark:bg-black-2 bg-grey/10 dark:text-white text-black-3 hover:opacity-80 active:ring-1 dark:active:ring-white active:ring-black-3 disabled:opacity-50",
         outline:
-          "border border-white bg-transparent hover:opacity-80 active:ring-1 active:ring-white disabled:opacity-50",
+          "border dark:border-white border-black-3 bg-transparent hover:opacity-80 active:ring-1 dark:active:ring-white active:ring-black-3 disabled:opacity-50",
         ghost:
-          "bg-transparent hover:bg-white/10 active:ring-1 active:ring-white disabled:opacity-50",
-        icon: "h-10 w-10 rounded-full bg-black-2 hover:opacity-80 active:ring-1 active:ring-white disabled:opacity-50",
+          "bg-transparent dark:hover:bg-white/10 hover:bg-black-3/10 active:ring-1 dark:active:ring-white active:ring-black-3 disabled:opacity-50",
+        icon: "h-10 w-10 rounded-full dark:bg-black-2 bg-grey/10 hover:opacity-80 active:ring-1 dark:active:ring-white active:ring-black-3 disabled:opacity-50",
       },
       size: {
         default: "h-10 px-6 py-2",

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -4,7 +4,7 @@ import * as RechartsPrimitive from "recharts";
 import { cn } from "@/lib/utils";
 
 // Format: { THEME_NAME: CSS_SELECTOR }
-const THEMES = { light: "", dark: ".dark" } as const;
+const THEMES = { light: ".light", dark: "" } as const;
 
 export type ChartConfig = {
   [k in string]: {

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -54,7 +54,10 @@ const CommandInput = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Input>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
 >(({ className, ...props }, ref) => (
-  <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
+  <div
+    className="flex items-center border-b px-3 bg-[rgba(135,135,135,0.1)] dark:bg-black-1"
+    cmdk-input-wrapper=""
+  >
     <MagnifyingGlassIcon className="mr-2 h-4 w-4 shrink-0 opacity-50" />
     <CommandPrimitive.Input
       ref={ref}

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -55,7 +55,7 @@ const CommandInput = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
 >(({ className, ...props }, ref) => (
   <div
-    className="flex items-center border-b px-3 bg-[rgba(135,135,135,0.1)] dark:bg-black-1"
+    className="flex items-center border-b px-3 bg-black-1 light:bg-[rgba(135,135,135,0.1)]"
     cmdk-input-wrapper=""
   >
     <MagnifyingGlassIcon className="mr-2 h-4 w-4 shrink-0 opacity-50" />

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -19,7 +19,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 dark:bg-black/80 bg-black/40 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className,
     )}
     {...props}
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border dark:bg-black-2 bg-white p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}
@@ -86,7 +86,7 @@ const DialogTitle = React.forwardRef<
   <DialogPrimitive.Title
     ref={ref}
     className={cn(
-      "text-lg font-semibold leading-none tracking-tight",
+      "text-lg font-semibold leading-none tracking-tight dark:text-white text-black-3",
       className,
     )}
     {...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -19,7 +19,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 dark:bg-black/80 bg-black/40 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-black/80 light:bg-black/40 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className,
     )}
     {...props}
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border dark:bg-black-2 bg-white p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-black-2 light:bg-white p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}
@@ -86,7 +86,7 @@ const DialogTitle = React.forwardRef<
   <DialogPrimitive.Title
     ref={ref}
     className={cn(
-      "text-lg font-semibold leading-none tracking-tight dark:text-white text-black-3",
+      "text-lg font-semibold leading-none tracking-tight text-white light:text-black-3",
       className,
     )}
     {...props}

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -26,7 +26,7 @@ const DrawerOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DrawerPrimitive.Overlay
     ref={ref}
-    className={cn("fixed inset-0 z-50 bg-black/80", className)}
+    className={cn("fixed inset-0 z-50 dark:bg-black/80 bg-black/40", className)}
     {...props}
   />
 ));
@@ -41,7 +41,7 @@ const DrawerContent = React.forwardRef<
     <DrawerPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background",
+        "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border dark:bg-black-2 bg-white",
         className,
       )}
       {...props}
@@ -82,7 +82,7 @@ const DrawerTitle = React.forwardRef<
   <DrawerPrimitive.Title
     ref={ref}
     className={cn(
-      "text-lg font-semibold leading-none tracking-tight",
+      "text-lg font-semibold leading-none tracking-tight dark:text-white text-black-3",
       className,
     )}
     {...props}

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -26,7 +26,10 @@ const DrawerOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DrawerPrimitive.Overlay
     ref={ref}
-    className={cn("fixed inset-0 z-50 dark:bg-black/80 bg-black/40", className)}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80 light:bg-black/40",
+      className,
+    )}
     {...props}
   />
 ));
@@ -41,7 +44,7 @@ const DrawerContent = React.forwardRef<
     <DrawerPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border dark:bg-black-2 bg-white",
+        "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-black-2 light:bg-white",
         className,
       )}
       {...props}
@@ -82,7 +85,7 @@ const DrawerTitle = React.forwardRef<
   <DrawerPrimitive.Title
     ref={ref}
     className={cn(
-      "text-lg font-semibold leading-none tracking-tight dark:text-white text-black-3",
+      "text-lg font-semibold leading-none tracking-tight text-white light:text-black-3",
       className,
     )}
     {...props}

--- a/src/components/ui/globalsearch.tsx
+++ b/src/components/ui/globalsearch.tsx
@@ -62,7 +62,7 @@ const GlobalSearch = () => {
     <div className="flex flex-col gap-4 w-[300px] relative">
       <label
         htmlFor="landingInput"
-        className="text-xl mt-6 dark:text-white text-black-3"
+        className="text-xl mt-6 text-white light:text-black-3"
       >
         {t("globalSearch.title")}
       </label>
@@ -73,15 +73,15 @@ const GlobalSearch = () => {
           placeholder={t("globalSearch.placeholder")}
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
-          className="dark:bg-black-1 bg-grey/10 border dark:border-transparent border-grey/20 placeholder:text-center relative h-10 rounded-md px-2 text-base text-lg dark:focus:outline-white focus:outline-black-3 font-medium focus:text-left focus:ring-1 dark:focus:ring-blue-2 focus:ring-blue-3 relative w-full dark:text-white text-black-3"
+          className="bg-black-1 light:bg-grey/10 border border-transparent light:border-grey/20 placeholder:text-center relative h-10 rounded-md px-2 text-base text-lg focus:outline-white light:focus:outline-black-3 font-medium focus:text-left focus:ring-1 focus:ring-blue-2 light:focus:ring-blue-3 relative w-full text-white light:text-black-3"
         />
         {searchQuery ? (
           <X
             onClick={() => setSearchQuery("")}
-            className="absolute right-0 -translate-x-2 w-4 h-4 opacity-80 cursor-pointer dark:text-white text-black-3"
+            className="absolute right-0 -translate-x-2 w-4 h-4 opacity-80 cursor-pointer text-white light:text-black-3"
           />
         ) : (
-          <SearchIcon className="absolute right-0 -translate-x-2 w-4 h-4 opacity-80 dark:text-white text-black-3" />
+          <SearchIcon className="absolute right-0 -translate-x-2 w-4 h-4 opacity-80 text-white light:text-black-3" />
         )}
       </div>
       <div
@@ -91,7 +91,7 @@ const GlobalSearch = () => {
           ${isMobile ? "max-h-[250px]" : "max-h-[300px]"}
           ${!isDropdownOpen && "hidden"}
           ${searchResult.length > 0 ? "overflow-y-scroll" : "overflow-y-hidden"}
-          w-[300px] top-28 absolute dark:bg-black-2 bg-white rounded-xl border dark:border-transparent border-grey/20 shadow-lg`}
+          w-[300px] top-28 absolute bg-black-2 light:bg-white rounded-xl border border-transparent light:border-grey/20 shadow-lg`}
         style={{
           scrollbarWidth: "thin",
         }}
@@ -101,7 +101,7 @@ const GlobalSearch = () => {
             return (
               <a
                 href={`${item.category === "companies" ? "/companies/" : "/municipalities/"}${item.id}`}
-                className="text-left text-lg font-md max-w-[300px] p-3 flex justify-between dark:hover:bg-black-1 hover:bg-grey/10 transition-colors dark:text-white text-black-3"
+                className="text-left text-lg font-md max-w-[300px] p-3 flex justify-between hover:bg-black-1 light:hover:bg-grey/10 transition-colors text-white light:text-black-3"
                 key={item.id}
               >
                 {item.name}
@@ -114,7 +114,7 @@ const GlobalSearch = () => {
             );
           })
         ) : (
-          <Text className="dark:text-grey text-black-2 text-center text-lg font-md h-14 max-w-[300px] overflow-visible p-3">
+          <Text className="text-grey light:text-black-2 text-center text-lg font-md h-14 max-w-[300px] overflow-visible p-3">
             No results found
           </Text>
         )}

--- a/src/components/ui/globalsearch.tsx
+++ b/src/components/ui/globalsearch.tsx
@@ -60,7 +60,10 @@ const GlobalSearch = () => {
 
   return (
     <div className="flex flex-col gap-4 w-[300px] relative">
-      <label htmlFor="landingInput" className="text-xl mt-6">
+      <label
+        htmlFor="landingInput"
+        className="text-xl mt-6 dark:text-white text-black-3"
+      >
         {t("globalSearch.title")}
       </label>
       <div className="flex gap-2 items-center">
@@ -70,15 +73,15 @@ const GlobalSearch = () => {
           placeholder={t("globalSearch.placeholder")}
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
-          className="bg-black-1 placeholder:text-center relative h-10 rounded-md px-2 text-base text-lg focus:outline-white font-medium focus:text-left focus:ring-1 focus:ring-blue-2 relative w-full"
+          className="dark:bg-black-1 bg-white border dark:border-transparent border-grey/20 placeholder:text-center relative h-10 rounded-md px-2 text-base text-lg dark:focus:outline-white focus:outline-black-3 font-medium focus:text-left focus:ring-1 dark:focus:ring-blue-2 focus:ring-blue-3 relative w-full dark:text-white text-black-3"
         />
         {searchQuery ? (
           <X
             onClick={() => setSearchQuery("")}
-            className="absolute right-0 -translate-x-2 w-4 h-4 opacity-80 cursor-pointer"
+            className="absolute right-0 -translate-x-2 w-4 h-4 opacity-80 cursor-pointer dark:text-white text-black-3"
           />
         ) : (
-          <SearchIcon className="absolute right-0 -translate-x-2 w-4 h-4 opacity-80" />
+          <SearchIcon className="absolute right-0 -translate-x-2 w-4 h-4 opacity-80 dark:text-white text-black-3" />
         )}
       </div>
       <div
@@ -88,7 +91,7 @@ const GlobalSearch = () => {
           ${isMobile ? "max-h-[250px]" : "max-h-[300px]"}
           ${!isDropdownOpen && "hidden"}
           ${searchResult.length > 0 ? "overflow-y-scroll" : "overflow-y-hidden"}
-          w-[300px] top-28 absolute bg-black-2 rounded-xl`}
+          w-[300px] top-28 absolute dark:bg-black-2 bg-white rounded-xl border dark:border-transparent border-grey/20 shadow-lg`}
         style={{
           scrollbarWidth: "thin",
         }}
@@ -98,7 +101,7 @@ const GlobalSearch = () => {
             return (
               <a
                 href={`${item.category === "companies" ? "/companies/" : "/municipalities/"}${item.id}`}
-                className="text-left text-lg font-md max-w-[300px] p-3 flex justify-between hover:bg-black-1 transition-colors"
+                className="text-left text-lg font-md max-w-[300px] p-3 flex justify-between dark:hover:bg-black-1 hover:bg-grey/10 transition-colors dark:text-white text-black-3"
                 key={item.id}
               >
                 {item.name}
@@ -111,7 +114,7 @@ const GlobalSearch = () => {
             );
           })
         ) : (
-          <Text className="text-grey text-center text-lg font-md h-14 max-w-[300px] overflow-visible p-3">
+          <Text className="dark:text-grey text-black-2 text-center text-lg font-md h-14 max-w-[300px] overflow-visible p-3">
             No results found
           </Text>
         )}

--- a/src/components/ui/globalsearch.tsx
+++ b/src/components/ui/globalsearch.tsx
@@ -73,7 +73,7 @@ const GlobalSearch = () => {
           placeholder={t("globalSearch.placeholder")}
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
-          className="dark:bg-black-1 bg-white border dark:border-transparent border-grey/20 placeholder:text-center relative h-10 rounded-md px-2 text-base text-lg dark:focus:outline-white focus:outline-black-3 font-medium focus:text-left focus:ring-1 dark:focus:ring-blue-2 focus:ring-blue-3 relative w-full dark:text-white text-black-3"
+          className="dark:bg-black-1 bg-grey/10 border dark:border-transparent border-grey/20 placeholder:text-center relative h-10 rounded-md px-2 text-base text-lg dark:focus:outline-white focus:outline-black-3 font-medium focus:text-left focus:ring-1 dark:focus:ring-blue-2 focus:ring-blue-3 relative w-full dark:text-white text-black-3"
         />
         {searchQuery ? (
           <X

--- a/src/components/ui/link-card.tsx
+++ b/src/components/ui/link-card.tsx
@@ -19,16 +19,16 @@ export const LinkCard = ({
       href={link}
       target="_blank"
       rel="noopener noreferrer"
-      className="block dark:bg-black-1 bg-grey/10 rounded-level-2 p-6 dark:hover:bg-black-1/80 hover:bg-grey/20 transition-colors"
+      className="block bg-black-1 light:bg-grey/10 rounded-level-2 p-6 hover:bg-black-1/80 light:hover:bg-grey/20 transition-colors"
       onClick={(e) => e.stopPropagation()}
     >
       <div className="flex items-center justify-between">
         <div>
           <Text
             variant="h6"
-            className="flex items-center gap-2 dark:text-white text-black-3 mb-2"
+            className="flex items-center gap-2 text-white light:text-black-3 mb-2"
           >
-            <FileText className="w-6 h-6 dark:text-white text-black-3" />
+            <FileText className="w-6 h-6 text-white light:text-black-3" />
             <span>{title}</span>
           </Text>
           <Text variant="body" className={descriptionColor}>
@@ -36,7 +36,7 @@ export const LinkCard = ({
           </Text>
         </div>
         {link && (
-          <ArrowUpRight className="w-6 h-6 dark:text-white text-black-3" />
+          <ArrowUpRight className="w-6 h-6 text-white light:text-black-3" />
         )}
       </div>
     </a>

--- a/src/components/ui/link-card.tsx
+++ b/src/components/ui/link-card.tsx
@@ -19,23 +19,25 @@ export const LinkCard = ({
       href={link}
       target="_blank"
       rel="noopener noreferrer"
-      className="block bg-black-1 rounded-level-2 p-6 hover:bg-black-1/80 transition-colors"
+      className="block dark:bg-black-1 bg-grey/10 rounded-level-2 p-6 dark:hover:bg-black-1/80 hover:bg-grey/20 transition-colors"
       onClick={(e) => e.stopPropagation()}
     >
       <div className="flex items-center justify-between">
         <div>
           <Text
             variant="h6"
-            className="flex items-center gap-2 text-white mb-2"
+            className="flex items-center gap-2 dark:text-white text-black-3 mb-2"
           >
-            <FileText className="w-6 h-6 text-white" />
+            <FileText className="w-6 h-6 dark:text-white text-black-3" />
             <span>{title}</span>
           </Text>
           <Text variant="body" className={descriptionColor}>
             {description}
           </Text>
         </div>
-        {link && <ArrowUpRight className="w-6 h-6" />}
+        {link && (
+          <ArrowUpRight className="w-6 h-6 dark:text-white text-black-3" />
+        )}
       </div>
     </a>
   );

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -68,7 +68,7 @@ const NavigationMenuContent = React.forwardRef<
   <NavigationMenuPrimitive.Content
     ref={ref}
     className={cn(
-      "w-full md:absolute md:w-auto min-w-56 p-3 top-12 bg-black-2",
+      "w-full md:absolute md:w-auto min-w-56 p-3 top-12 dark:bg-black-2 bg-white",
       className,
     )}
     {...props}
@@ -85,7 +85,7 @@ const NavigationMenuViewport = React.forwardRef<
   <div className={cn("absolute left-0 top-full flex justify-center")}>
     <NavigationMenuPrimitive.Viewport
       className={cn(
-        "origin-top-center relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border bg-popover text-popover-foreground shadow data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 md:w-[var(--radix-navigation-menu-viewport-width)]",
+        "origin-top-center relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border dark:bg-black-2 bg-white dark:text-white text-black-3 shadow data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 md:w-[var(--radix-navigation-menu-viewport-width)]",
         className,
       )}
       ref={ref}

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -68,7 +68,7 @@ const NavigationMenuContent = React.forwardRef<
   <NavigationMenuPrimitive.Content
     ref={ref}
     className={cn(
-      "w-full md:absolute md:w-auto min-w-56 p-3 top-12 dark:bg-black-2 bg-white",
+      "w-full md:absolute md:w-auto min-w-56 p-3 top-12 bg-black-2 light:bg-white",
       className,
     )}
     {...props}
@@ -85,7 +85,7 @@ const NavigationMenuViewport = React.forwardRef<
   <div className={cn("absolute left-0 top-full flex justify-center")}>
     <NavigationMenuPrimitive.Viewport
       className={cn(
-        "origin-top-center relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border dark:bg-black-2 bg-white dark:text-white text-black-3 shadow data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 md:w-[var(--radix-navigation-menu-viewport-width)]",
+        "origin-top-center relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border bg-black-2 light:bg-white text-white light:text-black-3 shadow data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 md:w-[var(--radix-navigation-menu-viewport-width)]",
         className,
       )}
       ref={ref}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -19,7 +19,7 @@ const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 dark:bg-black/80 bg-black/40 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-black/80 light:bg-black/40 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className,
     )}
     {...props}
@@ -29,7 +29,7 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
 
 const sheetVariants = cva(
-  "fixed z-50 gap-4 dark:bg-black-2 bg-white p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out",
+  "fixed z-50 gap-4 bg-black-2 light:bg-white p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out",
   {
     variants: {
       side: {
@@ -107,7 +107,7 @@ const SheetTitle = React.forwardRef<
   <SheetPrimitive.Title
     ref={ref}
     className={cn(
-      "text-lg font-semibold dark:text-white text-black-3",
+      "text-lg font-semibold text-white light:text-black-3",
       className,
     )}
     {...props}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -19,7 +19,7 @@ const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 dark:bg-black/80 bg-black/40 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className,
     )}
     {...props}
@@ -29,7 +29,7 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
 
 const sheetVariants = cva(
-  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out",
+  "fixed z-50 gap-4 dark:bg-black-2 bg-white p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out",
   {
     variants: {
       side: {
@@ -106,7 +106,10 @@ const SheetTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Title
     ref={ref}
-    className={cn("text-lg font-semibold text-foreground", className)}
+    className={cn(
+      "text-lg font-semibold dark:text-white text-black-3",
+      className,
+    )}
     {...props}
   />
 ));

--- a/src/components/ui/theme-toggle.tsx
+++ b/src/components/ui/theme-toggle.tsx
@@ -1,0 +1,55 @@
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
+import { Button } from "./button";
+import { cn } from "@/lib/utils";
+
+export function ThemeToggle({ className }: { className?: string }) {
+  const { theme, setTheme, resolvedTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  // useEffect only runs on the client, so now we can safely show the UI
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return (
+      <Button
+        variant="ghost"
+        size="icon"
+        className={cn("h-8 w-8", className)}
+        aria-label="Toggle theme"
+      >
+        <Sun className="h-4 w-4" />
+      </Button>
+    );
+  }
+
+  // Use resolvedTheme to get the actual theme (handles "system" theme)
+  const currentTheme = resolvedTheme || theme;
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      className={cn("h-8 w-8", className)}
+      onClick={() => {
+        if (theme === "system") {
+          // If system, toggle to the opposite of current resolved theme
+          setTheme(currentTheme === "dark" ? "light" : "dark");
+        } else {
+          // Toggle between light and dark
+          setTheme(theme === "dark" ? "light" : "dark");
+        }
+      }}
+      aria-label="Toggle theme"
+    >
+      {currentTheme === "dark" ? (
+        <Sun className="h-4 w-4" />
+      ) : (
+        <Moon className="h-4 w-4" />
+      )}
+    </Button>
+  );
+}

--- a/src/components/ui/typewriter.tsx
+++ b/src/components/ui/typewriter.tsx
@@ -57,10 +57,10 @@ const Typewriter = ({
   const texts = useMemo(() => (Array.isArray(text) ? text : [text]), [text]);
 
   // Reset display text when language is changed
-  i18next.on('languageChanged', () => {
-    setDisplayText('');
+  i18next.on("languageChanged", () => {
+    setDisplayText("");
     setIsDeleting(true);
-  })
+  });
 
   useEffect(() => {
     let timeout: NodeJS.Timeout;
@@ -126,8 +126,8 @@ const Typewriter = ({
   ]);
 
   return (
-    <div className={`inline whitespace-pre-wrap tracking-tight ${className}`}>
-      <span>{displayText}</span>
+    <div className="inline whitespace-pre-wrap tracking-tight">
+      <span className={cn(className)}>{displayText}</span>
       {showCursor && (
         <motion.span
           variants={cursorAnimationVariants}

--- a/src/components/ui/view-mode-toggle.tsx
+++ b/src/components/ui/view-mode-toggle.tsx
@@ -30,7 +30,7 @@ export function ViewModeToggle<T extends string>({
   return (
     <div
       className={cn(
-        "flex dark:bg-black-1 bg-grey/10 rounded-md overflow-hidden",
+        "flex bg-black-1 light:bg-grey/10 rounded-md overflow-hidden",
       )}
     >
       {modes.map((mode) => (

--- a/src/components/ui/view-mode-toggle.tsx
+++ b/src/components/ui/view-mode-toggle.tsx
@@ -28,7 +28,11 @@ export function ViewModeToggle<T extends string>({
   } as Record<string, React.ReactNode>;
 
   return (
-    <div className={cn("flex bg-black-1 rounded-md overflow-hidden")}>
+    <div
+      className={cn(
+        "flex dark:bg-black-1 bg-grey/10 rounded-md overflow-hidden",
+      )}
+    >
       {modes.map((mode) => (
         <Button
           key={mode}

--- a/src/contexts/ThemeProvider.tsx
+++ b/src/contexts/ThemeProvider.tsx
@@ -1,0 +1,6 @@
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import { type ThemeProviderProps } from "next-themes/dist/types";
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -16,8 +16,6 @@
     sans-serif;
   line-height: 1.5;
   font-weight: 400;
-  background-color: black;
-  color: white;
 
   /* Grey palette */
   --grey: #878787;
@@ -60,12 +58,25 @@
   --pink-3-muted: color-mix(in srgb, var(--pink-3) 20%, transparent);
 }
 
+:root.dark {
+  background-color: black;
+  color: white;
+}
+
+:root.light {
+  background-color: #f7f7f7;
+  color: #000000;
+}
+
 @layer base {
   * {
     @apply border-border;
   }
   body {
-    @apply bg-black text-white;
+    @apply bg-black dark:bg-black text-white dark:text-white;
+  }
+  html.light body {
+    @apply bg-white text-black-3;
   }
   h1,
   h2,
@@ -84,52 +95,52 @@
 @layer components {
   /* Command menu styling */
   .cmd-menu {
-    @apply bg-black-2 border-none text-white;
+    @apply bg-black-2 dark:bg-black-2 bg-white border-none text-white dark:text-white text-black-3;
   }
 
   .cmd-input {
-    @apply bg-black-1 border-none;
+    @apply bg-black-1 dark:bg-black-1 bg-grey/10 border-none;
   }
 
   .cmd-item {
-    @apply text-grey hover:bg-black-1 hover:text-white;
+    @apply text-grey dark:text-grey hover:bg-black-1 dark:hover:bg-black-1 hover:bg-grey/20 hover:text-white dark:hover:text-white hover:text-black-3;
   }
 
   /* Popover styling */
   .popover-content {
-    @apply bg-black-2 border-none;
+    @apply bg-black-2 dark:bg-black-2 bg-white border-none;
   }
 
   /* Select styling */
   .select-trigger {
-    @apply bg-black-1 border-none text-white;
+    @apply bg-black-1 dark:bg-black-1 bg-grey/10 border-none text-white dark:text-white text-black-3;
   }
 
   .select-content {
-    @apply bg-black-2 border-none;
+    @apply bg-black-2 dark:bg-black-2 bg-white border-none;
   }
 
   .select-item {
-    @apply text-grey hover:bg-black-1 hover:text-white;
+    @apply text-grey dark:text-grey hover:bg-black-1 dark:hover:bg-black-1 hover:bg-grey/20 hover:text-white dark:hover:text-white hover:text-black-3;
   }
 
   /* Dialog styling */
   .dialog-content {
-    @apply bg-black-2 border-none;
+    @apply bg-black-2 dark:bg-black-2 bg-white border-none;
   }
 
   /* Sheet styling */
   .sheet-content {
-    @apply bg-black-2 border-none;
+    @apply bg-black-2 dark:bg-black-2 bg-white border-none;
   }
 
   /* Dropdown menu styling */
   .dropdown-content {
-    @apply bg-black-2 border-none;
+    @apply bg-black-2 dark:bg-black-2 bg-white border-none;
   }
 
   .dropdown-item {
-    @apply text-grey hover:bg-black-1 hover:text-white;
+    @apply text-grey dark:text-grey hover:bg-black-1 dark:hover:bg-black-1 hover:bg-grey/20 hover:text-white dark:hover:text-white hover:text-black-3;
   }
 
   /* Menubar styling */
@@ -138,33 +149,33 @@
   }
 
   .menubar-content {
-    @apply bg-black-2 border-none rounded-level-2 p-2;
+    @apply bg-black-2 dark:bg-black-2 bg-white border-none rounded-level-2 p-2;
   }
 
   .menubar-item {
-    @apply text-grey hover:bg-black-1 hover:text-white rounded-level-2 cursor-pointer;
+    @apply text-grey dark:text-grey hover:bg-black-1 dark:hover:bg-black-1 hover:bg-grey/20 hover:text-white dark:hover:text-white hover:text-black-3 rounded-level-2 cursor-pointer;
   }
 
   .menubar-separator {
-    @apply bg-black-1;
+    @apply bg-black-1 dark:bg-black-1 bg-grey/20;
   }
 
   .menubar-shortcut {
-    @apply text-grey;
+    @apply text-grey dark:text-grey;
   }
 }
 
 /* Prose styling for blog content */
 .prose {
-  @apply text-grey;
+  @apply text-grey dark:text-grey;
 }
 
 .prose h2 {
-  @apply text-3xl font-light text-white mt-12 mb-6;
+  @apply text-3xl font-light text-white dark:text-white text-black-3 mt-12 mb-6;
 }
 
 .prose h3 {
-  @apply text-2xl font-light text-white mt-8 mb-4;
+  @apply text-2xl font-light text-white dark:text-white text-black-3 mt-8 mb-4;
 }
 
 .prose p {

--- a/src/index.css
+++ b/src/index.css
@@ -73,10 +73,10 @@
     @apply border-border;
   }
   body {
-    @apply bg-black dark:bg-black text-white dark:text-white;
+    @apply bg-black text-white;
   }
   html.light body {
-    @apply bg-white text-black-3;
+    @apply light:bg-white light:text-black-3;
   }
   h1,
   h2,
@@ -95,52 +95,52 @@
 @layer components {
   /* Command menu styling */
   .cmd-menu {
-    @apply bg-black-2 dark:bg-black-2 bg-white border-none text-white dark:text-white text-black-3;
+    @apply bg-black-2 light:bg-white border-none text-white light:text-black-3;
   }
 
   .cmd-input {
-    @apply bg-black-1 dark:bg-black-1 bg-grey/10 border-none;
+    @apply bg-black-1 light:bg-grey/10 border-none;
   }
 
   .cmd-item {
-    @apply text-grey dark:text-grey hover:bg-black-1 dark:hover:bg-black-1 hover:bg-grey/20 hover:text-white dark:hover:text-white hover:text-black-3;
+    @apply text-grey light:text-grey hover:bg-black-1 light:hover:bg-grey/20 hover:text-white light:hover:text-black-3;
   }
 
   /* Popover styling */
   .popover-content {
-    @apply bg-black-2 dark:bg-black-2 bg-white border-none;
+    @apply bg-black-2 light:bg-white border-none;
   }
 
   /* Select styling */
   .select-trigger {
-    @apply bg-black-1 dark:bg-black-1 bg-grey/10 border-none text-white dark:text-white text-black-3;
+    @apply bg-black-1 light:bg-grey/10 border-none text-white light:text-black-3;
   }
 
   .select-content {
-    @apply bg-black-2 dark:bg-black-2 bg-white border-none;
+    @apply bg-black-2 light:bg-white border-none;
   }
 
   .select-item {
-    @apply text-grey dark:text-grey hover:bg-black-1 dark:hover:bg-black-1 hover:bg-grey/20 hover:text-white dark:hover:text-white hover:text-black-3;
+    @apply text-grey light:text-grey hover:bg-black-1 light:hover:bg-grey/20 hover:text-white light:hover:text-black-3;
   }
 
   /* Dialog styling */
   .dialog-content {
-    @apply bg-black-2 dark:bg-black-2 bg-white border-none;
+    @apply bg-black-2 light:bg-white border-none;
   }
 
   /* Sheet styling */
   .sheet-content {
-    @apply bg-black-2 dark:bg-black-2 bg-white border-none;
+    @apply bg-black-2 light:bg-white border-none;
   }
 
   /* Dropdown menu styling */
   .dropdown-content {
-    @apply bg-black-2 dark:bg-black-2 bg-white border-none;
+    @apply bg-black-2 light:bg-white border-none;
   }
 
   .dropdown-item {
-    @apply text-grey dark:text-grey hover:bg-black-1 dark:hover:bg-black-1 hover:bg-grey/20 hover:text-white dark:hover:text-white hover:text-black-3;
+    @apply text-grey light:text-grey hover:bg-black-1 light:hover:bg-grey/20 hover:text-white light:hover:text-black-3;
   }
 
   /* Menubar styling */
@@ -149,33 +149,33 @@
   }
 
   .menubar-content {
-    @apply bg-black-2 dark:bg-black-2 bg-white border-none rounded-level-2 p-2;
+    @apply bg-black-2 light:bg-white border-none rounded-level-2 p-2;
   }
 
   .menubar-item {
-    @apply text-grey dark:text-grey hover:bg-black-1 dark:hover:bg-black-1 hover:bg-grey/20 hover:text-white dark:hover:text-white hover:text-black-3 rounded-level-2 cursor-pointer;
+    @apply text-grey light:text-grey hover:bg-black-1 light:hover:bg-grey/20 hover:text-white light:hover:text-black-3 rounded-level-2 cursor-pointer;
   }
 
   .menubar-separator {
-    @apply bg-black-1 dark:bg-black-1 bg-grey/20;
+    @apply bg-black-1 light:bg-grey/20;
   }
 
   .menubar-shortcut {
-    @apply text-grey dark:text-grey;
+    @apply text-grey light:text-grey;
   }
 }
 
 /* Prose styling for blog content */
 .prose {
-  @apply text-grey dark:text-grey;
+  @apply text-grey light:text-grey;
 }
 
 .prose h2 {
-  @apply text-3xl font-light text-white dark:text-white text-black-3 mt-12 mb-6;
+  @apply text-3xl font-light text-white light:text-black-3 mt-12 mb-6;
 }
 
 .prose h3 {
-  @apply text-2xl font-light text-white dark:text-white text-black-3 mt-8 mb-4;
+  @apply text-2xl font-light text-white light:text-black-3 mt-8 mb-4;
 }
 
 .prose p {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { HelmetProvider } from "react-helmet-async";
 import { RouterProvider, createBrowserRouter } from "react-router-dom";
 import AuthProvider from "./contexts/AuthContext";
+import { ThemeProvider } from "./contexts/ThemeProvider";
 import "./index.css";
 import "./i18n";
 
@@ -17,13 +18,15 @@ const router = createBrowserRouter([
   {
     path: "*",
     element: (
-      <AuthProvider>
-        <LanguageProvider>
-          <Layout>
-            <App />
-          </Layout>
-        </LanguageProvider>
-      </AuthProvider>
+      <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+        <AuthProvider>
+          <LanguageProvider>
+            <Layout>
+              <App />
+            </Layout>
+          </LanguageProvider>
+        </AuthProvider>
+      </ThemeProvider>
     ),
   },
 ]);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -18,7 +18,7 @@ const router = createBrowserRouter([
   {
     path: "*",
     element: (
-      <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+      <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
         <AuthProvider>
           <LanguageProvider>
             <Layout>

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -44,14 +44,14 @@ export function AboutPage() {
         />
         <Accordion type="single" collapsible className="space-y-6">
           {/* Main Content */}
-          <div className="dark:bg-black-2 bg-white rounded-level-1 p-4 md:p-8">
+          <div className="bg-black-2 light:bg-white rounded-level-1 p-4 md:p-8">
             <div className="flex flex-col md:flex-row items-start justify-between">
               <div className="space-y-4 w-full">
                 {/* Header */}
                 <div className="flex flex-wrap items-center gap-4">
                   <Text
                     variant="h3"
-                    className="text-4xl md:text-3xl sm:text-2xl dark:text-white text-black-3"
+                    className="text-4xl md:text-3xl sm:text-2xl text-white light:text-black-3"
                   >
                     {t("aboutPage.mainContent.title")}
                   </Text>
@@ -59,13 +59,13 @@ export function AboutPage() {
                 <KlimatkollenVideo />
 
                 <div className="flex flex-col md:flex-row space-y-8 md:space-y-0 md:space-x-4">
-                  <div className="prose dark:prose-invert w-full max-w-5xl space-y-4">
+                  <div className="prose prose-invert w-full max-w-5xl space-y-4">
                     <p>{t("aboutPage.mainContent.paragraph1")}</p>
                     <p>{t("aboutPage.mainContent.paragraph2")}</p>
                   </div>
                 </div>
 
-                <div className="prose dark:prose-invert w-full max-w-6xl space-y-4">
+                <div className="prose prose-invert w-full max-w-6xl space-y-4">
                   <p>{t("aboutPage.mainContent.paragraph3")}</p>
 
                   <p>{t("aboutPage.mainContent.paragraph4")}</p>
@@ -79,7 +79,7 @@ export function AboutPage() {
             title={t("aboutPage.ourApproachSection.title")}
             value="ourApproachSection"
           >
-            <div className="prose dark:prose-invert w-[90%] max-w-5xl mx-auto space-y-4">
+            <div className="prose prose-invert w-[90%] max-w-5xl mx-auto space-y-4">
               <p>{t("aboutPage.ourApproachSection.paragraph1")}</p>
               <p>{t("aboutPage.ourApproachSection.paragraph2")}</p>
               <p>{t("aboutPage.ourApproachSection.paragraph3")}</p>
@@ -92,7 +92,7 @@ export function AboutPage() {
                     <a
                       title="Email us"
                       href="mailto:hej@klimatkollen.se"
-                      className="underline dark:hover:text-white hover:text-black-3"
+                      className="underline hover:text-white light:hover:text-black-3"
                     />,
                   ]}
                 />
@@ -115,14 +115,14 @@ export function AboutPage() {
             value="boardSection"
           >
             <MembersGrid members={boardMembers} />
-            <div className="p-8 prose dark:prose-invert">
+            <div className="p-8 prose prose-invert">
               <p>
                 {t("aboutPage.boardSection.links.stadgar")}{" "}
                 <a
                   href="/documents/stadgar.pdf"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="underline dark:hover:text-white hover:text-black-3"
+                  className="underline hover:text-white light:hover:text-black-3"
                 >
                   {t("aboutPage.boardSection.links.stadgarLink")}
                 </a>
@@ -131,7 +131,7 @@ export function AboutPage() {
                   href="/documents/uppforandekod.pdf"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="underline dark:hover:text-white hover:text-black-3"
+                  className="underline hover:text-white light:hover:text-black-3"
                 >
                   {t("aboutPage.boardSection.links.uppforandekodLink")}
                 </a>{" "}
@@ -140,7 +140,7 @@ export function AboutPage() {
                   href="/documents/antikorruptionspolicy.pdf"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="underline dark:hover:text-white hover:text-black-3"
+                  className="underline hover:text-white light:hover:text-black-3"
                 >
                   {t("aboutPage.boardSection.links.antikorruptionspolicyLink")}
                 </a>{" "}
@@ -154,13 +154,13 @@ export function AboutPage() {
             title={t("aboutPage.financingSection.title")}
             value="financingSection"
           >
-            <div className="prose dark:prose-invert w-[90%] max-w-5xl mx-auto space-y-4">
+            <div className="prose prose-invert w-[90%] max-w-5xl mx-auto space-y-4">
               <p>{t("aboutPage.financingSection.paragraph1")}</p>
               <p>{t("aboutPage.financingSection.paragraph2")}</p>
               <p>{t("aboutPage.financingSection.paragraph3")}</p>
               <p>{t("aboutPage.financingSection.paragraph4")}</p>
-              <div className="dark:bg-blue-5/30 bg-blue-1/50 rounded-level-2 p-6 mt-8 max-w-3xl">
-                <Text variant="body" className="dark:text-white text-black-3">
+              <div className="bg-blue-5/30 light:bg-blue-1/50 rounded-level-2 p-6 mt-8 max-w-3xl">
+                <Text variant="body" className="text-white light:text-black-3">
                   {t("aboutPage.financingSection.donate")}
                 </Text>
                 <Text className="text-grey">
@@ -182,12 +182,12 @@ export function AboutPage() {
             title={t("aboutPage.previousProjectsSection.title")}
             value="previousProjects"
           >
-            <div className="prose dark:prose-invert w-[90%] max-w-5xl mx-auto space-y-8">
+            <div className="prose prose-invert w-[90%] max-w-5xl mx-auto space-y-8">
               <div className="space-y-4">
                 <Text className="text-blue-2 font-bold text-2xl">
                   {t("aboutPage.previousProjectsSection.kommunprojektetTitle")}
                 </Text>
-                <Text variant="body" className="dark:text-white text-black-3">
+                <Text variant="body" className="text-white light:text-black-3">
                   {t(
                     "aboutPage.previousProjectsSection.kommunprojektetDescription",
                   )}
@@ -198,7 +198,7 @@ export function AboutPage() {
                 <Text className="text-blue-2 font-bold text-2xl">
                   {t("aboutPage.previousProjectsSection.riksdagsvaletTitle")}
                 </Text>
-                <Text variant="body" className="dark:text-white text-black-3">
+                <Text variant="body" className="text-white light:text-black-3">
                   {t(
                     "aboutPage.previousProjectsSection.riksdagsvaletDescription",
                   )}

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -44,14 +44,14 @@ export function AboutPage() {
         />
         <Accordion type="single" collapsible className="space-y-6">
           {/* Main Content */}
-          <div className="bg-black-2 rounded-level-1 p-4 md:p-8">
+          <div className="dark:bg-black-2 bg-white rounded-level-1 p-4 md:p-8">
             <div className="flex flex-col md:flex-row items-start justify-between">
               <div className="space-y-4 w-full">
                 {/* Header */}
                 <div className="flex flex-wrap items-center gap-4">
                   <Text
                     variant="h3"
-                    className="text-4xl md:text-3xl sm:text-2xl"
+                    className="text-4xl md:text-3xl sm:text-2xl dark:text-white text-black-3"
                   >
                     {t("aboutPage.mainContent.title")}
                   </Text>
@@ -59,13 +59,13 @@ export function AboutPage() {
                 <KlimatkollenVideo />
 
                 <div className="flex flex-col md:flex-row space-y-8 md:space-y-0 md:space-x-4">
-                  <div className="prose prose-invert w-full max-w-5xl space-y-4">
+                  <div className="prose dark:prose-invert w-full max-w-5xl space-y-4">
                     <p>{t("aboutPage.mainContent.paragraph1")}</p>
                     <p>{t("aboutPage.mainContent.paragraph2")}</p>
                   </div>
                 </div>
 
-                <div className="prose prose-invert w-full max-w-6xl space-y-4">
+                <div className="prose dark:prose-invert w-full max-w-6xl space-y-4">
                   <p>{t("aboutPage.mainContent.paragraph3")}</p>
 
                   <p>{t("aboutPage.mainContent.paragraph4")}</p>
@@ -79,7 +79,7 @@ export function AboutPage() {
             title={t("aboutPage.ourApproachSection.title")}
             value="ourApproachSection"
           >
-            <div className="prose prose-invert w-[90%] max-w-5xl mx-auto space-y-4">
+            <div className="prose dark:prose-invert w-[90%] max-w-5xl mx-auto space-y-4">
               <p>{t("aboutPage.ourApproachSection.paragraph1")}</p>
               <p>{t("aboutPage.ourApproachSection.paragraph2")}</p>
               <p>{t("aboutPage.ourApproachSection.paragraph3")}</p>
@@ -92,7 +92,7 @@ export function AboutPage() {
                     <a
                       title="Email us"
                       href="mailto:hej@klimatkollen.se"
-                      className="underline hover:text-white"
+                      className="underline dark:hover:text-white hover:text-black-3"
                     />,
                   ]}
                 />
@@ -115,14 +115,14 @@ export function AboutPage() {
             value="boardSection"
           >
             <MembersGrid members={boardMembers} />
-            <div className="p-8 prose prose-invert">
+            <div className="p-8 prose dark:prose-invert">
               <p>
                 {t("aboutPage.boardSection.links.stadgar")}{" "}
                 <a
                   href="/documents/stadgar.pdf"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="underline hover:text-white"
+                  className="underline dark:hover:text-white hover:text-black-3"
                 >
                   {t("aboutPage.boardSection.links.stadgarLink")}
                 </a>
@@ -131,7 +131,7 @@ export function AboutPage() {
                   href="/documents/uppforandekod.pdf"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="underline hover:text-white"
+                  className="underline dark:hover:text-white hover:text-black-3"
                 >
                   {t("aboutPage.boardSection.links.uppforandekodLink")}
                 </a>{" "}
@@ -140,7 +140,7 @@ export function AboutPage() {
                   href="/documents/antikorruptionspolicy.pdf"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="underline hover:text-white"
+                  className="underline dark:hover:text-white hover:text-black-3"
                 >
                   {t("aboutPage.boardSection.links.antikorruptionspolicyLink")}
                 </a>{" "}
@@ -154,13 +154,13 @@ export function AboutPage() {
             title={t("aboutPage.financingSection.title")}
             value="financingSection"
           >
-            <div className="prose prose-invert w-[90%] max-w-5xl mx-auto space-y-4">
+            <div className="prose dark:prose-invert w-[90%] max-w-5xl mx-auto space-y-4">
               <p>{t("aboutPage.financingSection.paragraph1")}</p>
               <p>{t("aboutPage.financingSection.paragraph2")}</p>
               <p>{t("aboutPage.financingSection.paragraph3")}</p>
               <p>{t("aboutPage.financingSection.paragraph4")}</p>
-              <div className="bg-blue-5/30 rounded-level-2 p-6 mt-8 max-w-3xl">
-                <Text variant="body">
+              <div className="dark:bg-blue-5/30 bg-blue-1/50 rounded-level-2 p-6 mt-8 max-w-3xl">
+                <Text variant="body" className="dark:text-white text-black-3">
                   {t("aboutPage.financingSection.donate")}
                 </Text>
                 <Text className="text-grey">
@@ -182,12 +182,12 @@ export function AboutPage() {
             title={t("aboutPage.previousProjectsSection.title")}
             value="previousProjects"
           >
-            <div className="prose prose-invert w-[90%] max-w-5xl mx-auto space-y-8">
+            <div className="prose dark:prose-invert w-[90%] max-w-5xl mx-auto space-y-8">
               <div className="space-y-4">
                 <Text className="text-blue-2 font-bold text-2xl">
                   {t("aboutPage.previousProjectsSection.kommunprojektetTitle")}
                 </Text>
-                <Text variant="body">
+                <Text variant="body" className="dark:text-white text-black-3">
                   {t(
                     "aboutPage.previousProjectsSection.kommunprojektetDescription",
                   )}
@@ -198,7 +198,7 @@ export function AboutPage() {
                 <Text className="text-blue-2 font-bold text-2xl">
                   {t("aboutPage.previousProjectsSection.riksdagsvaletTitle")}
                 </Text>
-                <Text variant="body">
+                <Text variant="body" className="dark:text-white text-black-3">
                   {t(
                     "aboutPage.previousProjectsSection.riksdagsvaletDescription",
                   )}

--- a/src/pages/BlogDetailPage.tsx
+++ b/src/pages/BlogDetailPage.tsx
@@ -79,7 +79,7 @@ export function BlogDetailPage() {
           onClick={handleShare}
         >
           {copied ? (
-            <Check className="w-4 h-4 text-green-500" />
+            <Check className="w-4 h-4 dark:text-green-500 text-green-4" />
           ) : (
             <Share2 className="w-4 h-4" />
           )}
@@ -88,9 +88,9 @@ export function BlogDetailPage() {
       </div>
 
       {/* Hero Section */}
-      <div className={`space-y-${isMobile ? "4" : "8"}`}>
+      <div className={isMobile ? "space-y-4" : "space-y-8"}>
         <div className="flex flex-wrap items-center gap-4">
-          <span className="px-3 py-1 bg-blue-5/50 rounded-full text-blue-2 text-sm">
+          <span className="px-3 py-1 dark:bg-blue-5/50 bg-blue-1/50 rounded-full text-blue-2 text-sm">
             {t("insightCategories." + blogPost.metadata.category)}
           </span>
           <div className="flex items-center gap-2 text-grey text-sm">
@@ -107,7 +107,7 @@ export function BlogDetailPage() {
 
         <Text
           variant={isMobile ? "h1" : "display"}
-          className={isMobile ? "text-3xl" : ""}
+          className={`${isMobile ? "text-3xl" : ""} dark:text-white text-black-3`}
         >
           {blogPost.metadata.title}
         </Text>
@@ -132,20 +132,22 @@ export function BlogDetailPage() {
 
       {/* Author Section */}
       {blogPost.metadata.author && (
-        <div className="flex items-center gap-4 p-8 bg-black-2 rounded-level-2">
+        <div className="flex items-center gap-4 p-8 dark:bg-black-2 bg-white rounded-level-2 border dark:border-transparent border-grey/20">
           <img
             src={blogPost.metadata.author.avatar}
             alt={blogPost.metadata.author.name}
             className="w-16 h-16 rounded-full object-cover"
           />
           <div>
-            <Text variant="body">{blogPost.metadata.author.name}</Text>
+            <Text variant="body" className="dark:text-white text-black-3">
+              {blogPost.metadata.author.name}
+            </Text>
           </div>
         </div>
       )}
 
       {/* Content */}
-      <div className="prose prose-invert max-w-none">
+      <div className="prose dark:prose-invert max-w-none">
         <ReactMarkdown
           remarkPlugins={[remarkGfm, remarkBreaks, remarkMath]}
           rehypePlugins={[rehypeRaw, rehypeKatex]}
@@ -161,7 +163,7 @@ export function BlogDetailPage() {
                 {...props}
                 target="_blank" // Opens link in a new tab
                 rel="noopener noreferrer"
-                className="underline hover:text-white"
+                className="underline dark:hover:text-white hover:text-black-3"
               />
             ),
             table: ({ node, ...props }) => (
@@ -170,16 +172,19 @@ export function BlogDetailPage() {
               </div>
             ),
             thead: ({ node, ...props }) => (
-              <thead {...props} className="bg-blue-5/20" />
+              <thead {...props} className="dark:bg-blue-5/20 bg-blue-1/30" />
             ),
             th: ({ node, ...props }) => (
               <th
                 {...props}
-                className="border border-blue-2/50 px-4 py-3 text-left font-semibold text-blue-2"
+                className="border dark:border-blue-2/50 border-blue-4/50 px-4 py-3 text-left font-semibold text-blue-2"
               />
             ),
             td: ({ node, ...props }) => (
-              <td {...props} className="border border-slate-500/50 px-4 py-3" />
+              <td
+                {...props}
+                className="border dark:border-slate-500/50 border-grey/30 px-4 py-3"
+              />
             ),
           }}
         >
@@ -190,7 +195,9 @@ export function BlogDetailPage() {
       {/* Related Posts */}
       {relatedPosts.length > 0 && (
         <div className="space-y-8">
-          <Text variant="h3">{t("blogDetailPage.relatedArticles")}</Text>
+          <Text variant="h3" className="dark:text-white text-black-3">
+            {t("blogDetailPage.relatedArticles")}
+          </Text>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
             {relatedPosts.map(
               (post) =>
@@ -198,7 +205,7 @@ export function BlogDetailPage() {
                   <Link
                     key={post.id}
                     to={`/insights/${post.id}`}
-                    className="group bg-black-2 rounded-level-2 overflow-hidden transition-transform hover:scale-[1.02]"
+                    className="group dark:bg-black-2 bg-white rounded-level-2 overflow-hidden transition-transform hover:scale-[1.02] border dark:border-transparent border-grey/20"
                   >
                     <div className="relative h-48 overflow-hidden">
                       <img
@@ -209,7 +216,7 @@ export function BlogDetailPage() {
                     </div>
                     <div className="p-8 space-y-4">
                       <div className="flex items-center gap-4">
-                        <span className="px-3 py-1 bg-blue-5/50 rounded-full text-blue-2 text-sm">
+                        <span className="px-3 py-1 dark:bg-blue-5/50 bg-blue-1/50 rounded-full text-blue-2 text-sm">
                           {post.category}
                         </span>
                         <div className="flex items-center gap-2 text-grey text-sm">
@@ -225,7 +232,7 @@ export function BlogDetailPage() {
                       </div>
                       <Text
                         variant="h4"
-                        className="group-hover:text-blue-2 transition-colors"
+                        className="dark:text-white text-black-3 group-hover:text-blue-2 transition-colors"
                       >
                         {post.title}
                       </Text>

--- a/src/pages/BlogDetailPage.tsx
+++ b/src/pages/BlogDetailPage.tsx
@@ -132,7 +132,7 @@ export function BlogDetailPage() {
 
       {/* Author Section */}
       {blogPost.metadata.author && (
-        <div className="flex items-center gap-4 p-8 dark:bg-black-2 bg-white rounded-level-2 border dark:border-transparent border-grey/20">
+        <div className="flex items-center gap-4 p-8 dark:bg-black-2 bg-grey/10 rounded-level-2 border dark:border-transparent border-grey/20">
           <img
             src={blogPost.metadata.author.avatar}
             alt={blogPost.metadata.author.name}
@@ -205,7 +205,7 @@ export function BlogDetailPage() {
                   <Link
                     key={post.id}
                     to={`/insights/${post.id}`}
-                    className="group dark:bg-black-2 bg-white rounded-level-2 overflow-hidden transition-transform hover:scale-[1.02] border dark:border-transparent border-grey/20"
+                    className="group dark:bg-black-2 bg-grey/10 rounded-level-2 overflow-hidden transition-transform hover:scale-[1.02] border dark:border-transparent border-grey/20"
                   >
                     <div className="relative h-48 overflow-hidden">
                       <img

--- a/src/pages/BlogDetailPage.tsx
+++ b/src/pages/BlogDetailPage.tsx
@@ -79,7 +79,7 @@ export function BlogDetailPage() {
           onClick={handleShare}
         >
           {copied ? (
-            <Check className="w-4 h-4 dark:text-green-500 text-green-4" />
+            <Check className="w-4 h-4 text-green-500 light:text-green-4" />
           ) : (
             <Share2 className="w-4 h-4" />
           )}
@@ -90,7 +90,7 @@ export function BlogDetailPage() {
       {/* Hero Section */}
       <div className={isMobile ? "space-y-4" : "space-y-8"}>
         <div className="flex flex-wrap items-center gap-4">
-          <span className="px-3 py-1 dark:bg-blue-5/50 bg-blue-1/50 rounded-full text-blue-2 text-sm">
+          <span className="px-3 py-1 bg-blue-5/50 light:bg-blue-1/50 rounded-full text-blue-2 text-sm">
             {t("insightCategories." + blogPost.metadata.category)}
           </span>
           <div className="flex items-center gap-2 text-grey text-sm">
@@ -107,7 +107,7 @@ export function BlogDetailPage() {
 
         <Text
           variant={isMobile ? "h1" : "display"}
-          className={`${isMobile ? "text-3xl" : ""} dark:text-white text-black-3`}
+          className={`${isMobile ? "text-3xl" : ""} text-white light:text-black-3`}
         >
           {blogPost.metadata.title}
         </Text>
@@ -132,14 +132,14 @@ export function BlogDetailPage() {
 
       {/* Author Section */}
       {blogPost.metadata.author && (
-        <div className="flex items-center gap-4 p-8 dark:bg-black-2 bg-grey/10 rounded-level-2 border dark:border-transparent border-grey/20">
+        <div className="flex items-center gap-4 p-8 bg-black-2 light:bg-grey/10 rounded-level-2 border border-transparent light:border-grey/20">
           <img
             src={blogPost.metadata.author.avatar}
             alt={blogPost.metadata.author.name}
             className="w-16 h-16 rounded-full object-cover"
           />
           <div>
-            <Text variant="body" className="dark:text-white text-black-3">
+            <Text variant="body" className="text-white light:text-black-3">
               {blogPost.metadata.author.name}
             </Text>
           </div>
@@ -147,7 +147,7 @@ export function BlogDetailPage() {
       )}
 
       {/* Content */}
-      <div className="prose dark:prose-invert max-w-none">
+      <div className="prose prose-invert max-w-none">
         <ReactMarkdown
           remarkPlugins={[remarkGfm, remarkBreaks, remarkMath]}
           rehypePlugins={[rehypeRaw, rehypeKatex]}
@@ -163,7 +163,7 @@ export function BlogDetailPage() {
                 {...props}
                 target="_blank" // Opens link in a new tab
                 rel="noopener noreferrer"
-                className="underline dark:hover:text-white hover:text-black-3"
+                className="underline hover:text-white light:hover:text-black-3"
               />
             ),
             table: ({ node, ...props }) => (
@@ -172,18 +172,18 @@ export function BlogDetailPage() {
               </div>
             ),
             thead: ({ node, ...props }) => (
-              <thead {...props} className="dark:bg-blue-5/20 bg-blue-1/30" />
+              <thead {...props} className="bg-blue-5/20 light:bg-blue-1/30" />
             ),
             th: ({ node, ...props }) => (
               <th
                 {...props}
-                className="border dark:border-blue-2/50 border-blue-4/50 px-4 py-3 text-left font-semibold text-blue-2"
+                className="border border-blue-2/50 light:border-blue-4/50 px-4 py-3 text-left font-semibold text-blue-2"
               />
             ),
             td: ({ node, ...props }) => (
               <td
                 {...props}
-                className="border dark:border-slate-500/50 border-grey/30 px-4 py-3"
+                className="border border-slate-500/50 light:border-grey/30 px-4 py-3"
               />
             ),
           }}
@@ -195,7 +195,7 @@ export function BlogDetailPage() {
       {/* Related Posts */}
       {relatedPosts.length > 0 && (
         <div className="space-y-8">
-          <Text variant="h3" className="dark:text-white text-black-3">
+          <Text variant="h3" className="text-white light:text-black-3">
             {t("blogDetailPage.relatedArticles")}
           </Text>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
@@ -205,7 +205,7 @@ export function BlogDetailPage() {
                   <Link
                     key={post.id}
                     to={`/insights/${post.id}`}
-                    className="group dark:bg-black-2 bg-grey/10 rounded-level-2 overflow-hidden transition-transform hover:scale-[1.02] border dark:border-transparent border-grey/20"
+                    className="group bg-black-2 light:bg-grey/10 rounded-level-2 overflow-hidden transition-transform hover:scale-[1.02] border border-transparent light:border-grey/20"
                   >
                     <div className="relative h-48 overflow-hidden">
                       <img
@@ -216,7 +216,7 @@ export function BlogDetailPage() {
                     </div>
                     <div className="p-8 space-y-4">
                       <div className="flex items-center gap-4">
-                        <span className="px-3 py-1 dark:bg-blue-5/50 bg-blue-1/50 rounded-full text-blue-2 text-sm">
+                        <span className="px-3 py-1 bg-blue-5/50 light:bg-blue-1/50 rounded-full text-blue-2 text-sm">
                           {post.category}
                         </span>
                         <div className="flex items-center gap-2 text-grey text-sm">
@@ -232,7 +232,7 @@ export function BlogDetailPage() {
                       </div>
                       <Text
                         variant="h4"
-                        className="dark:text-white text-black-3 group-hover:text-blue-2 transition-colors"
+                        className="text-white light:text-black-3 group-hover:text-blue-2 transition-colors"
                       >
                         {post.title}
                       </Text>

--- a/src/pages/CompaniesListPage.tsx
+++ b/src/pages/CompaniesListPage.tsx
@@ -74,7 +74,7 @@ export function CompaniesListPage() {
         {[...Array(4)].map((_, i) => (
           <div
             key={i}
-            className="h-64 dark:bg-black-2 bg-grey/10 rounded-level-2"
+            className="h-64 bg-black-2 light:bg-grey/10 rounded-level-2"
           />
         ))}
       </div>
@@ -104,10 +104,10 @@ export function CompaniesListPage() {
       <div
         className={cn(
           screenSize.isMobile ? "relative" : "sticky top-0 z-10",
-          "dark:bg-black bg-white",
+          "bg-black light:bg-white",
         )}
       >
-        <div className="absolute inset-0 w-full dark:bg-black bg-white -z-10" />
+        <div className="absolute inset-0 w-full bg-black light:bg-white -z-10" />
 
         {/* Wrapper for Filters, Search, and Badges */}
         <div className={cn("flex flex-wrap items-center gap-2 mb-2 md:mb-4")}>
@@ -117,7 +117,7 @@ export function CompaniesListPage() {
             placeholder={t("companiesPage.searchPlaceholder")}
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="dark:bg-black-1 bg-grey/10 dark:text-white text-black-3 rounded-md px-3 text-sm focus:outline-none focus:ring-1 focus:ring-blue-2 relative w-full md:w-[350px]"
+            className="bg-black-1 light:bg-grey/10 text-white light:text-black-3 rounded-md px-3 text-sm focus:outline-none focus:ring-1 focus:ring-blue-2 relative w-full md:w-[350px]"
           />
 
           {/* Filter and Sort Buttons */}

--- a/src/pages/CompaniesListPage.tsx
+++ b/src/pages/CompaniesListPage.tsx
@@ -42,8 +42,7 @@ export function CompaniesListPage() {
       ? sectors.map((sector) => ({
           type: "filter" as const,
           label: sectorNames[sector as keyof typeof sectorNames] || sector,
-          onRemove: () =>
-            setSectors(sectors.filter((s) => s !== sector)),
+          onRemove: () => setSectors(sectors.filter((s) => s !== sector)),
         }))
       : []),
     ...(meetsParisFilter !== "all"
@@ -73,7 +72,10 @@ export function CompaniesListPage() {
     return (
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 animate-pulse">
         {[...Array(4)].map((_, i) => (
-          <div key={i} className="h-64 bg-black-2 rounded-level-2" />
+          <div
+            key={i}
+            className="h-64 dark:bg-black-2 bg-grey/10 rounded-level-2"
+          />
         ))}
       </div>
     );
@@ -102,10 +104,10 @@ export function CompaniesListPage() {
       <div
         className={cn(
           screenSize.isMobile ? "relative" : "sticky top-0 z-10",
-          "bg-black shadow-md",
+          "dark:bg-black bg-white",
         )}
       >
-        <div className="absolute inset-0 w-full bg-black -z-10" />
+        <div className="absolute inset-0 w-full dark:bg-black bg-white -z-10" />
 
         {/* Wrapper for Filters, Search, and Badges */}
         <div className={cn("flex flex-wrap items-center gap-2 mb-2 md:mb-4")}>
@@ -115,7 +117,7 @@ export function CompaniesListPage() {
             placeholder={t("companiesPage.searchPlaceholder")}
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="bg-black-1 rounded-md px-3 text-sm focus:outline-none focus:ring-1 focus:ring-blue-2 relative w-full md:w-[350px]"
+            className="dark:bg-black-1 bg-grey/10 dark:text-white text-black-3 rounded-md px-3 text-sm focus:outline-none focus:ring-1 focus:ring-blue-2 relative w-full md:w-[350px]"
           />
 
           {/* Filter and Sort Buttons */}

--- a/src/pages/CompaniesRankedPage.tsx
+++ b/src/pages/CompaniesRankedPage.tsx
@@ -138,10 +138,13 @@ export function CompaniesRankedPage() {
   if (loading) {
     return (
       <div className="animate-pulse space-y-16">
-        <div className="h-12 w-1/3 bg-black-1 rounded" />
+        <div className="h-12 w-1/3 dark:bg-black-1 bg-grey/10 rounded" />
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
           {[...Array(6)].map((_, i) => (
-            <div key={i} className="h-96 bg-black-1 rounded-level-2" />
+            <div
+              key={i}
+              className="h-96 dark:bg-black-1 bg-grey/10 rounded-level-2"
+            />
           ))}
         </div>
       </div>

--- a/src/pages/CompaniesRankedPage.tsx
+++ b/src/pages/CompaniesRankedPage.tsx
@@ -138,12 +138,12 @@ export function CompaniesRankedPage() {
   if (loading) {
     return (
       <div className="animate-pulse space-y-16">
-        <div className="h-12 w-1/3 dark:bg-black-1 bg-grey/10 rounded" />
+        <div className="h-12 w-1/3 bg-black-1 light:bg-grey/10 rounded" />
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
           {[...Array(6)].map((_, i) => (
             <div
               key={i}
-              className="h-96 dark:bg-black-1 bg-grey/10 rounded-level-2"
+              className="h-96 bg-black-1 light:bg-grey/10 rounded-level-2"
             />
           ))}
         </div>

--- a/src/pages/CompaniesSectorsPage.tsx
+++ b/src/pages/CompaniesSectorsPage.tsx
@@ -31,8 +31,7 @@ export function CompaniesSectorsPage() {
       ? sectors.map((sector) => ({
           type: "filter" as const,
           label: sectorNames[sector as keyof typeof sectorNames] || sector,
-          onRemove: () =>
-            setSectors(sectors.filter((s) => s !== sector)),
+          onRemove: () => setSectors(sectors.filter((s) => s !== sector)),
         }))
       : []),
     ...(meetsParisFilter !== "all"
@@ -56,7 +55,10 @@ export function CompaniesSectorsPage() {
     return (
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 animate-pulse">
         {[...Array(4)].map((_, i) => (
-          <div key={i} className="h-64 bg-black-2 rounded-level-2" />
+          <div
+            key={i}
+            className="h-64 bg-black-2 light:bg-grey/10 rounded-level-2"
+          />
         ))}
       </div>
     );
@@ -85,10 +87,10 @@ export function CompaniesSectorsPage() {
       <div
         className={cn(
           screenSize.isMobile ? "relative" : "sticky top-0 z-10",
-          "bg-black shadow-md",
+          "bg-black light:bg-white",
         )}
       >
-        <div className="absolute inset-0 w-full bg-black -z-10" />
+        <div className="absolute inset-0 w-full bg-black light:bg-white -z-10" />
 
         {/* Wrapper for Filters and Badges */}
         <div className={cn("flex flex-wrap items-center gap-2 mb-2 md:mb-4")}>

--- a/src/pages/CompanyDetailPage.tsx
+++ b/src/pages/CompanyDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useParams } from "react-router-dom";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useCompanyDetails } from "@/hooks/companies/useCompanyDetails";
 import { CompanyOverview } from "@/components/companies/detail/overview/CompanyOverview";
 import { EmissionsHistory } from "@/components/companies/detail/history/EmissionsHistory";

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -98,7 +98,7 @@ export function LandingPage() {
               <Typewriter
                 text={TypeWriterTexts}
                 speed={70}
-                className="text-[#E2FF8D]"
+                className="text-orange-2 dark:text-[#E2FF8D]"
                 waitTime={2000}
                 deleteSpeed={40}
                 cursorChar="_"

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -87,7 +87,7 @@ export function LandingPage() {
         canonicalUrl={canonicalUrl}
         structuredData={structuredData}
       />
-      <div className="flex flex-col">
+      <div className="flex flex-col bg-white dark:bg-black">
         <div className="flex-1 flex flex-col items-center text-center px-4 py-14 md:py-24">
           <div className="max-w-lg md:max-w-4xl mx-auto space-y-4">
             <h1 className="text-4xl md:text-7xl font-light tracking-tight">

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -87,7 +87,7 @@ export function LandingPage() {
         canonicalUrl={canonicalUrl}
         structuredData={structuredData}
       />
-      <div className="flex flex-col bg-white dark:bg-black">
+      <div className="flex flex-col bg-black light:bg-white">
         <div className="flex-1 flex flex-col items-center text-center px-4 py-14 md:py-24">
           <div className="max-w-lg md:max-w-4xl mx-auto space-y-4">
             <h1 className="text-4xl md:text-7xl font-light tracking-tight">
@@ -98,7 +98,7 @@ export function LandingPage() {
               <Typewriter
                 text={TypeWriterTexts}
                 speed={70}
-                className="text-orange-2 dark:text-[#E2FF8D]"
+                className="text-orange-2 light:text-[#E2FF8D]"
                 waitTime={2000}
                 deleteSpeed={40}
                 cursorChar="_"

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -98,7 +98,7 @@ export function LandingPage() {
               <Typewriter
                 text={TypeWriterTexts}
                 speed={70}
-                className="text-orange-2 light:text-[#E2FF8D]"
+                className=":text-[#E2FF8D]"
                 waitTime={2000}
                 deleteSpeed={40}
                 cursorChar="_"

--- a/src/pages/LandingPageNew.tsx
+++ b/src/pages/LandingPageNew.tsx
@@ -119,7 +119,7 @@ export function LandingPageNew() {
               <Typewriter
                 text={typeWriterTexts}
                 speed={TYPEWRITER_SPEED}
-                className="text-[#E2FF8D]"
+                className="text-[#E2FF8D] light:text-[#B4CC70]"
                 waitTime={TYPEWRITER_WAIT_TIME}
                 deleteSpeed={TYPEWRITER_DELETE_SPEED}
                 cursorChar={TYPEWRITER_CURSOR_CHAR}

--- a/src/pages/LandingPageNew.tsx
+++ b/src/pages/LandingPageNew.tsx
@@ -108,7 +108,7 @@ export function LandingPageNew() {
         canonicalUrl={canonicalUrl}
         structuredData={structuredData}
       />
-      <div className="flex flex-col h-screen items-center bg-white dark:bg-black">
+      <div className="flex flex-col h-screen items-center bg-black light:bg-white">
         <div className="flex-1 flex flex-col items-center text-center px-4 py-44 md:py-56">
           <div className="max-w-lg md:max-w-4xl mx-auto space-y-4">
             <h1 className="text-4xl md:text-7xl font-light tracking-tight">
@@ -146,7 +146,7 @@ export function LandingPageNew() {
       <section ref={containerRef}>
         <ScrollAnimationSection
           steps={scrollSteps}
-          className="bg-white dark:bg-black"
+          className="bg-black light:bg-white"
         />
       </section>
 

--- a/src/pages/LandingPageNew.tsx
+++ b/src/pages/LandingPageNew.tsx
@@ -108,7 +108,7 @@ export function LandingPageNew() {
         canonicalUrl={canonicalUrl}
         structuredData={structuredData}
       />
-      <div className="flex flex-col h-screen items-center">
+      <div className="flex flex-col h-screen items-center bg-white dark:bg-black">
         <div className="flex-1 flex flex-col items-center text-center px-4 py-44 md:py-56">
           <div className="max-w-lg md:max-w-4xl mx-auto space-y-4">
             <h1 className="text-4xl md:text-7xl font-light tracking-tight">
@@ -144,7 +144,10 @@ export function LandingPageNew() {
 
       {/* Scroll Animation Section */}
       <section ref={containerRef}>
-        <ScrollAnimationSection steps={scrollSteps} className="bg-black" />
+        <ScrollAnimationSection
+          steps={scrollSteps}
+          className="bg-white dark:bg-black"
+        />
       </section>
 
       <SiteFeatures />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-  darkMode: ["class"],
+  darkMode: ["selector", ".light"],
   content: [
     "./pages/**/*.{ts,tsx}",
     "./components/**/*.{ts,tsx}",
@@ -140,5 +140,8 @@ export default {
   plugins: [
     require("tailwindcss-animate"),
     require("@tailwindcss/container-queries"),
+    require("tailwindcss/plugin")(function ({ addVariant }) {
+      addVariant("light", "&:where(.light, .light *)");
+    }),
   ],
 };


### PR DESCRIPTION
### ✨ What’s Changed?

Implement light mode on
* landing page
* footer
* header (search bar still to be converted)
* company explore page
* company sector page
* about page
* blog detail page

Still a bit of work to be done (and also agreeing on this being how we want light mode to look obvs), but thought it was better to do this in stages since a lot of files will be changed and I dont want to create a monster PR :).

PLEASE NOTE! I've hidden the light/dark mode toggle in the menu, search for {/* SHOW MODE TOGGLE */} and you'll find how to uncomment it.

### 📸 Screenshots (if applicable)
<img width="1312" height="869" alt="Screenshot 2025-12-11 at 09 42 31" src="https://github.com/user-attachments/assets/e7bbeae2-9c91-4ed8-bb4a-baca38b87572" />

<img width="1312" height="869" alt="Screenshot 2025-12-11 at 09 42 20" src="https://github.com/user-attachments/assets/b8955cf6-4218-4ed5-a12f-d66d3f1d1e4e" />

<img width="1312" height="869" alt="Screenshot 2025-12-11 at 09 42 41" src="https://github.com/user-attachments/assets/b8b45157-32c4-4cb5-b977-1602640e0625" />

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)