### PR TITLE
[Fix] sector year selector

### DIFF
--- a/src/components/landing/CountriesSection.tsx
+++ b/src/components/landing/CountriesSection.tsx
@@ -1,17 +1,13 @@
-import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useHiddenItems } from "@/components/charts";
 import { SectorEmissionsChart } from "@/components/charts/sectorChart/SectorEmissions";
 import { useSectorEmissions } from "@/hooks/territories/useSectorEmissions";
 import { useSectors } from "@/hooks/territories/useSectors";
+import { useSectorYearSelection } from "@/hooks/territories/useSectorYearSelection";
 import { Text } from "../ui/text";
 import { Button } from "../ui/button";
 import { LocalizedLink } from "@/components/LocalizedLink";
 import { ArrowRight } from "lucide-react";
-import {
-  getAvailableYearsFromSectors,
-  getCurrentYearFromAvailable,
-} from "@/utils/detail/sectorYearUtils";
 
 export const CountriesSection = () => {
   const { t } = useTranslation();
@@ -20,10 +16,8 @@ export const CountriesSection = () => {
   const { getSectorInfo } = useSectors();
   const { hiddenItems: filteredSectors, setHiddenItems: setFilteredSectors } =
     useHiddenItems<string>([]);
-  const [selectedYear, setSelectedYear] = useState<string>("2023");
-
-  const availableYears = getAvailableYearsFromSectors(sectorEmissions);
-  const currentYear = getCurrentYearFromAvailable(selectedYear, availableYears);
+  const { selectedYear, setSelectedYear, availableYears, currentYear } =
+    useSectorYearSelection(sectorEmissions);
 
   return (
     <div className="bg-black w-full flex flex-col items-center pt-44 md:pt-52">

--- a/src/hooks/nation/useNationPageData.ts
+++ b/src/hooks/nation/useNationPageData.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import {
   useNationDetails,
   useNationDetailHeaderStats,
@@ -6,10 +6,7 @@ import {
 import { useSectorEmissions } from "@/hooks/territories/useSectorEmissions";
 import { useSectors } from "@/hooks/territories/useSectors";
 import { useHiddenItems } from "@/components/charts";
-import {
-  getAvailableYearsFromSectors,
-  getCurrentYearFromAvailable,
-} from "@/utils/detail/sectorYearUtils";
+import { useSectorYearSelection } from "@/hooks/territories/useSectorYearSelection";
 import { useRegions } from "@/hooks/useRegions";
 import { transformNationEmissionsData } from "@/utils/data/nationTransforms";
 
@@ -20,8 +17,6 @@ export function useNationPageData() {
   const { getSectorInfo } = useSectors();
   const { hiddenItems: filteredSectors, setHiddenItems: setFilteredSectors } =
     useHiddenItems<string>([]);
-  const [selectedYear, setSelectedYear] = useState<string>("2023");
-
   const sortedRegions = useMemo(() => [...regions].sort(), [regions]);
   const emissionsData = useMemo(
     () => (nation ? transformNationEmissionsData(nation) : []),
@@ -35,12 +30,9 @@ export function useNationPageData() {
   }, [emissionsData]);
   const lastYear = lastYearEmissions?.year;
   const headerStats = useNationDetailHeaderStats(nation, lastYear);
-  const availableYears = getAvailableYearsFromSectors(sectorEmissions);
-  const currentYear = getCurrentYearFromAvailable(
-    selectedYear,
-    availableYears,
-    lastYear ?? 2023,
-  );
+
+  const { selectedYear, setSelectedYear, availableYears, currentYear } =
+    useSectorYearSelection(sectorEmissions, lastYear ?? 2023);
 
   return {
     nation,

--- a/src/hooks/territories/useSectorYearSelection.ts
+++ b/src/hooks/territories/useSectorYearSelection.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+import {
+  getAvailableYearsFromSectors,
+  getCurrentYearFromAvailable,
+} from "@/utils/detail/sectorYearUtils";
+import type { SectorEmissionsResponse } from "@/types/emissions";
+
+type SectorEmissionsInput =
+  | SectorEmissionsResponse
+  | { sectors?: Record<string, Record<string, number>> }
+  | null;
+
+export function useSectorYearSelection(
+  sectorEmissions: SectorEmissionsInput,
+  defaultYear?: number,
+) {
+  const [selectedYear, setSelectedYear] = useState<string>("");
+
+  const availableYears = getAvailableYearsFromSectors(sectorEmissions);
+
+  useEffect(() => {
+    if (selectedYear === "" && availableYears.length > 0) {
+      setSelectedYear(availableYears[0].toString());
+    }
+  }, [availableYears, selectedYear]);
+
+  const currentYear = getCurrentYearFromAvailable(
+    selectedYear,
+    availableYears,
+    defaultYear ?? 2023,
+  );
+
+  return { selectedYear, setSelectedYear, availableYears, currentYear };
+}

--- a/src/pages/MunicipalityDetailPage.tsx
+++ b/src/pages/MunicipalityDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useParams, useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { useState, useMemo } from "react";
+import { useMemo } from "react";
 import type { TFunction } from "i18next";
 import {
   useMunicipalityDetails,
@@ -19,10 +19,7 @@ import { useHiddenItems } from "@/components/charts";
 import { PageLoading } from "@/components/pageStates/Loading";
 import { PageError } from "@/components/pageStates/Error";
 import { PageNoData } from "@/components/pageStates/NoData";
-import {
-  getAvailableYearsFromSectors,
-  getCurrentYearFromAvailable,
-} from "@/utils/detail/sectorYearUtils";
+import { useSectorYearSelection } from "@/hooks/territories/useSectorYearSelection";
 import { getProcurementRequirementsText } from "@/utils/municipality/procurement";
 import { LinkCard } from "@/components/detail/DetailLinkCard";
 import { DetailHeader } from "@/components/detail/DetailHeader";
@@ -126,8 +123,6 @@ function useMunicipalityPageData(id: string | undefined) {
   const { getSectorInfo } = useSectors();
   const { hiddenItems: filteredSectors, setHiddenItems: setFilteredSectors } =
     useHiddenItems<string>([]);
-  const [selectedYear, setSelectedYear] = useState<string>("2023");
-
   const lastYearEmissions = municipality?.emissions.at(-1);
   const lastYear = lastYearEmissions?.year;
   const lastYearEmissionsTon = lastYearEmissions
@@ -148,12 +143,8 @@ function useMunicipalityPageData(id: string | undefined) {
     ? transformEmissionsData(municipality)
     : [];
 
-  const availableYears = getAvailableYearsFromSectors(sectorEmissions);
-  const currentYear = getCurrentYearFromAvailable(
-    selectedYear,
-    availableYears,
-    lastYear,
-  );
+  const { selectedYear, setSelectedYear, availableYears, currentYear } =
+    useSectorYearSelection(sectorEmissions, lastYear);
 
   return {
     t,

--- a/src/pages/RegionDetailPage.tsx
+++ b/src/pages/RegionDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useParams } from "react-router-dom";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import {
   useRegionDetails,
   useRegionDetailHeaderStats,
@@ -15,10 +15,7 @@ import { MunicipalityListBox } from "@/components/regions/MunicipalityListBox";
 import { useSectorEmissions } from "@/hooks/territories/useSectorEmissions";
 import { useSectors } from "@/hooks/territories/useSectors";
 import { useHiddenItems } from "@/components/charts";
-import {
-  getAvailableYearsFromSectors,
-  getCurrentYearFromAvailable,
-} from "@/utils/detail/sectorYearUtils";
+import { useSectorYearSelection } from "@/hooks/territories/useSectorYearSelection";
 import { SectorEmissionsChart } from "@/components/charts/sectorChart/SectorEmissions";
 import { DataPoint } from "@/types/emissions";
 
@@ -33,7 +30,6 @@ export function RegionDetailPage() {
   const { getSectorInfo } = useSectors();
   const { hiddenItems: filteredSectors, setHiddenItems: setFilteredSectors } =
     useHiddenItems<string>([]);
-  const [selectedYear, setSelectedYear] = useState<string>("2023");
 
   // Transform emissions data for chart
   const emissionsData = useMemo(() => {
@@ -83,12 +79,8 @@ export function RegionDetailPage() {
 
   const headerStats = useRegionDetailHeaderStats(region, lastYear);
 
-  const availableYears = getAvailableYearsFromSectors(sectorEmissions);
-  const currentYear = getCurrentYearFromAvailable(
-    selectedYear,
-    availableYears,
-    lastYear ?? 2023,
-  );
+  const { selectedYear, setSelectedYear, availableYears, currentYear } =
+    useSectorYearSelection(sectorEmissions, lastYear ?? 2023);
 
   // Filter municipalities that belong to this region
   const regionMunicipalities = useMemo(() => {


### PR DESCRIPTION
### ✨ What’s Changed?

Add a hook for year selection of sector charts. Should default to latest reported year, instead of having 2023 hardcoded.

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)