### PR TITLE
[#1399]: Use stable KPI keys in municipality links

### DIFF
--- a/src/pages/MunicipalitiesOverviewPage.test.tsx
+++ b/src/pages/MunicipalitiesOverviewPage.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MunicipalitiesOverviewPage } from "./MunicipalitiesOverviewPage";
+
+vi.mock("@/hooks/municipalities/useMunicipalities", () => ({
+  useMunicipalities: () => ({
+    municipalities: [],
+    municipalitiesLoading: false,
+    municipalitiesError: null,
+  }),
+}));
+
+vi.mock("@/components/layout/PageHeader", () => ({
+  PageHeader: () => <div />,
+}));
+
+vi.mock("@/components/maps/TerritoryMap", () => ({
+  default: ({ selectedKPI }: any) => (
+    <div data-testid="territory-map">{String(selectedKPI.key)}</div>
+  ),
+}));
+
+vi.mock("@/components/municipalities/MunicipalityRankedList", () => ({
+  MunicipalityRankedList: ({ selectedKPI }: any) => (
+    <div data-testid="ranked-list">{String(selectedKPI.key)}</div>
+  ),
+}));
+
+vi.mock("@/components/municipalities/rankedList/MunicipalityInsightsPanel", () => ({
+  default: ({ selectedKPI }: any) => (
+    <div data-testid="insights-panel">{String(selectedKPI.key)}</div>
+  ),
+}));
+
+vi.mock("@/components/ranked/KPIDataSelector", () => ({
+  KPIDataSelector: ({ selectedKPI }: any) => (
+    <div data-testid="kpi-selector">{String(selectedKPI.key)}</div>
+  ),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe("MunicipalitiesOverviewPage", () => {
+  it("selects municipality KPI from the URL using the stable KPI key", () => {
+    render(
+      <MemoryRouter
+        initialEntries={[
+          "/explore/municipalities?kpi=bicycleMetrePerCapita",
+        ]}
+      >
+        <Routes>
+          <Route
+            path="/explore/municipalities"
+            element={<MunicipalitiesOverviewPage />}
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId("kpi-selector")).toHaveTextContent(
+      "bicycleMetrePerCapita",
+    );
+  });
+});

--- a/src/pages/MunicipalitiesOverviewPage.tsx
+++ b/src/pages/MunicipalitiesOverviewPage.tsx
@@ -27,9 +27,9 @@ export function MunicipalitiesOverviewPage() {
 
   const getKPIFromURL = useCallback(() => {
     const params = new URLSearchParams(location.search);
-    const kpiLabel = params.get("kpi");
+    const kpiKey = params.get("kpi");
     return (
-      municipalityKPIs.find((kpi) => kpi.label === kpiLabel) ||
+      municipalityKPIs.find((kpi) => String(kpi.key) === kpiKey) ||
       municipalityKPIs[0]
     );
   }, [location.search, municipalityKPIs]);
@@ -170,7 +170,7 @@ export function MunicipalitiesOverviewPage() {
         selectedKPI={selectedKPI}
         onKPIChange={(kpi) => {
           setSelectedKPI(kpi);
-          setKPIInURL(kpi.label);
+          setKPIInURL(String(kpi.key));
         }}
         kpis={municipalityKPIs}
         translationPrefix="municipalities.list"


### PR DESCRIPTION
✨ What’s Changed?

This pull request updates municipality KPI links to use stable KPI keys instead of translated labels.

Previously, the selected KPI was stored in the URL using the translated `label` value. This caused issues when switching languages, since the label could differ between Swedish and English.

The URL now uses the stable `key` value instead, while keeping translated labels in the UI.

A regression test was also added to verify that municipality KPI selection works correctly from URL parameters.

📋 Checklist

* [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
* [x] I've verified the change runs locally both on mobile and desktop
* [x] Added a regression test for KPI URL handling

🛠 Related Issue

Closes #1399
