### PR TITLE
[#1186] Historic revenue and revenue intensities

### DIFF
--- a/src/components/charts/ChartModeSelector.tsx
+++ b/src/components/charts/ChartModeSelector.tsx
@@ -1,0 +1,42 @@
+import { useTranslation } from "react-i18next";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { ChartMode } from "@/hooks/charts/useChartState";
+
+interface ChartModeSelectorProps {
+  chartMode: ChartMode;
+  setChartMode: (mode: ChartMode) => void;
+}
+
+export const ChartModeSelector: React.FC<ChartModeSelectorProps> = ({
+  chartMode,
+  setChartMode,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex items-center">
+      <Select
+        value={chartMode}
+        onValueChange={(value) => setChartMode(value as ChartMode)}
+      >
+        <SelectTrigger className="w-fit h-auto p-0 bg-transparent border-none shadow-none focus:ring-0 text-grey italic gap-1 flex items-center hover:text-white transition-colors">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent className="bg-black-1 border-gray-800 text-white">
+          <SelectItem value="absolute">
+            {t("companies.emissionsHistory.unit")}
+          </SelectItem>
+          <SelectItem value="revenueIntensity">
+            {t("companies.emissionsHistory.intensityUnit")}
+          </SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  );
+};

--- a/src/components/charts/historicEmissions/ChartTooltip.tsx
+++ b/src/components/charts/historicEmissions/ChartTooltip.tsx
@@ -21,7 +21,6 @@ interface PayloadEntry {
     scope3Categories?: Array<Scope3Category & { isAIGenerated?: boolean }>;
   };
 }
