### PR TITLE
update editor to send stated total for scope 3 onverify

### DIFF
--- a/src/lib/company/company-edit.test.ts
+++ b/src/lib/company/company-edit.test.ts
@@ -430,7 +430,7 @@ describe("mapCompanyEditFormToRequestBody", () => {
       });
     });
 
-    it("should only send verified for statedTotalEmissions if only verified is changed", () => {
+    it("should send value and unit with verified for statedTotalEmissions when only verified is changed", () => {
       const periodWithStatedTotal = makeBasePeriod({
         emissions: {
           ...basePeriod.emissions!,
@@ -452,6 +452,8 @@ describe("mapCompanyEditFormToRequestBody", () => {
       expect(
         result.reportingPeriods[0].emissions.scope3.statedTotalEmissions,
       ).toEqual({
+        total: 123,
+        unit: "tCO2e",
         verified: true,
       });
     });

--- a/src/lib/company/company-edit.ts
+++ b/src/lib/company/company-edit.ts
@@ -206,6 +206,8 @@ export function mapCompanyEditFormToRequestBody(
         periodUpdate.emissions.scope3 = {};
       }
       periodUpdate.emissions.scope3.statedTotalEmissions = {
+        total: originalStatedTotal.total,
+        unit: originalStatedTotal.unit || "tCO2e",
         verified: statedTotalNewVerified,
       };
     }
@@ -241,6 +243,8 @@ export function mapCompanyEditFormToRequestBody(
       originalEmissionsStatedTotal.total !== undefined
     ) {
       periodUpdate.emissions.statedTotalEmissions = {
+        total: originalEmissionsStatedTotal.total,
+        unit: originalEmissionsStatedTotal.unit || "tCO2e",
         verified: emissionsStatedTotalNewVerified,
       };
     }


### PR DESCRIPTION
### ✨ What’s Changed?

In the editor when the user only validated (no value change) scope 3 stated total, the api interpreted sending only verified as setting the value to null. Updated to now send the original value along with the verified so that value is not cleared on save. 

### 📸 Screenshots (if applicable)

no ui changes


### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [x] I've set the labels, issue, and milestone for the PR
- [ ] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #1356  <!-- or: Related to #[issue-number] -->