### PR TITLE
#1427: Make all company logos the same size

### DIFF
--- a/src/components/companies/CompanyLogo.tsx
+++ b/src/components/companies/CompanyLogo.tsx
@@ -39,8 +39,8 @@ export function CompanyLogo({ src, className }: CompanyLogoProps) {
     return (
       <img
         src={url.toString()}
-        alt="logo"
-        className={(padding ? "p-1 " : "") + className}
+        alt=""
+        className={className + (padding ? " p-1" : "")}
         crossOrigin="anonymous"
         style={{
           backgroundColor: `rgba(${backgroundColor.r}, ${backgroundColor.g}, ${backgroundColor.b}, ${backgroundColor.a / 255})`,
@@ -56,8 +56,8 @@ export function CompanyLogo({ src, className }: CompanyLogoProps) {
     return (
       <img
         src={url.toString()}
-        alt="logo"
-        className={"bg-white p-1 " + className}
+        alt=""
+        className={className + " bg-white p-1"}
       />
     );
   }

--- a/src/components/companies/detail/overview/CompanyOverview.tsx
+++ b/src/components/companies/detail/overview/CompanyOverview.tsx
@@ -168,7 +168,7 @@ export function CompanyOverview({
         {company.logoUrl && (
           <CompanyLogo
             src={company.logoUrl}
-            className="max-h-[120px] max-w-[120px] object-contain rounded-xl hidden lg:inline "
+            className="rounded-xl size-[120px] object-contain hidden lg:inline"
           />
         )}
       </div>

--- a/src/components/companies/edit/LogoDevDialog.tsx
+++ b/src/components/companies/edit/LogoDevDialog.tsx
@@ -49,8 +49,8 @@ export function LogoDevDialog({
   }, [open, logoUrl]);
 
   const url =
-    domain.length > 3 &&
-    domain.includes(".") &&
+    domain.indexOf(".") > 0 &&
+    domain.indexOf(".") < domain.length - 1 &&
     new URL(`https://img.logo.dev/${domain}`);
 
   if (url && theme !== "auto") {

--- a/src/components/explore/ListCard.tsx
+++ b/src/components/explore/ListCard.tsx
@@ -127,7 +127,7 @@ export function ListCard({
               : logoUrl && (
                   <CompanyLogo
                     src={logoUrl}
-                    className="rounded-xl max-w-[90px] max-h-[90px] object-contain hidden @lg:inline"
+                    className="rounded-xl size-[90px] object-contain hidden @lg:inline"
                   />
                 )}
           </div>


### PR DESCRIPTION
### ✨ What’s Changed?

Made sure that all company logos are the same size regardless of the shape of the logo which can happen when using a source other than logo.dev.

Also removed unnecessary alt-text and made the validation when generating a logo.dev URL a bit stricter.

### 📸 Screenshots

Before:
<img width="1150" height="291" alt="bild" src="https://github.com/user-attachments/assets/a19e1f47-2b70-4b17-bc39-a5a97e7ffebf" />

After:
<img width="1151" height="296" alt="bild" src="https://github.com/user-attachments/assets/9b307b43-8e66-4ab1-bf7c-e61c3e5e9424" />

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [ ] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #1427 