### PR TITLE
[1457]: Connect companies section search to /companies/search endpoint

### DIFF
--- a/src/components/landing/CompaniesSection.tsx
+++ b/src/components/landing/CompaniesSection.tsx
@@ -26,7 +26,11 @@ export const CompaniesSection = () => {
   // Memoize chart section so it only re-renders when selectedCompany or chart props change
   const chartSection = useMemo(() => {
     if (!selectedCompany?.reportingPeriods?.length) {
-      return <Text className="text-grey">{t("landingPage.companiesSection.noEmissionsData")}</Text>;
+      return (
+        <Text className="text-grey">
+          {t("landingPage.companiesSection.noEmissionsData")}
+        </Text>
+      );
     }
     const companyBaseYear = selectedCompany?.baseYear?.year;
     const chartData = getChartData(

--- a/src/components/landing/CompaniesSection.tsx
+++ b/src/components/landing/CompaniesSection.tsx
@@ -1,93 +1,72 @@
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Search } from "lucide-react";
 import { Text } from "../ui/text";
-import { Input } from "../ui/input";
 import { OverviewChart } from "../companies/detail/history/OverviewChart";
 import { useVerificationStatus } from "@/hooks/useVerificationStatus";
 import { useTimeSeriesChartState } from "@/components/charts";
 import { getChartData } from "@/utils/data/chartData";
 import { calculateTrendline } from "@/lib/calculations/trends/analysis";
 import { generateApproximatedData } from "@/lib/calculations/trends/approximatedData";
-import type { RankedCompany, ReportingPeriod } from "@/types/company";
+import type { ReportingPeriod } from "@/types/company";
 import { Button } from "../ui/button";
 import { LocalizedLink } from "@/components/LocalizedLink";
 import { ArrowRight } from "lucide-react";
+import { CompanySearchInput } from "./CompanySearchInput";
+import { RankedCompany } from "@/types/company";
 
-interface CompaniesSectionProps {
-  companies: RankedCompany[];
-}
-
-export const CompaniesSection = ({ companies }: CompaniesSectionProps) => {
+export const CompaniesSection = () => {
   const { t } = useTranslation();
   const { isAIGenerated, isEmissionsAIGenerated } = useVerificationStatus();
   const { chartEndYear, setChartEndYear, shortEndYear, longEndYear } =
     useTimeSeriesChartState();
-  const [searchQuery, setSearchQuery] = useState("");
-  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-  const [selectedCompanyId, setSelectedCompanyId] = useState<
-    string | undefined
-  >(undefined);
+  const [selectedCompany, setSelectedCompany] = useState<RankedCompany | null>(
+    null,
+  );
 
-  const filteredCompanies = useMemo(() => {
-    const query = searchQuery.trim().toLowerCase();
-    if (!query) {
-      return companies;
-    }
-
-    return companies.filter((company) =>
-      company.name.toLowerCase().includes(query),
-    );
-  }, [companies, searchQuery]);
-
-  const selectedCompany = useMemo(() => {
-    if (selectedCompanyId) {
-      const selectedById = companies.find(
-        (company) => String(company.wikidataId) === selectedCompanyId,
-      );
-      if (selectedById) {
-        return selectedById;
-      }
-    }
-
-    return (
-      companies.find((company) => company.name === "ABB Ltd.") || companies[0]
-    );
-  }, [companies, selectedCompanyId]);
-
-  const companyBaseYear = selectedCompany?.baseYear?.year;
-
-  const chartData = useMemo(() => {
+  // Memoize chart section so it only re-renders when selectedCompany or chart props change
+  const chartSection = useMemo(() => {
     if (!selectedCompany?.reportingPeriods?.length) {
-      return [];
+      return <Text className="text-grey">No emissions data available.</Text>;
     }
-
-    return getChartData(
+    const companyBaseYear = selectedCompany?.baseYear?.year;
+    const chartData = getChartData(
       selectedCompany.reportingPeriods as unknown as ReportingPeriod[],
       isAIGenerated,
       isEmissionsAIGenerated,
     );
-  }, [selectedCompany, isAIGenerated, isEmissionsAIGenerated]);
-
-  const trendAnalysis = useMemo(() => {
-    if (!selectedCompany) {
-      return null;
-    }
-
-    return calculateTrendline(selectedCompany);
-  }, [selectedCompany]);
-
-  const approximatedData = useMemo(() => {
-    if (!trendAnalysis?.coefficients || chartData.length === 0) {
-      return null;
-    }
-
-    return generateApproximatedData(
-      chartData,
-      chartEndYear,
-      trendAnalysis.coefficients,
+    const trendAnalysis = calculateTrendline(selectedCompany);
+    const approximatedData =
+      trendAnalysis?.coefficients && chartData.length > 0
+        ? generateApproximatedData(
+            chartData,
+            chartEndYear,
+            trendAnalysis.coefficients,
+          )
+        : null;
+    return (
+      <div className="w-full h-[520px]">
+        <OverviewChart
+          key={String(selectedCompany.wikidataId)}
+          data={chartData}
+          companyBaseYear={companyBaseYear}
+          chartEndYear={chartEndYear}
+          setChartEndYear={setChartEndYear}
+          shortEndYear={shortEndYear}
+          longEndYear={longEndYear}
+          approximatedData={approximatedData}
+          onYearSelect={() => undefined}
+          yearControlsPlacement="top-right"
+        />
+      </div>
     );
-  }, [chartData, chartEndYear, trendAnalysis]);
+  }, [
+    selectedCompany,
+    isAIGenerated,
+    isEmissionsAIGenerated,
+    chartEndYear,
+    shortEndYear,
+    longEndYear,
+  ]);
 
   return (
     <div className="bg-black w-full flex flex-col items-center min-h-screen pt-24 lg:pt-72">
@@ -126,56 +105,7 @@ export const CompaniesSection = ({ companies }: CompaniesSectionProps) => {
 
           <div className="order-2 lg:order-1 w-full lg:w-3/5 flex flex-col gap-3">
             <div className="flex w-full flex-col gap-3 md:flex-row md:items-center md:justify-start md:gap-6 md:pt-4">
-              <div className="relative w-full max-w-[18rem]">
-                <div className="relative">
-                  <Search
-                    className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-white/50"
-                    aria-hidden="true"
-                  />
-                  <Input
-                    value={searchQuery}
-                    onChange={(event) => {
-                      setSearchQuery(event.target.value);
-                      setIsDropdownOpen(true);
-                    }}
-                    onFocus={() => setIsDropdownOpen(true)}
-                    onKeyDown={(event) => {
-                      if (event.key === "Escape") {
-                        setIsDropdownOpen(false);
-                      }
-                    }}
-                    placeholder={t("landingPage.searchPlaceholder")}
-                    className="h-11 border-white/25 bg-black-2 pl-10 text-white placeholder:text-white/50 focus-visible:ring-white/40"
-                    aria-label={t("landingPage.placeholder")}
-                  />
-                </div>
-
-                {isDropdownOpen && searchQuery.trim() && (
-                  <div className="absolute left-0 top-full z-30 mt-2 max-h-48 w-full overflow-y-auto rounded-md border border-white/10 bg-black-2 shadow-lg">
-                    {filteredCompanies.length > 0 ? (
-                      filteredCompanies.slice(0, 8).map((company) => (
-                        <button
-                          key={company.wikidataId}
-                          type="button"
-                          tabIndex={0}
-                          onClick={() => {
-                            setSelectedCompanyId(String(company.wikidataId));
-                            setSearchQuery(company.name);
-                            setIsDropdownOpen(false);
-                          }}
-                          className="w-full px-3 py-2 text-left text-sm text-white hover:bg-white/10"
-                        >
-                          {company.name}
-                        </button>
-                      ))
-                    ) : (
-                      <div className="px-3 py-2 text-sm text-white/60">
-                        {t("globalSearch.searchDialog.emptyText")}
-                      </div>
-                    )}
-                  </div>
-                )}
-              </div>
+              <CompanySearchInput onSelect={setSelectedCompany} />
 
               <div className="w-full flex items-center gap-2">
                 <Text className="text-lg font-light text-[18px] text-grey">
@@ -187,24 +117,7 @@ export const CompaniesSection = ({ companies }: CompaniesSectionProps) => {
               </div>
             </div>
 
-            {selectedCompany && chartData.length > 0 ? (
-              <div className="w-full h-[520px]">
-                <OverviewChart
-                  key={String(selectedCompany.wikidataId)}
-                  data={chartData}
-                  companyBaseYear={companyBaseYear}
-                  chartEndYear={chartEndYear}
-                  setChartEndYear={setChartEndYear}
-                  shortEndYear={shortEndYear}
-                  longEndYear={longEndYear}
-                  approximatedData={approximatedData}
-                  onYearSelect={() => undefined}
-                  yearControlsPlacement="top-right"
-                />
-              </div>
-            ) : (
-              <Text className="text-grey">No emissions data available.</Text>
-            )}
+            {chartSection}
           </div>
 
           <LocalizedLink

--- a/src/components/landing/CompaniesSection.tsx
+++ b/src/components/landing/CompaniesSection.tsx
@@ -26,7 +26,7 @@ export const CompaniesSection = () => {
   // Memoize chart section so it only re-renders when selectedCompany or chart props change
   const chartSection = useMemo(() => {
     if (!selectedCompany?.reportingPeriods?.length) {
-      return <Text className="text-grey">No emissions data available.</Text>;
+      return <Text className="text-grey">{t("landingPage.companiesSection.noEmissionsData")}</Text>;
     }
     const companyBaseYear = selectedCompany?.baseYear?.year;
     const chartData = getChartData(

--- a/src/components/landing/CompanySearchInput.tsx
+++ b/src/components/landing/CompanySearchInput.tsx
@@ -1,0 +1,89 @@
+import { useState, useEffect, memo } from "react";
+import { useTranslation } from "react-i18next";
+import { Search } from "lucide-react";
+import { Input } from "../ui/input";
+import { Loader2 } from "lucide-react";
+import { useCompanySearch } from "@/hooks/companies/useCompanySearch";
+import { RankedCompany } from "@/types/company";
+
+export const CompanySearchInput = memo(function CompanySearchInput({
+  onSelect,
+}: {
+  onSelect: (company: RankedCompany) => void;
+}) {
+  const { t } = useTranslation();
+  const [inputValue, setInputValue] = useState("");
+  const [searchQuery, setSearchQuery] = useState("ABB Ltd.");
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const { searchResults, isSearching, isDebouncing } =
+    useCompanySearch(searchQuery);
+
+  // On mount, set input and searchQuery to ABB Ltd.
+  useEffect(() => {
+    setInputValue("ABB Ltd.");
+    setSearchQuery("ABB Ltd.");
+  }, []);
+
+  // Auto-select ABB Ltd. on mount
+  useEffect(() => {
+    if (searchQuery.trim() === "ABB Ltd." && searchResults.length > 0) {
+      onSelect(searchResults[0] as RankedCompany);
+    }
+  }, [searchResults]);
+
+  return (
+    <div className="relative w-full max-w-[18rem]">
+      <div className="relative">
+        <Search
+          className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-white/50"
+          aria-hidden="true"
+        />
+        <Input
+          value={inputValue}
+          onChange={(event) => {
+            setInputValue(event.target.value);
+            setSearchQuery(event.target.value);
+            setIsDropdownOpen(true);
+          }}
+          onFocus={() => setIsDropdownOpen(true)}
+          onKeyDown={(event) => {
+            if (event.key === "Escape") setIsDropdownOpen(false);
+          }}
+          placeholder={t("landingPage.searchPlaceholder")}
+          className="h-11 border-white/25 bg-black-2 pl-10 text-white placeholder:text-white/50 focus-visible:ring-white/40"
+          aria-label={t("landingPage.placeholder")}
+        />
+      </div>
+      {isDropdownOpen && inputValue.trim() && (
+        <div className="absolute left-0 top-full z-30 mt-2 max-h-48 w-full overflow-y-auto rounded-md border border-white/10 bg-black-2 shadow-lg">
+          {isDebouncing || isSearching ? (
+            <div className="flex items-center gap-2 px-3 py-2 text-sm text-white/70">
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+              <span>{t("landingPage.heroSearchLoadingText")}</span>
+            </div>
+          ) : searchResults.length > 0 ? (
+            searchResults.slice(0, 30).map((company) => (
+              <button
+                key={company.wikidataId}
+                type="button"
+                tabIndex={0}
+                onClick={() => {
+                  onSelect(company as RankedCompany);
+                  setInputValue(company.name);
+                  setIsDropdownOpen(false);
+                }}
+                className="w-full px-3 py-2 text-left text-sm text-white hover:bg-white/10"
+              >
+                {company.name}
+              </button>
+            ))
+          ) : (
+            <div className="px-3 py-2 text-sm text-white/60">
+              {t("globalSearch.searchDialog.emptyText")}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+});

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, useEffect, useMemo } from "react";
 import { useLocation, useParams } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
-import { getCompanies, getMunicipalities } from "@/lib/api";
+import { getMunicipalities } from "@/lib/api";
 import { Seo } from "@/components/SEO/Seo";
 import { getSeoForRoute } from "@/seo/routes";
 import { Header } from "./Header";

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -31,11 +31,6 @@ export function Layout({ children }: LayoutProps) {
 
   useEffect(() => {
     queryClient.prefetchQuery({
-      queryKey: ["companies"],
-      queryFn: getCompanies,
-    });
-
-    queryClient.prefetchQuery({
       queryKey: ["municipalities"],
       queryFn: getMunicipalities,
     });

--- a/src/hooks/companies/useCompanySearch.ts
+++ b/src/hooks/companies/useCompanySearch.ts
@@ -1,0 +1,37 @@
+import { useQuery } from "@tanstack/react-query";
+import { useState, useEffect } from "react";
+import { getCompaniesBySearchTerm } from "@/lib/api";
+import { HERO_SEARCH_DEBOUNCE_MS } from "@/lib/constants/landingPage";
+
+export function useCompanySearch(searchQuery: string) {
+  const [debouncedQuery, setDebouncedQuery] = useState(searchQuery.trim());
+  const [isDebouncing, setIsDebouncing] = useState(false);
+
+  useEffect(() => {
+    setIsDebouncing(true);
+    const handler = setTimeout(() => {
+      setDebouncedQuery(searchQuery.trim());
+      setIsDebouncing(false);
+    }, HERO_SEARCH_DEBOUNCE_MS);
+    return () => {
+      clearTimeout(handler);
+      setIsDebouncing(false);
+    };
+  }, [searchQuery]);
+
+  const { data: searchResults = [], isFetching: isSearching } = useQuery({
+    queryKey: ["companySearch", debouncedQuery],
+    queryFn: () =>
+      debouncedQuery
+        ? getCompaniesBySearchTerm(debouncedQuery)
+        : Promise.resolve([]),
+    enabled: !!debouncedQuery,
+    staleTime: 60 * 1000,
+  });
+
+  return {
+    searchResults,
+    isSearching,
+    isDebouncing,
+  };
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -371,3 +371,22 @@ export async function getNationalData() {
     return [];
   }
 }
+
+// Company Search API
+export type CompanySearchApiResponse =
+  paths["/companies/search"]["get"]["responses"][200]["content"]["application/json"];
+
+export async function getCompaniesBySearchTerm(
+  q: string,
+): Promise<CompanySearchApiResponse> {
+  try {
+    const { data, error } = await GET("/companies/search", {
+      params: { query: { q } },
+    });
+    if (error) throw error;
+    return (data as CompanySearchApiResponse) || [];
+  } catch (error) {
+    console.error("Error searching companies:", error);
+    return [];
+  }
+}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -112,7 +112,8 @@
       "title": "How's it going with company emissions?",
       "description": "Explore over 400 companies and access detailed data on reported emissions and whether they are aligned with the Paris Agreement.",
       "exploreButton": "Explore Companies",
-      "currentlyViewing": "Currently viewing:"
+      "currentlyViewing": "Currently viewing:",
+      "noEmissionsData": "No emissions data available."
     },
     "municipalitiesSection": {
       "title": "How is your municipality performing?",

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -117,7 +117,8 @@
       "title": "Hur går det med företagens utsläpp?",
       "description": "Utforska över 400 bolag och få detaljerad data om rapporterade utsläpp och om de ligger i linje med Parisavtalet.",
       "exploreButton": "Utforska företag",
-      "currentlyViewing": "Visar just nu:"
+      "currentlyViewing": "Visar just nu:",
+      "noEmissionsData": "Ingen utsläppsdata tillgänglig"
     },
     "municipalitiesSection": {
       "title": "Hur presterar din kommun?",
@@ -639,7 +640,7 @@
         },
         "whyWorks": {
           "title": "Varför fungerar en linjär trendlinje för Paris-bedömning?",
-          "paragraph1": "Bedömningen av Paris-linjen baseras på de totala kumulativa utsläppen 2025–2050 – organisationens koldioxidbudget för en 1,5°C-bana med ungefär 50 % sannolikhet.",
+          "paragraph1": "Bedömningen av Paris-linjen baseras på de totala kumulativa utsläppen 2025–2050 – organisationens koldioxidbudget för en 1,5°C-bana med ungefär 50 % sannolikhet att begränsa uppvärmningen till 1,5 °C.",
           "point1": "Den linjära trendlinjen gör det möjligt att uppskatta om den projicerade banan håller sig inom denna budget.",
           "point2": "Om trendlinjen ligger inom budgeten kommer utsläppen nödvändigtvis att närma sig mycket låga nivåer långt före 2050.",
           "point3": "Att använda samma metod för alla kommuner och företag möjliggör rättvisa och jämförbara bedömningar.",
@@ -1053,7 +1054,7 @@
             "Genom att publicera öppna klimatdata bidrar Klimatkollen till transparens och ett ökat stöd för Parisavtalet i politik och näringsliv. För om vi inte vet hur det går med utsläppen – och hur det borde gå – kommer vi inte kunna göra det som krävs för att minska dem i linje med Parisavtalet.",
             "Klimatkollen är en data-driven ideell förening som bygger en rörelse kring öppna klimatdata.",
             "Vi samverkar med näringsliv, akademi och civilsamhälle för ökad slagkraft. För oss står AI, öppna data, bred kommunikation och medborgarengagemang i centrum.",
-            "Var en del av rörelsen för öppna klimatdata – bli stödföretag i dag!"
+            "Var en del av rörelsen för öppen klimatdata – bli stödföretag i dag!"
           ],
           "benefitsHeader": "Som stödföretag får du:",
           "benefits": [
@@ -1546,7 +1547,9 @@
           "booleanLabels": {
             "true": "Klarar Parisavtalet",
             "false": "Missar Parisavtalet"
-          }
+          },
+          "aboveString": "är på väg att klara Parisavtalet",
+          "belowString": "är på väg att missa Parisavtalet"
         }
       }
     }
@@ -1644,7 +1647,7 @@
           "label": "Klimatplanerna",
           "description": "Har en aktuell klimatplan",
           "detailedDescription": "Vilka kommuner har en aktuell klimatplan?",
-          "source": "Klimatkollens öppna sammanställning av klimatplaner med hjälp från medlemmar av Klimatklubben och Naturskyddsföreningen",
+          "source": "Klimatkollens öppna sammanställning av klimatplaner med hjälp från medlemmar i Klimatklubben och Naturskyddsföreningen",
           "booleanLabels": {
             "true": "Har klimatplan",
             "false": "Saknar klimatplan"

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { ChevronDown } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { Typewriter } from "@/components/ui/typewriter";
-import { useCompanies } from "@/hooks/companies/useCompanies";
 import { useMunicipalities } from "@/hooks/municipalities/useMunicipalities";
 import { PageSEO } from "@/components/SEO/PageSEO";
 import { SCROLL_FADE_THRESHOLD } from "@/hooks/landing/useLandingPageData";
@@ -18,7 +17,6 @@ import { Text } from "@/components/ui/text";
 
 export function LandingPage() {
   const { t } = useTranslation();
-  const { companies } = useCompanies();
   const { municipalities } = useMunicipalities();
   const companiesSectionRef = useRef<HTMLDivElement | null>(null);
   const [fadeChevron, setFadeChevron] = useState(false);
@@ -138,7 +136,7 @@ export function LandingPage() {
         />
       </div>
       <div ref={companiesSectionRef} id="companies-section" className="w-full">
-        <CompaniesSection companies={companies} />
+        <CompaniesSection />
       </div>
       <MunicipalitiesSection municipalities={municipalities} />
       <CountriesSection />


### PR DESCRIPTION
### ✨ What’s Changed?
This pull request refactors the company search and selection functionality on the landing page to use a new debounced, API-powered search component. The previous implementation, which relied on passing all companies as props and filtering them client-side, has been replaced with a new `CompanySearchInput` component that fetches search results from the backend. This change improves performance and scalability, especially as the number of companies grows. Additionally, related state management and chart rendering logic in `CompaniesSection` have been simplified and made more modular.

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [x] I've set the labels, issue, and milestone for the PR
- [ ] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #1457 