### PR TITLE
[fix] add loading states to landing page section graphs

### DIFF
--- a/src/components/landing/CompaniesSection.tsx
+++ b/src/components/landing/CompaniesSection.tsx
@@ -7,12 +7,11 @@ import { useTimeSeriesChartState } from "@/components/charts";
 import { getChartData } from "@/utils/data/chartData";
 import { calculateTrendline } from "@/lib/calculations/trends/analysis";
 import { generateApproximatedData } from "@/lib/calculations/trends/approximatedData";
-import type { ReportingPeriod } from "@/types/company";
+import type { RankedCompany, ReportingPeriod } from "@/types/company";
 import { Button } from "../ui/button";
 import { LocalizedLink } from "@/components/LocalizedLink";
 import { ArrowRight } from "lucide-react";
 import { CompanySearchInput } from "./CompanySearchInput";
-import { RankedCompany } from "@/types/company";
 
 export const CompaniesSection = () => {
   const { t } = useTranslation();

--- a/src/components/landing/CompaniesSection.tsx
+++ b/src/components/landing/CompaniesSection.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Text } from "../ui/text";
 import { OverviewChart } from "../companies/detail/history/OverviewChart";
@@ -22,6 +22,10 @@ export const CompaniesSection = () => {
   const [selectedCompany, setSelectedCompany] = useState<RankedCompany | null>(
     null,
   );
+  const [isCompanySearchBusy, setIsCompanySearchBusy] = useState(true);
+  const handleSearchBusyChange = useCallback((busy: boolean) => {
+    setIsCompanySearchBusy(busy);
+  }, []);
 
   // Memoize chart section so it only re-renders when selectedCompany or chart props change
   const chartSection = useMemo(() => {
@@ -109,7 +113,10 @@ export const CompaniesSection = () => {
 
           <div className="order-2 lg:order-1 w-full lg:w-3/5 flex flex-col gap-3">
             <div className="flex w-full flex-col gap-3 md:flex-row md:items-center md:justify-start md:gap-6 md:pt-4">
-              <CompanySearchInput onSelect={setSelectedCompany} />
+              <CompanySearchInput
+                onSelect={setSelectedCompany}
+                onBusyChange={handleSearchBusyChange}
+              />
 
               <div className="w-full flex items-center gap-2">
                 <Text className="text-lg font-light text-[18px] text-grey">
@@ -121,7 +128,11 @@ export const CompaniesSection = () => {
               </div>
             </div>
 
-            {chartSection}
+            {isCompanySearchBusy ? (
+              <div className="w-full h-[520px] animate-pulse bg-black-2 rounded-level-2" />
+            ) : (
+              chartSection
+            )}
           </div>
 
           <LocalizedLink

--- a/src/components/landing/CompanySearchInput.tsx
+++ b/src/components/landing/CompanySearchInput.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, memo } from "react";
+import { useState, useEffect, useLayoutEffect, memo } from "react";
 import { useTranslation } from "react-i18next";
 import { Search } from "lucide-react";
 import { Input } from "../ui/input";
@@ -8,28 +8,34 @@ import { RankedCompany } from "@/types/company";
 
 export const CompanySearchInput = memo(function CompanySearchInput({
   onSelect,
+  onBusyChange,
 }: {
   onSelect: (company: RankedCompany) => void;
+  onBusyChange?: (busy: boolean) => void;
 }) {
   const { t } = useTranslation();
   const [inputValue, setInputValue] = useState("");
-  const [searchQuery, setSearchQuery] = useState("ABB Ltd.");
+  const [searchQuery, setSearchQuery] = useState("Arla");
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const { searchResults, isSearching, isDebouncing } =
     useCompanySearch(searchQuery);
 
-  // On mount, set input and searchQuery to ABB Ltd.
   useEffect(() => {
-    setInputValue("ABB Ltd.");
-    setSearchQuery("ABB Ltd.");
+    onBusyChange?.(isDebouncing || isSearching);
+  }, [isDebouncing, isSearching, onBusyChange]);
+
+  // On mount, set input and searchQuery to Arla
+  useEffect(() => {
+    setInputValue("Arla");
+    setSearchQuery("Arla");
   }, []);
 
-  // Auto-select ABB Ltd. on mount
-  useEffect(() => {
-    if (searchQuery.trim() === "ABB Ltd." && searchResults.length > 0) {
+  // Auto-select Arla on mount before paint to avoid chart placeholder flash
+  useLayoutEffect(() => {
+    if (searchQuery.trim() === "Arla" && searchResults.length > 0) {
       onSelect(searchResults[0] as RankedCompany);
     }
-  }, [searchResults]);
+  }, [searchResults, searchQuery, onSelect]);
 
   return (
     <div className="relative w-full max-w-[18rem]">

--- a/src/components/landing/CompanySearchInput.tsx
+++ b/src/components/landing/CompanySearchInput.tsx
@@ -1,8 +1,7 @@
 import { useState, useEffect, useLayoutEffect, memo } from "react";
 import { useTranslation } from "react-i18next";
-import { Search } from "lucide-react";
+import { Loader2, Search } from "lucide-react";
 import { Input } from "../ui/input";
-import { Loader2 } from "lucide-react";
 import { useCompanySearch } from "@/hooks/companies/useCompanySearch";
 import { RankedCompany } from "@/types/company";
 

--- a/src/components/landing/CountriesSection.tsx
+++ b/src/components/landing/CountriesSection.tsx
@@ -15,7 +15,8 @@ import {
 
 export const CountriesSection = () => {
   const { t } = useTranslation();
-  const { sectorEmissions } = useSectorEmissions("nation", undefined);
+  const { sectorEmissions, loading: sectorEmissionsLoading } =
+    useSectorEmissions("nation", undefined);
   const { getSectorInfo } = useSectors();
   const { hiddenItems: filteredSectors, setHiddenItems: setFilteredSectors } =
     useHiddenItems<string>([]);
@@ -36,20 +37,24 @@ export const CountriesSection = () => {
           </Text>
         </div>
         <div className="w-full">
-          <SectorEmissionsChart
-            sectorEmissions={sectorEmissions}
-            availableYears={availableYears}
-            selectedYear={selectedYear}
-            onYearChange={setSelectedYear}
-            currentYear={currentYear}
-            getSectorInfo={getSectorInfo}
-            filteredSectors={filteredSectors}
-            onFilteredSectorsChange={setFilteredSectors}
-            helpItems={[]}
-            sectionClassName="bg-transparent !rounded-none !px-0 !py-0 [&>div:first-child]:pb-0"
-            showHeader={false}
-            compactLayout={false}
-          />
+          {sectorEmissionsLoading ? (
+            <div className="h-[min(520px,70vh)] w-full animate-pulse bg-black-2 rounded-level-2" />
+          ) : (
+            <SectorEmissionsChart
+              sectorEmissions={sectorEmissions}
+              availableYears={availableYears}
+              selectedYear={selectedYear}
+              onYearChange={setSelectedYear}
+              currentYear={currentYear}
+              getSectorInfo={getSectorInfo}
+              filteredSectors={filteredSectors}
+              onFilteredSectorsChange={setFilteredSectors}
+              helpItems={[]}
+              sectionClassName="bg-transparent !rounded-none !px-0 !py-0 [&>div:first-child]:pb-0"
+              showHeader={false}
+              compactLayout={false}
+            />
+          )}
         </div>
 
         <div className="w-full flex justify-start md:justify-end">

--- a/src/components/landing/MunicipalitiesSection.tsx
+++ b/src/components/landing/MunicipalitiesSection.tsx
@@ -157,9 +157,7 @@ export const MunicipalitiesSection = ({
       : t("landingPage.regionsSection.exploreButton");
 
   const mapLoading =
-    territoryMode === "municipalities"
-      ? municipalitiesLoading
-      : regionsLoading;
+    territoryMode === "municipalities" ? municipalitiesLoading : regionsLoading;
 
   if (!selectedKPI) {
     return null;

--- a/src/components/landing/MunicipalitiesSection.tsx
+++ b/src/components/landing/MunicipalitiesSection.tsx
@@ -24,18 +24,20 @@ import {
 
 interface MunicipalitiesSectionProps {
   municipalities: Municipality[];
+  municipalitiesLoading: boolean;
 }
 
 type TerritoryMode = "municipalities" | "regions";
 
 export const MunicipalitiesSection = ({
   municipalities,
+  municipalitiesLoading,
 }: MunicipalitiesSectionProps) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const municipalityKPIs = useMunicipalityKPIs();
   const regionalKPIs = useRegionalKPIs();
-  const { regionsData } = useRegions();
+  const { regionsData, loading: regionsLoading } = useRegions();
   const [territoryMode, setTerritoryMode] =
     useState<TerritoryMode>("municipalities");
   const [selectedKPIKey, setSelectedKPIKey] = useState<string>(
@@ -154,6 +156,11 @@ export const MunicipalitiesSection = ({
       ? t("landingPage.municipalitiesSection.exploreButton")
       : t("landingPage.regionsSection.exploreButton");
 
+  const mapLoading =
+    territoryMode === "municipalities"
+      ? municipalitiesLoading
+      : regionsLoading;
+
   if (!selectedKPI) {
     return null;
   }
@@ -211,19 +218,23 @@ export const MunicipalitiesSection = ({
             </div>
 
             <div className="relative w-full h-[55vh] md:h-[65vh] lg:h-[75vh]">
-              <TerritoryMap
-                key={territoryMode}
-                entityType={territoryMode}
-                geoData={activeGeoData}
-                data={activeMapData}
-                selectedKPI={selectedKPI}
-                onAreaClick={activeAreaClickHandler}
-                mapBackgroundColor="transparent"
-                scrollWheelZoom={false}
-                defaultCenter={
-                  territoryMode === "regions" ? [63.7, 17] : [63, 17]
-                }
-              />
+              {mapLoading ? (
+                <div className="h-full w-full animate-pulse bg-black-2 rounded-level-2" />
+              ) : (
+                <TerritoryMap
+                  key={territoryMode}
+                  entityType={territoryMode}
+                  geoData={activeGeoData}
+                  data={activeMapData}
+                  selectedKPI={selectedKPI}
+                  onAreaClick={activeAreaClickHandler}
+                  mapBackgroundColor="transparent"
+                  scrollWheelZoom={false}
+                  defaultCenter={
+                    territoryMode === "regions" ? [63.7, 17] : [63, 17]
+                  }
+                />
+              )}
             </div>
           </div>
 

--- a/src/hooks/companies/useCompanySearch.ts
+++ b/src/hooks/companies/useCompanySearch.ts
@@ -5,7 +5,8 @@ import { HERO_SEARCH_DEBOUNCE_MS } from "@/lib/constants/landingPage";
 
 export function useCompanySearch(searchQuery: string) {
   const [debouncedQuery, setDebouncedQuery] = useState(searchQuery.trim());
-  const [isDebouncing, setIsDebouncing] = useState(false);
+  /** Start true so consumers can show loading until the first debounce cycle runs. */
+  const [isDebouncing, setIsDebouncing] = useState(true);
 
   useEffect(() => {
     setIsDebouncing(true);

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -17,7 +17,7 @@ import { Text } from "@/components/ui/text";
 
 export function LandingPage() {
   const { t } = useTranslation();
-  const { municipalities } = useMunicipalities();
+  const { municipalities, municipalitiesLoading } = useMunicipalities();
   const companiesSectionRef = useRef<HTMLDivElement | null>(null);
   const [fadeChevron, setFadeChevron] = useState(false);
 
@@ -138,7 +138,10 @@ export function LandingPage() {
       <div ref={companiesSectionRef} id="companies-section" className="w-full">
         <CompaniesSection />
       </div>
-      <MunicipalitiesSection municipalities={municipalities} />
+      <MunicipalitiesSection
+        municipalities={municipalities}
+        municipalitiesLoading={municipalitiesLoading}
+      />
       <CountriesSection />
       <MissionSection />
       <PartnersSection />


### PR DESCRIPTION
### ✨ What’s Changed?

Add loading states to landing page sections graphs (company/municipality/country). Before this, comapny graph defaulted to "No emissions data available." while loading company

Also, chnage default company from ABB to Arla bc better graph and more relatable