### PR TITLE
[1471] list turnovers < 1 bn in mns

### DIFF
--- a/src/components/companies/detail/overview/OverviewStatistics.tsx
+++ b/src/components/companies/detail/overview/OverviewStatistics.tsx
@@ -22,6 +22,17 @@ export function OverviewStatistics({
   employeesAIGenerated,
   className,
 }: OverviewStatisticProps) {
+  const formattedTurnover = selectedPeriod.economy?.turnover?.value
+    ? (() => {
+        const { value } = selectedPeriod.economy.turnover;
+        const useMillions = value < 1e9;
+        return `${localizeUnit(
+          value / (useMillions ? 1e6 : 1e9),
+          currentLanguage,
+        )} ${t(useMillions ? "companies.overview.million" : "companies.overview.billion")} ${selectedPeriod.economy.turnover.currency}`;
+      })()
+    : t("companies.overview.notReported");
+
   return (
     <div className={className ? `@container ${className}` : "@container"}>
       <div className="mt-8 @md:mt-12 bg-black-1 rounded-level-2 p-6">
@@ -31,18 +42,7 @@ export function OverviewStatistics({
               {t("companies.overview.turnover")}
             </Text>
             <span className="flex items-center gap-2">
-              <Text>
-                {selectedPeriod.economy?.turnover?.value
-                  ? (() => {
-                      const { value } = selectedPeriod.economy.turnover;
-                      const useMillions = value < 1e9;
-                      return `${localizeUnit(
-                        value / (useMillions ? 1e6 : 1e9),
-                        currentLanguage,
-                      )} ${t(useMillions ? "companies.overview.million" : "companies.overview.billion")} ${selectedPeriod.economy.turnover.currency}`;
-                    })()
-                  : t("companies.overview.notReported")}
-              </Text>
+              <Text>{formattedTurnover}</Text>
               {turnoverAIGenerated && <AiIcon size="md" />}
             </span>
           </div>

--- a/src/components/companies/detail/overview/OverviewStatistics.tsx
+++ b/src/components/companies/detail/overview/OverviewStatistics.tsx
@@ -33,10 +33,14 @@ export function OverviewStatistics({
             <span className="flex items-center gap-2">
               <Text>
                 {selectedPeriod.economy?.turnover?.value
-                  ? `${localizeUnit(
-                      selectedPeriod.economy.turnover.value / 1e9,
-                      currentLanguage,
-                    )} ${t("companies.overview.billion")} ${selectedPeriod.economy.turnover.currency}`
+                  ? (() => {
+                      const { value } = selectedPeriod.economy.turnover;
+                      const useMillions = value < 1e9;
+                      return `${localizeUnit(
+                        value / (useMillions ? 1e6 : 1e9),
+                        currentLanguage,
+                      )} ${t(useMillions ? "companies.overview.million" : "companies.overview.billion")} ${selectedPeriod.economy.turnover.currency}`;
+                    })()
                   : t("companies.overview.notReported")}
               </Text>
               {turnoverAIGenerated && <AiIcon size="md" />}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1398,6 +1398,7 @@
       "readLess": "Read Less",
       "aiGeneratedData": "Includes AI-extracted values. To read more, visit our Sources and Methods page.",
       "billion": "bn",
+      "million": "mn",
       "financialsTooltip": "Financed emissions are often reported with a delay, as they are often based on the previous year's data from the companies included in the investment. We show emissions data in scope 3 category 15 in the year it is publicly reported in the annual report, even if it is sometimes stated that the data in this category comes from a previous year."
     },
     "sectionedCompanyList": {

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -1455,6 +1455,7 @@
       "readLess": "Läs mindre",
       "aiGeneratedData": "Innehåller AI-extraherade värden. För att läsa mer, besök vår sida om Källor och metoder.",
       "billion": "mdr",
+      "million": "milj",
       "financialsTooltip": "Finansierade utsläpp rapporteras ofta med fördröjning, eftersom de ofta baseras på föregående års data från de bolag som ingår i investeringen. Vi visar utsläppsdata i scope 3 kategori 15 det år det rapporteras publikt i årsredovisningen, även om det ibland anges att datan i denna kategori är från ett tidigare år."
     },
     "sectionedCompanyList": {


### PR DESCRIPTION
### ✨ What’s Changed?

List turnovers that are smaller than 1 bn in mn:s instead.

### 📸 Screenshots (if applicable)

Before
<img width="549" height="721" alt="Screenshot 2026-05-07 at 11 24 27" src="https://github.com/user-attachments/assets/e6554717-8119-4cff-a221-818856954c97" />


After
<img width="549" height="721" alt="Screenshot 2026-05-07 at 11 24 20" src="https://github.com/user-attachments/assets/6ec374bd-fa31-46d5-bca3-7d6cb9fa1288" />


### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #1471 