### PR TITLE
[1350] Add buttons to show more results in the search results dialog

### DIFF
--- a/src/components/search/SearchDialog.tsx
+++ b/src/components/search/SearchDialog.tsx
@@ -86,7 +86,7 @@ export function SearchDialog({
           )}
         </DialogDescription>
         <DialogOverlay className="backdrop-blur-sm bg-black/40" />
-        <DialogPrimitive.Content className="fixed top-16 left-1/2 transform -translate-x-1/2 w-full max-w-lg z-50 focus:outline-none">
+        <DialogPrimitive.Content className="fixed top-[7vh] left-1/2 transform -translate-x-1/2 w-full max-w-lg z-50 focus:outline-none">
           <div
             className={cn(
               "bg-black-2 shadow-lg overflow-hidden",
@@ -107,14 +107,8 @@ export function SearchDialog({
                 </p>
               </CommandEmpty>
               <CommandList
-                className="pt-4 transition-all duration-200 ease-in-out min-h-60"
+                className="pt-4 transition-all duration-200 ease-in-out max-h-[50vh] min-h-60"
                 ref={commandListRef}
-                style={{
-                  maxHeight:
-                    results.data.length > 0
-                      ? `${Math.min(results.data.length * 48, 300)}px`
-                      : "0px",
-                }}
               >
                 {results.loading && (
                   <CommandPrimitive.Loading>

--- a/src/components/search/SearchResultList.tsx
+++ b/src/components/search/SearchResultList.tsx
@@ -1,8 +1,9 @@
-import type { ElementType } from "react";
+import { useEffect, useState, type ElementType } from "react";
 import { useTranslation } from "react-i18next";
 import type { CombinedData } from "@/hooks/useCombinedData";
 import { CommandItem } from "../ui/command";
 import SearchResultItem from "./SearchResultItem";
+import { CirclePlus } from "lucide-react";
 
 interface SearchResultListProps {
   list: CombinedData[];
@@ -21,6 +22,10 @@ const SearchResultList = ({
 }: SearchResultListProps) => {
   const { t } = useTranslation();
 
+  const [itemsToLoad, setItemsToLoad] = useState(5);
+
+  useEffect(() => setItemsToLoad(5), [list]);
+
   if (!list || list.length === 0) return null;
 
   return (
@@ -28,7 +33,7 @@ const SearchResultList = ({
       <p className="text-sm flex pb-2 items-center gap-2">
         <Icon size={15} /> {t(translationKey)}
       </p>
-      {list.slice(0, 5).map((item) => (
+      {list.slice(0, itemsToLoad).map((item) => (
         <CommandItem
           key={item.id}
           onSelect={() => {
@@ -40,6 +45,16 @@ const SearchResultList = ({
           <SearchResultItem item={item} />
         </CommandItem>
       ))}
+      {list.length > itemsToLoad && (
+        <div className="flex py-2">
+          <button
+            className="m-auto text-gray-500 hover:opacity-50"
+            onClick={() => setItemsToLoad(itemsToLoad + 5)}
+          >
+            <CirclePlus />
+          </button>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
### ✨ What’s Changed?

Added buttons to show more search results in the search dialog (it was previously capped at 5 results per category) so that users don't have to be so specific when searching. The maximum size of the search dialog was also increased slightly to make it easier to browse the results.

### 📸 Screenshots

Before:
<img width="518" height="441" alt="bild" src="https://github.com/user-attachments/assets/96c1a395-a8b4-486a-9f3b-af22a89e1b18" />

After:
<img width="500" height="596" alt="bild" src="https://github.com/user-attachments/assets/ff85663b-840b-4f0b-8d0c-46bea5e66edf" />


### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [ ] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #1350 