### PR TITLE
[hotfix] allow plausible analytics under content-security-policy

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -40,7 +40,7 @@ server {
     add_header X-XSS-Protection "1; mode=block";
     add_header X-Content-Type-Options "nosniff";
     add_header Referrer-Policy "strict-origin-when-cross-origin";
-    add_header Content-Security-Policy "default-src 'self' https://api.klimatkollen.se https://images.unsplash.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' https://images.unsplash.com data:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self' https://api.klimatkollen.se;";
+    add_header Content-Security-Policy "default-src 'self' https://api.klimatkollen.se https://images.unsplash.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' https://images.unsplash.com data:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://plausible.io; connect-src 'self' https://api.klimatkollen.se https://plausible.io;";
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()";
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 


### PR DESCRIPTION
### ✨ What’s Changed?

The site loads Plausible from https://plausible.io/js/script.js in index.html, but the nginx Content-Security-Policy only allowed scripts and API calls from 'self' and the existing API origin. That mismatch can cause the browser to block the Plausible script and its event requests.

This change adds https://plausible.io to script-src (for the loader) and connect-src (for beacons / API calls), so analytics can run in production while keeping the rest of the policy unchanged.