-
 interface ChartTooltipProps {
   active?: boolean;
   payload?: PayloadEntry[];
@@ -143,10 +142,15 @@ export const ChartTooltip: React.FC<ChartTooltipProps> = ({
     formatEmissionsAbsolute(Math.round(value ?? 0), currentLanguage);
 
   const defaultNameFormatter = (name: string, entry: PayloadEntry) => {
+    const dataKey = typeof entry.dataKey === "string" ? entry.dataKey : null;
+
     // Handle company category names
-    if (entry.dataKey?.startsWith("cat")) {
-      const categoryId = parseInt(entry.dataKey.replace("cat", ""));
+    if (dataKey?.startsWith("cat")) {
+      const categoryId = parseInt(dataKey.replace("cat", ""));
       return `${categoryId.toLocaleString()}. ${name}`;
+    }
+    if (dataKey === "turnover") {
+      return t("companies.overview.turnover");
     }
     return name;
   };

--- a/src/components/charts/historicEmissions/styles/chartStyles.ts
+++ b/src/components/charts/historicEmissions/styles/chartStyles.ts
@@ -85,6 +85,16 @@ export const LINE_CONFIGS = {
     color: "var(--pink-3)", // Will be overridden by stroke prop
     style: LINE_STYLES.primary,
   },
+  turnover: {
+    type: "primary" as const,
+    color: "var(--blue-2)",
+    style: LINE_STYLES.primary,
+  },
+  intensity: {
+    type: "primary" as const,
+    color: "var(--orange-2)",
+    style: LINE_STYLES.primary,
+  },
 } as const;
 
 // Re-export from utils modules

--- a/src/components/charts/historicEmissions/utils/chartData.ts
+++ b/src/components/charts/historicEmissions/utils/chartData.ts
@@ -105,6 +105,7 @@ export const mergeChartDataWithApproximated = (
         scope2: mainDataPoint?.scope2,
         scope3: mainDataPoint?.scope3,
         scope3Categories: mainDataPoint?.scope3Categories,
+        turnover: mainDataPoint?.turnover,
         originalValues: mainDataPoint?.originalValues,
       };
     });

--- a/src/components/charts/historicEmissions/utils/chartTicks.ts
+++ b/src/components/charts/historicEmissions/utils/chartTicks.ts
@@ -11,7 +11,7 @@ export const generateChartTicks = (
 ) => {
   // Only include currentYear if it's within the data range
   const baseTicks = [dataStartYear, 2020];
-  if (currentYear <= chartEndYear) {
+  if (currentYear <= chartEndYear && currentYear < shortEndYear) {
     baseTicks.push(currentYear);
   }
   if (2025 <= chartEndYear) {

--- a/src/components/charts/historicEmissions/utils/chartUtils.ts
+++ b/src/components/charts/historicEmissions/utils/chartUtils.ts
@@ -102,22 +102,36 @@ export const getXAxisProps = (
 export const getYAxisProps = (
   currentLanguage: "sv" | "en",
   domain: [number, number | "auto"] = [0, "auto"],
+  options: {
+    orientation?: "left" | "right";
+    yAxisId?: string;
+    formatter?: (value: number, lang: "sv" | "en") => string;
+  } = {},
 ) => ({
   stroke: "var(--grey)",
   tickLine: false,
   axisLine: false,
+  orientation: options.orientation || "left",
+  yAxisId: options.yAxisId || "left",
   tick: ({ x, y, payload }: TickProps) => {
+    const formattedValue = options.formatter
+      ? options.formatter(payload.value, currentLanguage)
+      : formatEmissionsAbsoluteCompact(payload.value, currentLanguage);
+
     return React.createElement(
       "text",
       {
-        x: x - 5, // Moved further left
+        x: options.orientation === "right" ? x + 5 : x - 5,
         y: y + 5,
         fontSize: 12,
         fill: "var(--grey)",
-        textAnchor: "end",
-        transform: `rotate(-30, ${x - 5}, ${y + 5})`, // Updated transform origin
+        textAnchor: options.orientation === "right" ? "start" : "end",
+        transform:
+          options.orientation === "right"
+            ? `rotate(30, ${x + 5}, ${y + 5})`
+            : `rotate(-30, ${x - 5}, ${y + 5})`,
       },
-      formatEmissionsAbsoluteCompact(payload.value, currentLanguage),
+      formattedValue,
     ) as unknown as React.ReactElement<SVGElement>;
   },
   domain,
@@ -300,3 +314,34 @@ export const getLineStyle = (type: keyof typeof LINE_STYLES) =>
 // Utility function to get color
 export const getChartColor = (color: keyof typeof CHART_COLORS) =>
   CHART_COLORS[color];
+
+/**
+ * Calculate intensity (emissions per million SEK turnover)
+ * Used for on-the-fly intensity calculations in charts
+ */
+export const getIntensityValue = (
+  value: number | undefined,
+  turnover: number | undefined,
+): number | undefined =>
+  value && turnover ? (value / turnover) * 1000000 : undefined;
+
+/**
+ * Get the last year that has actual data (total !== undefined)
+ * Used to determine chart x-axis end for views without future projections
+ */
+export const getLastDataYear = (
+  data: Array<{ year: number; total?: number }>,
+  fallback: number,
+): number =>
+  data.filter((item) => item.total !== undefined).slice(-1)[0]?.year || fallback;
+
+/**
+ * Get the appropriate emissions unit based on chart mode
+ */
+export const getEmissionsUnit = (
+  chartMode: "absolute" | "revenueIntensity",
+  t: (key: string) => string,
+): string =>
+  chartMode === "revenueIntensity"
+    ? t("companies.emissionsHistory.intensityUnit")
+    : t("companies.tooltip.tonsCO2e");

--- a/src/components/charts/index.ts
+++ b/src/components/charts/index.ts
@@ -11,6 +11,7 @@ export { ChartTooltip } from "./historicEmissions/ChartTooltip";
 // Chart controls
 export { ChartYearControls } from "./ChartYearControls";
 export { DataViewSelector } from "./DataViewSelector";
+export { ChartModeSelector } from "./ChartModeSelector";
 
 // Data view hooks
 export * from "../../hooks/charts/useDataViewOptions";
@@ -51,3 +52,4 @@ export {
   useDataView,
   useTimeSeriesChartState,
 } from "../../hooks/charts/useChartState";
+export type { ChartMode } from "../../hooks/charts/useChartState";

--- a/src/components/companies/detail/history/CategoriesChart.tsx
+++ b/src/components/companies/detail/history/CategoriesChart.tsx
@@ -30,6 +30,10 @@ import {
   createCustomTickRenderer,
   filterValidCategoryData,
   ChartTooltip,
+  getIntensityValue,
+  getLastDataYear,
+  getEmissionsUnit,
+  ChartMode,
 } from "@/components/charts";
 import { useLanguage } from "@/components/LanguageProvider";
 
@@ -47,6 +51,7 @@ interface CategoriesChartProps {
   onYearSelect: (year: number) => void;
   exploreMode?: boolean;
   setExploreMode?: (val: boolean) => void;
+  chartMode?: ChartMode;
 }
 
 export const CategoriesChart: FC<CategoriesChartProps> = ({
@@ -58,6 +63,7 @@ export const CategoriesChart: FC<CategoriesChartProps> = ({
   getCategoryName,
   getCategoryColor,
   onYearSelect,
+  chartMode = "absolute",
 }) => {
   const { t } = useTranslation();
   const { currentLanguage } = useLanguage();
@@ -68,9 +74,7 @@ export const CategoriesChart: FC<CategoriesChartProps> = ({
     return filterValidCategoryData(data);
   }, [data]);
 
-  const lastDataYear =
-    filteredData.filter((item) => item.total !== undefined).slice(-1)[0]
-      ?.year || shortEndYear;
+  const lastDataYear = getLastDataYear(filteredData, shortEndYear);
   const ticks = generateChartTicks(
     filteredData[0]?.year || 2000,
     lastDataYear,
@@ -126,7 +130,7 @@ export const CategoriesChart: FC<CategoriesChartProps> = ({
               content={
                 <ChartTooltip
                   companyBaseYear={companyBaseYear}
-                  unit={t("companies.tooltip.tonsCO2e")}
+                  unit={getEmissionsUnit(chartMode, t)}
                 />
               }
               wrapperStyle={{ outline: "none", zIndex: 60 }}
@@ -152,12 +156,17 @@ export const CategoriesChart: FC<CategoriesChartProps> = ({
               if (isHidden) return null;
 
               const categoryColor = getCategoryColor(categoryId);
+              const dataKey =
+                chartMode === "revenueIntensity"
+                  ? (d: ChartData) =>
+                      getIntensityValue(d[categoryKey] as number, d.turnover)
+                  : categoryKey;
 
               return (
                 <Line
                   key={categoryKey}
                   type="monotone"
-                  dataKey={categoryKey}
+                  dataKey={dataKey}
                   {...getConsistentLineProps(
                     "category",
                     isMobile,

--- a/src/components/companies/detail/history/EmissionsHistory.tsx
+++ b/src/components/companies/detail/history/EmissionsHistory.tsx
@@ -11,6 +11,7 @@ import {
   useTimeSeriesChartState,
   useHiddenItems,
   useCompanyViewOptions,
+  ChartModeSelector,
 } from "@/components/charts";
 import { CardHeader } from "@/components/layout/CardHeader";
 import { useVerificationStatus } from "@/hooks/useVerificationStatus";
@@ -53,8 +54,14 @@ export function EmissionsHistory({
 
   const dataViewOptions = useCompanyViewOptions(hasScope3Categories);
 
-  const { chartEndYear, setChartEndYear, shortEndYear, longEndYear } =
-    useTimeSeriesChartState();
+  const {
+    chartEndYear,
+    setChartEndYear,
+    shortEndYear,
+    longEndYear,
+    chartMode,
+    setChartMode,
+  } = useTimeSeriesChartState();
 
   const { hiddenItems: hiddenScopes, toggleItem: toggleScope } = useHiddenItems<
     "scope1" | "scope2" | "scope3"
@@ -121,7 +128,7 @@ export function EmissionsHistory({
 
     // No trend analysis = no future projections
     return null;
-  }, [chartData, dataView, chartEndYear, companyBaseYear, trendAnalysis]);
+  }, [chartData, dataView, chartEndYear, trendAnalysis]);
 
   // Calculate yDomain for explore mode
   const yDomain = useMemo((): [number, number] => {
@@ -175,7 +182,12 @@ export function EmissionsHistory({
           <CardHeader
             title={t("companies.emissionsHistory.title")}
             tooltipContent={t("companies.emissionsHistory.tooltip")}
-            unit={t("companies.emissionsHistory.unit")}
+            unit={
+              <ChartModeSelector
+                chartMode={chartMode}
+                setChartMode={setChartMode}
+              />
+            }
             dataView={dataView}
             setDataView={(value) =>
               setDataView(value as "overview" | "scopes" | "categories")
@@ -198,6 +210,7 @@ export function EmissionsHistory({
                     onYearSelect={handleYearSelect}
                     exploreMode={exploreMode}
                     setExploreMode={setExploreMode}
+                    chartMode={chartMode}
                   />
                 )}
                 {dataView === "scopes" && (
@@ -213,6 +226,7 @@ export function EmissionsHistory({
                     onYearSelect={handleYearSelect}
                     exploreMode={exploreMode}
                     setExploreMode={setExploreMode}
+                    chartMode={chartMode}
                   />
                 )}
                 {dataView === "categories" && (
@@ -230,6 +244,7 @@ export function EmissionsHistory({
                     onYearSelect={handleYearSelect}
                     exploreMode={exploreMode}
                     setExploreMode={setExploreMode}
+                    chartMode={chartMode}
                   />
                 )}
               </>

--- a/src/components/layout/CardHeader.tsx
+++ b/src/components/layout/CardHeader.tsx
@@ -14,7 +14,7 @@ interface CardHeaderProps<T extends string = string> {
 
   // Optional fields with defaults
   tooltipContent?: string;
-  unit?: string;
+  unit?: string |React.ReactNode;
   description?: string;
 
   // Data view selector options (for charts)
@@ -92,11 +92,13 @@ export const CardHeader = <T extends string = string>({
               </InfoTooltip>
             )}
           </div>
-          {unit && (
+          {typeof unit === "string" ? (
             <Text variant="body" className="text-grey">
               {unit}
             </Text>
-          )}
+          ) : unit != null ? (
+            <div className="text-grey text-sm">{unit}</div>
+          ) : null}
           {description && (
             <Text variant="body" className="text-grey">
               {description}

--- a/src/hooks/charts/useChartState.ts
+++ b/src/hooks/charts/useChartState.ts
@@ -80,6 +80,11 @@ export const useDataView = <T extends string>(
 };
 
 /**
+ * Chart display mode - absolute values or revenue intensity (per million SEK turnover)
+ */
+export type ChartMode = "absolute" | "revenueIntensity";
+
+/**
  * Specialized hook for time-series charts with year range controls
  * Used for historic emissions charts and other temporal data
  */
@@ -88,6 +93,7 @@ export const useTimeSeriesChartState = (initialConfig?: {
   shortEndYear?: number;
   longEndYear?: number;
   currentYear?: number;
+  initialMode?: ChartMode;
 }) => {
   const currentYear = initialConfig?.currentYear || new Date().getFullYear();
   const defaultShortEndYear = initialConfig?.shortEndYear || currentYear + 5;
@@ -98,6 +104,9 @@ export const useTimeSeriesChartState = (initialConfig?: {
   const [chartEndYear, setChartEndYear] = useState(defaultChartEndYear);
   const [shortEndYear] = useState(defaultShortEndYear);
   const [longEndYear] = useState(defaultLongEndYear);
+  const [chartMode, setChartMode] = useState<ChartMode>(
+    initialConfig?.initialMode || "absolute",
+  );
 
   // Computed values
   const isShortView = useMemo(
@@ -118,5 +127,7 @@ export const useTimeSeriesChartState = (initialConfig?: {
     currentYear,
     isShortView,
     isLongView,
+    chartMode,
+    setChartMode,
   };
 };

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1233,6 +1233,8 @@
       "title": "Emissions development",
       "tooltip": "Showing the development of reported emissions over time; click on a point to remove the line from the graph. Hover over a point to see the values for the reporting period.",
       "unit": "In tons CO₂e",
+      "intensityUnit": "tons CO₂e / m. turnover",
+      "intensity": "Intensity",
       "totalEmissions": "Total Emissions",
       "baseYear": "Base year",
       "baseYearInfo": "The base year refers to a specific year chosen as a reference point against which future emissions are compared.",

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -1286,6 +1286,8 @@
       "title": "Utsläppsutveckling",
       "tooltip": "Visar de rapporterade utsläppen över tid. Klicka på en punkt för att ta bort linjen från grafen. Hovra över punkten för att se värdena för rapporteringsperioden.",
       "unit": "I ton CO₂e",
+      "intensityUnit": "ton CO₂e / milj. omsättning",
+      "intensity": "Intensitet",
       "totalEmissions": "Totala utsläpp",
       "baseYear": "Basår",
       "baseYearInfo": "Basår syftar på ett specifikt år som väljs som referenspunkt för att jämföra framtida utsläpp mot.",

--- a/src/types/emissions.ts
+++ b/src/types/emissions.ts
@@ -10,6 +10,7 @@ export interface ChartData {
     value: number;
     isAIGenerated?: boolean;
   }>;
+  turnover?: number;
   originalValues?: Record<string, number | null>; // Keeps track of original null values
   [key: string]: any; // Allow any type for additional keys
 }

--- a/src/utils/data/chartData.ts
+++ b/src/utils/data/chartData.ts
@@ -64,9 +64,13 @@ export function getChartData(
       acc[key] = categoryEntry?.total ?? null; // Preserve null if data is missing
       return acc;
     }, {});
+    const total = period.emissions?.calculatedTotalEmissions ?? 0;
+    const turnover = period.economy?.turnover?.value ?? undefined;
+
     return {
       year,
-      total: period.emissions?.calculatedTotalEmissions ?? 0,
+      total,
+      turnover,
       isAIGenerated: isEmissionsAIGenerated(period),
       scope1: scope1Data,
       scope2: scope2Data,


### PR DESCRIPTION
### ✨ What’s Changed?

- Added historical turnover data to the overview chart
- Added revenue intensity breakdown to both the overview and the scope breakdown charts

(I can split this in to separate PRs if needed)

### 📸 Screenshots
<img width="1552" height="987" alt="Screenshot 2026-01-16 at 15 22 47" src="https://github.com/user-attachments/assets/c2ca41b1-8861-4333-a606-7c2e1f9ff9d0" />
<img width="1552" height="987" alt="Screenshot 2026-01-16 at 15 22 53" src="https://github.com/user-attachments/assets/4800ba83-2f2e-4325-8503-ca209f7eda52" />


### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [ ] I've set the labels, issue, and milestone for the PR
- [ ] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #1186 <!-- or: Related to #[issue-number] -->