### PR TITLE
[fix] percent in sector pie chart tooltip

### DIFF
--- a/src/components/charts/sectorChart/SectorPieChart.tsx
+++ b/src/components/charts/sectorChart/SectorPieChart.tsx
@@ -48,6 +48,9 @@ const SectorPieChart: React.FC<SectorPieChartProps> = ({
     .filter((item) => !filteredSectors.has(item.name))
     .sort((a, b) => (b.value as number) - (a.value as number));
 
+  const total = pieData.reduce((sum, item) => sum + (item.value as number), 0);
+  const pieDataWithTotal = pieData.map((item) => ({ ...item, total }));
+
   const handleSectorClick = (data: SectorData) => {
     if (isMobile) {
       // On mobile, handle double-click for filtering
@@ -90,7 +93,7 @@ const SectorPieChart: React.FC<SectorPieChartProps> = ({
       <ResponsiveContainer width="100%" height={size.outerRadius * 2.5}>
         <PieChart>
           <Pie
-            data={pieData}
+            data={pieDataWithTotal}
             dataKey="value"
             nameKey="translatedName"
             cx="50%"
@@ -103,7 +106,7 @@ const SectorPieChart: React.FC<SectorPieChartProps> = ({
             animationBegin={0}
             animationDuration={300}
           >
-            {pieData.map((entry) => (
+            {pieDataWithTotal.map((entry) => (
               <Cell
                 key={entry.name}
                 fill={entry.color}

--- a/src/components/graphs/tooltips/PieTooltip.tsx
+++ b/src/components/graphs/tooltips/PieTooltip.tsx
@@ -7,6 +7,7 @@ import {
   formatPercent,
 } from "@/utils/formatting/localization";
 import { useScreenSize } from "@/hooks/useScreenSize";
+import type { SupportedLanguage } from "@/lib/languageDetection";
 
 interface PieTooltipEntry {
   name?: string;
@@ -23,6 +24,15 @@ interface PieTooltipProps {
   customActionLabel?: string;
   showPercentage?: boolean;
   percentageLabel?: string;
+}
+
+function computePercent(
+  value: number,
+  total: number | null | undefined,
+  language: SupportedLanguage,
+): string | null {
+  if (total == null || total === 0) return null;
+  return formatPercent(value / total, language);
 }
 
 function getActionHint(
@@ -60,8 +70,7 @@ const PieTooltip: React.FC<PieTooltipProps> = ({
 
   const { value, payload: data } = payload[0];
   const safeValue = value != null ? value : 0;
-  const safeTotal = data?.total != null ? data.total : 1;
-  const percentage = formatPercent(safeValue / safeTotal, currentLanguage);
+  const percentage = computePercent(safeValue, data?.total, currentLanguage);
   const actionHint = getActionHint(customActionLabel, isMobile, t);
 
   return (
@@ -85,7 +94,7 @@ const PieTooltip: React.FC<PieTooltipProps> = ({
           {formatEmissionsAbsolute(Math.round(safeValue), currentLanguage)}{" "}
           {t("emissionsUnit")}
         </div>
-        {showPercentage && safeTotal && (
+        {showPercentage && percentage && (
           <div>
             {percentage} {percentageLabel || t("graphs.pieChart.ofTotal")}
           </div>


### PR DESCRIPTION
### ✨ What’s Changed?

Fix percent in sector pie chart tooltip so it's correctly displayed.
Also replace any with type and reduce complexity of arrow function in said tooltip.

### 📸 Screenshots (if applicable)

Didn't get the tooltip working with my screenshot.

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)