### PR TITLE
[1407] Add color coding to ranked list

### DIFF
--- a/src/components/ranked/RankedList.tsx
+++ b/src/components/ranked/RankedList.tsx
@@ -3,6 +3,7 @@ import { Search } from "lucide-react";
 import { t } from "i18next";
 import MultiPagePagination from "@/components/ui/multi-page-pagination";
 import { DataPoint } from "@/types/rankings";
+import { cn } from "@/lib/utils";
 
 export interface RankedListProps<T extends Record<string, unknown>> {
   data: T[];
@@ -57,6 +58,22 @@ export function RankedList<T extends Record<string, unknown>>({
     const bNum = bValue as number;
     return selectedDataPoint.higherIsBetter ? bNum - aNum : aNum - bNum;
   });
+
+  const validValues = sortedData
+    .map((item) => item[selectedDataPoint.key])
+    .filter(
+      (value) =>
+        (selectedDataPoint.isBoolean && typeof value === "boolean") ||
+        (typeof value === "number" && !isNaN(value as number)),
+    );
+
+  const average =
+    validValues.reduce(
+      (sum, value) =>
+        sum +
+        (selectedDataPoint.isBoolean ? (value ? 1 : 0) : (value as number)),
+      0,
+    ) / validValues.length;
 
   const filteredData = sortedData.filter((item) => {
     const searchValue = item[searchKey];
@@ -121,6 +138,22 @@ export function RankedList<T extends Record<string, unknown>>({
     return originalRankMap.get(item) || 0;
   };
 
+  const getColor = (item: T): string => {
+    const value = item[selectedDataPoint.key];
+
+    if (value === null || value === undefined) {
+      return "text-pink-3";
+    } else if (selectedDataPoint.isBoolean) {
+      return value == selectedDataPoint.higherIsBetter
+        ? "text-blue-3"
+        : "text-pink-3";
+    } else {
+      return (value as number) > average == selectedDataPoint.higherIsBetter
+        ? "text-blue-3"
+        : "text-pink-3";
+    }
+  };
+
   const defaultRenderItem = (item: T, index: number) => {
     const originalRank = getOriginalRank(item);
     return (
@@ -140,7 +173,12 @@ export function RankedList<T extends Record<string, unknown>>({
             {String(item[searchKey])}
           </span>
         </div>
-        <span className="text-orange-2 text-sm md:text-base font-medium text-right">
+        <span
+          className={cn(
+            getColor(item),
+            "text-sm md:text-base font-medium text-right",
+          )}
+        >
           {formatValue(item)}
         </span>
       </button>

--- a/src/utils/insights/rankedListUtils.ts
+++ b/src/utils/insights/rankedListUtils.ts
@@ -104,14 +104,14 @@ export function calculateEntityStatistics<
   const distributionStats = [
     {
       count: aboveAverageCount,
-      colorClass: "text-blue-3",
+      colorClass: selectedKPI.higherIsBetter ? "text-blue-3" : "text-pink-3",
       label: selectedKPI.isBoolean
         ? selectedKPI.booleanLabels?.true || t("yes")
         : aboveAverageLabel,
     },
     {
       count: belowAverageCount,
-      colorClass: "text-pink-3",
+      colorClass: selectedKPI.higherIsBetter ? "text-pink-3" : "text-blue-3",
       label: selectedKPI.isBoolean
         ? selectedKPI.booleanLabels?.false || t("no")
         : belowAverageLabel,


### PR DESCRIPTION
### ✨ What’s Changed?

Colour coding has been added to the ranked list on the overview/ranking pages. The colours of the above/below average counters have also been updated to match the rest of the page.

### 📸 Screenshots

Before:
<img width="1385" height="920" alt="bild" src="https://github.com/user-attachments/assets/d8b3908d-7ff6-4c94-9f34-4e03239c2631" />

After:
<img width="1391" height="922" alt="bild" src="https://github.com/user-attachments/assets/d3386ff4-dcf7-4706-aa77-acb6b45b76e4" />

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [ ] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #1407 