### PR TITLE
[1320] Select multiple regions on the explore municipalities page

### DIFF
--- a/src/hooks/companies/useCompanyFilters.ts
+++ b/src/hooks/companies/useCompanyFilters.ts
@@ -33,8 +33,9 @@ export const useCompanyFilters = (companies: RankedCompany[]) => {
   const sectors = (searchParams
     .get("sectors")
     ?.split(",")
-    .filter((s) => SECTORS.some((sector) => sector.value === s)) ??
-    []) as CompanySector[];
+    .filter((s) => SECTORS.some((sector) => sector.value === s)) ?? [
+    "all",
+  ]) as CompanySector[];
   const sortBy = isSortOption(searchParams.get("sortBy") ?? "")
     ? (searchParams.get("sortBy") as SortOption)
     : "total_emissions";
@@ -91,7 +92,6 @@ export const useCompanyFilters = (companies: RankedCompany[]) => {
       .filter((company) => {
         // Filter by sector
         const matchesSector =
-          sectors.length === 0 ||
           sectors.includes("all") ||
           (company.industry?.industryGics?.sectorCode &&
             sectors.includes(company.industry.industryGics.sectorCode));
@@ -251,7 +251,7 @@ export const useCompanyFilters = (companies: RankedCompany[]) => {
 
   const activeFilters = useMemo(() => {
     return [
-      ...(sectors.length > 0 && !sectors.includes("all")
+      ...(!sectors.includes("all")
         ? sectors.map((sector) => ({
             type: "filter" as const,
             label: sectorNames[sector as keyof typeof sectorNames] || sector,

--- a/src/hooks/municipalities/useMunicipalitiesFilters.ts
+++ b/src/hooks/municipalities/useMunicipalitiesFilters.ts
@@ -27,10 +27,11 @@ export const useMunicipalitiesFilters = (municipalities: Municipality[]) => {
     ? (searchParams.get("meetsParisFilter") as MeetsParisFilter)
     : "all";
   const selectedRegions = (searchParams
-      .get("selectedRegions")
-      ?.split(",")
-      .filter((s) => Object.keys(regions).some((region) => region === s) || s == "all") ??
-      []) as string[];
+    .get("selectedRegions")
+    ?.split(",")
+    .filter(
+      (s) => Object.keys(regions).some((region) => region === s) || s == "all",
+    ) ?? ["all"]) as string[];
   const sortBy = isMunicipalitySortBy(searchParams.get("sortBy") ?? "")
     ? (searchParams.get("sortBy") as MunicipalitySortBy)
     : "emissions";
@@ -143,11 +144,14 @@ export const useMunicipalitiesFilters = (municipalities: Municipality[]) => {
 
   const activeFilters = useMemo(() => {
     return [
-      ...(selectedRegions.length > 0 && !selectedRegions.includes("all")
+      ...(!selectedRegions.includes("all")
         ? selectedRegions.map((selectedRegion) => ({
             type: "filter" as const,
             label: selectedRegion,
-            onRemove: () => setSelectedRegions(selectedRegions.filter((s) => s !== selectedRegion)),
+            onRemove: () =>
+              setSelectedRegions(
+                selectedRegions.filter((s) => s !== selectedRegion),
+              ),
           }))
         : []),
       ...(meetsParisFilter !== "all"
@@ -207,7 +211,10 @@ const filterAndSortMunicipalities = (
   return municipalities
     .filter((municipality) => {
       // Filter by region
-      if (selectedRegions.length > 0 && !selectedRegions.includes("all") && !selectedRegions.includes(municipality.region)) {
+      if (
+        !selectedRegions.includes("all") &&
+        !selectedRegions.includes(municipality.region)
+      ) {
         return false;
       }
 


### PR DESCRIPTION
### ✨ What’s Changed?

Multiple regions can now be selected at the same time in the filter menu on the explore municipalities page. The "All regions/sectors" filter is also shown as being selected by default on the explore pages.

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [ ] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #1320 