### PR TITLE
[1433] Hide company logo when the list card is too small

### DIFF
--- a/src/components/explore/ListCard.tsx
+++ b/src/components/explore/ListCard.tsx
@@ -90,7 +90,7 @@ export function ListCard({
   const linkMinHeightClass = isRegion ? "min-h-[300px]" : "min-h-[410px]";
 
   return (
-    <div className="relative rounded-level-2">
+    <div className="relative rounded-level-2 @container">
       <LocalizedLink
         to={linkTo}
         className={cn(

--- a/src/components/explore/ListCardHeader.tsx
+++ b/src/components/explore/ListCardHeader.tsx
@@ -37,21 +37,19 @@ export function ListCardHeader({
           <p className="text-grey text-sm line-clamp-2 min-h-[40px]">
             {description}
           </p>
+          <div className="flex items-center gap-2 text-grey text-lg">
+            {meetsParisTitle}
+          </div>
+          <div
+            className={cn(
+              "w-full text-xl font-light border-b border-black-1 pb-6",
+              meetsParisIsYes ? "text-green-3" : "text-pink-3",
+            )}
+          >
+            {meetsParisAnswer}
+          </div>
         </div>
         {logo}
-      </div>
-      <div className="w-full">
-        <div className="flex items-center gap-2 text-grey text-lg">
-          {meetsParisTitle}
-        </div>
-        <div
-          className={cn(
-            "w-full text-xl font-light border-b border-black-1 pb-6",
-            meetsParisIsYes ? "text-green-3" : "text-pink-3",
-          )}
-        >
-          {meetsParisAnswer}
-        </div>
       </div>
     </div>
   );

--- a/src/hooks/useListCardHeader.tsx
+++ b/src/hooks/useListCardHeader.tsx
@@ -31,7 +31,7 @@ export function useListCardHeader({
     ) : (
       <CompanyLogo
         src={logoUrl}
-        className="shrink-0 rounded-xl size-[90px] object-contain"
+        className="shrink-0 rounded-xl size-[90px] object-contain hidden @lg:inline"
       />
     )
   ) : null;


### PR DESCRIPTION
### ✨ What’s Changed?
Hides the company logo on the explore page when the list card is too small and changes the list card header layout so that the cards keep a consistent size.

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [ ] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue
Closes #1433 