### PR TITLE
[1137] Changed translation text for empty dialog search

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1723,7 +1723,7 @@
     "searchDialog": {
       "title": "Search",
       "description": "Search for companies or municipalities",
-      "emptyText": "Start typing to search",
+      "emptyText": "Start typing to search for companies or municipalities",
       "loadingText": "Fetching companies and municipalities...",
       "shortcutTipText": "Trigger search by Ctrl+K / ⌘+K"
     }

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -1776,7 +1776,7 @@
     "searchDialog": {
       "title": "Sök",
       "description": "Sök efter företag eller kommuner",
-      "emptyText": "Börja skriv för att söka",
+      "emptyText": "Börja skriva för att söka efter företag eller kommuner",
       "loadingText": "Hämtar företag och kommuner...",
       "shortcutTipText": "Starta sök med Ctrl+K / ⌘+K"
     }


### PR DESCRIPTION
### ✨ What’s Changed?

Changed text in the empty dialog search to clarify that the search only is for companies and/or municipalities.

### 📸 Screenshots (if applicable)

Before:
<img width="474" height="180" alt="image" src="https://github.com/user-attachments/assets/58c87a10-42d1-4c1b-b46f-b62c7a76116c" />


After:
<img width="481" height="183" alt="image" src="https://github.com/user-attachments/assets/22681825-85f5-406d-95fc-63f0c4ce7da8" />



### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [x] I've set the labels, issue, and milestone for the PR
- [ ] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #1137 