### PR TITLE
[feat] group company and territorial pages in data section of header

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -47,8 +47,8 @@ const NAV_LINKS: NavLink[] = [
         onlyShowOnStaging: true,
       },
       {
-        label: "header.municipalities",
-        path: `/municipalities`,
+        label: "header.companiesSectors",
+        path: `/sectors`,
       },
       {
         label: "header.regions",
@@ -56,8 +56,8 @@ const NAV_LINKS: NavLink[] = [
         onlyShowOnStaging: true,
       },
       {
-        label: "header.companiesSectors",
-        path: `/sectors`,
+        label: "header.municipalities",
+        path: `/municipalities`,
       },
       {
         label: "header.explore",


### PR DESCRIPTION
### ✨ What’s Changed?

Group company and territorial pages in data section of header - feel like current grouping doesnt really make sense.

### 📸 Screenshots (if applicable)

Before
<img width="974" height="434" alt="Screenshot 2026-02-12 at 15 31 13" src="https://github.com/user-attachments/assets/4dd786d0-7672-4b3f-ac64-7569ec53c722" />

After
<img width="974" height="434" alt="Screenshot 2026-02-12 at 15 31 04" src="https://github.com/user-attachments/assets/84baa413-67b7-40fa-90c9-6943401874b8" />


### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)