### PR TITLE
[fix] define appearance prop for compatibility in theme

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -202,6 +202,7 @@ input[type="number"]::-webkit-outer-spin-button {
 /* For Firefox (hides the increment/decrement arrows in number inputs) */
 input[type="number"] {
   -moz-appearance: textfield;
+  appearance: textfield;
 }
 
 @layer base {


### PR DESCRIPTION
### ✨ What’s Changed?

Define appearance prop for compatibility in index.css since '-moz-appearance' is not supported by Chrome, Chrome Android, Edge, Opera, Safari, Safari on iOS, Samsung Internet.