### PR TITLE
[1487] Stack national emissions graph by category

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,9 @@ VITE_GITHUB_CLIENT_ID=
 # Backend endpoint for local development
 VITE_API_PROXY=https://klimatkollen.se/
 
+# Required when using local Garbo (e.g. http://localhost:3000/) — Vite adds this as X-API-Key
+# GARBO_PROXY_CLIENT_API_KEY=garb_<lookup>.<secret>
+
 # Site origin for absolute URLs (canonical, OpenGraph, etc.)
 VITE_SITE_ORIGIN=https://klimatkollen.se
 

--- a/src/components/charts/historicEmissions/ChartTooltip.tsx
+++ b/src/components/charts/historicEmissions/ChartTooltip.tsx
@@ -138,6 +138,7 @@ export const ChartTooltip: React.FC<ChartTooltipProps> = ({
         entry.dataKey &&
         stackKeys.has(entry.dataKey) &&
         !entry.dataKey.endsWith("TrendTop") &&
+        !entry.dataKey.endsWith("HistoricalTop") &&
         !entry.dataKey.endsWith("CarbonLawTop"),
     );
 

--- a/src/components/charts/historicEmissions/ChartTooltip.tsx
+++ b/src/components/charts/historicEmissions/ChartTooltip.tsx
@@ -55,24 +55,6 @@ interface ChartTooltipProps {
   showAIIndicators?: boolean;
 }
 
-const NATION_PARIS_TOOLTIP_LAYERS = [
-  {
-    topKey: "territorialFossilCarbonLawTop",
-    valueKey: "territorialFossilCarbonLaw",
-    labelKey: "nation.detailPage.graph.territorialFossilParis",
-  },
-  {
-    topKey: "biogenicCarbonLawTop",
-    valueKey: "biogenicCarbonLaw",
-    labelKey: "nation.detailPage.graph.biogenicParis",
-  },
-  {
-    topKey: "consumptionAbroadCarbonLawTop",
-    valueKey: "consumptionAbroadCarbonLaw",
-    labelKey: "nation.detailPage.graph.consumptionAbroadParis",
-  },
-] as const;
-
 export const ChartTooltip: React.FC<ChartTooltipProps> = ({
   active,
   payload,
@@ -107,10 +89,8 @@ export const ChartTooltip: React.FC<ChartTooltipProps> = ({
     // Keep trend and Paris data even if zero
     if (
       entry.dataKey === "approximated" ||
-      entry.dataKey === "carbonLaw" ||
-      entry.dataKey === "territorialFossilCarbonLaw" ||
-      entry.dataKey === "biogenicCarbonLaw" ||
-      entry.dataKey === "consumptionAbroadCarbonLaw"
+      entry.dataKey === "trend" ||
+      entry.dataKey === "carbonLaw"
     ) {
       return entry.value != null;
     }
@@ -139,9 +119,16 @@ export const ChartTooltip: React.FC<ChartTooltipProps> = ({
   }
 
   if (dataView === "nation-overview") {
-    const dataPoint = payload[0]?.payload as
-      | Record<string, number | undefined>
-      | undefined;
+    const nationTrendLabelKeys: Record<string, string> = {
+      territorialFossilTrend: "nation.detailPage.graph.territorialFossil",
+      biogenicTrend: "nation.detailPage.graph.biogenic",
+      consumptionAbroadTrend: "nation.detailPage.graph.consumptionAbroad",
+    };
+    const nationTrendColors: Record<string, string> = {
+      territorialFossilTrend: "var(--orange-2)",
+      biogenicTrend: "var(--green-2)",
+      consumptionAbroadTrend: "var(--blue-2)",
+    };
 
     const stackKeys = new Set([
       "territorialFossil",
@@ -151,56 +138,34 @@ export const ChartTooltip: React.FC<ChartTooltipProps> = ({
       "biogenicTrend",
       "consumptionAbroadTrend",
     ]);
-    filteredPayload = filteredPayload.filter(
-      (entry) =>
-        entry.dataKey &&
-        stackKeys.has(entry.dataKey) &&
-        !entry.dataKey.endsWith("TrendTop") &&
-        !entry.dataKey.endsWith("HistoricalTop"),
-    );
-
-    const hasReported = filteredPayload.some(
-      (entry) =>
-        entry.dataKey &&
-        ["territorialFossil", "biogenic", "consumptionAbroad"].includes(
-          entry.dataKey,
-        ) &&
-        entry.value != null,
-    );
-    if (hasReported) {
-      filteredPayload = filteredPayload.filter(
+    filteredPayload = filteredPayload
+      .filter(
         (entry) =>
-          !entry.dataKey ||
-          ![
-            "territorialFossilTrend",
-            "biogenicTrend",
-            "consumptionAbroadTrend",
-          ].includes(entry.dataKey),
-      );
-    }
-
-    const parisTooltipEntries: PayloadEntry[] =
-      NATION_PARIS_TOOLTIP_LAYERS.flatMap((layer) => {
-        const topEntry = payload.find(
-          (entry) => entry.dataKey === layer.topKey,
-        );
-        const segmentValue = dataPoint?.[layer.valueKey];
-        if (segmentValue == null || !topEntry) {
-          return [];
+          entry.dataKey &&
+          stackKeys.has(entry.dataKey) &&
+          !entry.dataKey.endsWith("TrendTop") &&
+          !entry.dataKey.endsWith("HistoricalTop"),
+      )
+      .map((entry) => {
+        const labelKey = nationTrendLabelKeys[entry.dataKey as string];
+        if (!labelKey) {
+          return entry;
         }
 
-        return [
-          {
-            dataKey: layer.valueKey,
-            value: segmentValue,
-            name: t(layer.labelKey),
-            color: topEntry.color,
-            payload: payload[0]?.payload,
-          },
-        ];
+        return {
+          ...entry,
+          name: `${t(labelKey)} (${t("detailPage.graph.trend")})`,
+          color: nationTrendColors[entry.dataKey as string] ?? entry.color,
+        };
       });
 
-    filteredPayload = [...filteredPayload, ...parisTooltipEntries];
+    const seenDataKeys = new Set<string>();
+    filteredPayload = filteredPayload.filter((entry) => {
+      if (!entry.dataKey) return false;
+      if (seenDataKeys.has(entry.dataKey)) return false;
+      seenDataKeys.add(entry.dataKey);
+      return true;
+    });
   }
 
   // For municipality overview, handle approximated data logic

--- a/src/components/charts/historicEmissions/ChartTooltip.tsx
+++ b/src/components/charts/historicEmissions/ChartTooltip.tsx
@@ -55,6 +55,24 @@ interface ChartTooltipProps {
   showAIIndicators?: boolean;
 }
 
+const NATION_PARIS_TOOLTIP_LAYERS = [
+  {
+    topKey: "territorialFossilCarbonLawTop",
+    valueKey: "territorialFossilCarbonLaw",
+    labelKey: "nation.detailPage.graph.territorialFossilParis",
+  },
+  {
+    topKey: "biogenicCarbonLawTop",
+    valueKey: "biogenicCarbonLaw",
+    labelKey: "nation.detailPage.graph.biogenicParis",
+  },
+  {
+    topKey: "consumptionAbroadCarbonLawTop",
+    valueKey: "consumptionAbroadCarbonLaw",
+    labelKey: "nation.detailPage.graph.consumptionAbroadParis",
+  },
+] as const;
+
 export const ChartTooltip: React.FC<ChartTooltipProps> = ({
   active,
   payload,
@@ -97,7 +115,6 @@ export const ChartTooltip: React.FC<ChartTooltipProps> = ({
       return entry.value != null;
     }
 
-    showUnit = false;
     // For other data, only show if not null and > 0
     return entry.value != null && entry.value > 0;
   });
@@ -122,6 +139,10 @@ export const ChartTooltip: React.FC<ChartTooltipProps> = ({
   }
 
   if (dataView === "nation-overview") {
+    const dataPoint = payload[0]?.payload as
+      | Record<string, number | undefined>
+      | undefined;
+
     const stackKeys = new Set([
       "territorialFossil",
       "biogenic",
@@ -129,17 +150,13 @@ export const ChartTooltip: React.FC<ChartTooltipProps> = ({
       "territorialFossilTrend",
       "biogenicTrend",
       "consumptionAbroadTrend",
-      "territorialFossilCarbonLaw",
-      "biogenicCarbonLaw",
-      "consumptionAbroadCarbonLaw",
     ]);
     filteredPayload = filteredPayload.filter(
       (entry) =>
         entry.dataKey &&
         stackKeys.has(entry.dataKey) &&
         !entry.dataKey.endsWith("TrendTop") &&
-        !entry.dataKey.endsWith("HistoricalTop") &&
-        !entry.dataKey.endsWith("CarbonLawTop"),
+        !entry.dataKey.endsWith("HistoricalTop"),
     );
 
     const hasReported = filteredPayload.some(
@@ -159,6 +176,28 @@ export const ChartTooltip: React.FC<ChartTooltipProps> = ({
           ),
       );
     }
+
+    const parisTooltipEntries: PayloadEntry[] = NATION_PARIS_TOOLTIP_LAYERS.flatMap(
+      (layer) => {
+        const topEntry = payload.find((entry) => entry.dataKey === layer.topKey);
+        const segmentValue = dataPoint?.[layer.valueKey];
+        if (segmentValue == null || !topEntry) {
+          return [];
+        }
+
+        return [
+          {
+            dataKey: layer.valueKey,
+            value: segmentValue,
+            name: t(layer.labelKey),
+            color: topEntry.color,
+            payload: payload[0]?.payload,
+          },
+        ];
+      },
+    );
+
+    filteredPayload = [...filteredPayload, ...parisTooltipEntries];
   }
 
   // For municipality overview, handle approximated data logic

--- a/src/components/charts/historicEmissions/ChartTooltip.tsx
+++ b/src/components/charts/historicEmissions/ChartTooltip.tsx
@@ -171,15 +171,19 @@ export const ChartTooltip: React.FC<ChartTooltipProps> = ({
       filteredPayload = filteredPayload.filter(
         (entry) =>
           !entry.dataKey ||
-          !["territorialFossilTrend", "biogenicTrend", "consumptionAbroadTrend"].includes(
-            entry.dataKey,
-          ),
+          ![
+            "territorialFossilTrend",
+            "biogenicTrend",
+            "consumptionAbroadTrend",
+          ].includes(entry.dataKey),
       );
     }
 
-    const parisTooltipEntries: PayloadEntry[] = NATION_PARIS_TOOLTIP_LAYERS.flatMap(
-      (layer) => {
-        const topEntry = payload.find((entry) => entry.dataKey === layer.topKey);
+    const parisTooltipEntries: PayloadEntry[] =
+      NATION_PARIS_TOOLTIP_LAYERS.flatMap((layer) => {
+        const topEntry = payload.find(
+          (entry) => entry.dataKey === layer.topKey,
+        );
         const segmentValue = dataPoint?.[layer.valueKey];
         if (segmentValue == null || !topEntry) {
           return [];
@@ -194,8 +198,7 @@ export const ChartTooltip: React.FC<ChartTooltipProps> = ({
             payload: payload[0]?.payload,
           },
         ];
-      },
-    );
+      });
 
     filteredPayload = [...filteredPayload, ...parisTooltipEntries];
   }
@@ -351,9 +354,11 @@ export const ChartTooltip: React.FC<ChartTooltipProps> = ({
 
       {dataView === "nation-overview" &&
         filteredPayload.some((entry) =>
-          ["territorialFossilTrend", "biogenicTrend", "consumptionAbroadTrend"].includes(
-            entry.dataKey as string,
-          ),
+          [
+            "territorialFossilTrend",
+            "biogenicTrend",
+            "consumptionAbroadTrend",
+          ].includes(entry.dataKey as string),
         ) && (
           <div className="text-xs text-blue-2 mt-2 col-span-2">
             {t("municipalities.graph.estimatedValue")}

--- a/src/components/charts/historicEmissions/ChartTooltip.tsx
+++ b/src/components/charts/historicEmissions/ChartTooltip.tsx
@@ -87,7 +87,13 @@ export const ChartTooltip: React.FC<ChartTooltipProps> = ({
   // First, filter out zero, undefined, or null values, but keep trend and Paris data
   filteredPayload = payload.filter((entry) => {
     // Keep trend and Paris data even if zero
-    if (entry.dataKey === "approximated" || entry.dataKey === "carbonLaw") {
+    if (
+      entry.dataKey === "approximated" ||
+      entry.dataKey === "carbonLaw" ||
+      entry.dataKey === "territorialFossilCarbonLaw" ||
+      entry.dataKey === "biogenicCarbonLaw" ||
+      entry.dataKey === "consumptionAbroadCarbonLaw"
+    ) {
       return entry.value != null;
     }
 
@@ -120,12 +126,38 @@ export const ChartTooltip: React.FC<ChartTooltipProps> = ({
       "territorialFossil",
       "biogenic",
       "consumptionAbroad",
+      "territorialFossilTrend",
+      "biogenicTrend",
+      "consumptionAbroadTrend",
+      "territorialFossilCarbonLaw",
+      "biogenicCarbonLaw",
+      "consumptionAbroadCarbonLaw",
       "trend",
-      "carbonLaw",
     ]);
     filteredPayload = filteredPayload.filter(
-      (entry) => entry.dataKey && stackKeys.has(entry.dataKey),
+      (entry) =>
+        entry.dataKey &&
+        stackKeys.has(entry.dataKey) &&
+        !entry.dataKey.endsWith("TrendTop"),
     );
+
+    const hasReported = filteredPayload.some(
+      (entry) =>
+        entry.dataKey &&
+        ["territorialFossil", "biogenic", "consumptionAbroad"].includes(
+          entry.dataKey,
+        ) &&
+        entry.value != null,
+    );
+    if (hasReported) {
+      filteredPayload = filteredPayload.filter(
+        (entry) =>
+          !entry.dataKey ||
+          !["territorialFossilTrend", "biogenicTrend", "consumptionAbroadTrend"].includes(
+            entry.dataKey,
+          ),
+      );
+    }
   }
 
   // For municipality overview, handle approximated data logic
@@ -275,6 +307,17 @@ export const ChartTooltip: React.FC<ChartTooltipProps> = ({
               Trend: {trendData.slope >= 0 ? "↗ Increasing" : "↘ Decreasing"}
             </span>
           </span>
+        )}
+
+      {dataView === "nation-overview" &&
+        filteredPayload.some((entry) =>
+          ["territorialFossilTrend", "biogenicTrend", "consumptionAbroadTrend"].includes(
+            entry.dataKey as string,
+          ),
+        ) && (
+          <div className="text-xs text-blue-2 mt-2 col-span-2">
+            {t("municipalities.graph.estimatedValue")}
+          </div>
         )}
 
       {/* Municipality approximated value info */}

--- a/src/components/charts/historicEmissions/ChartTooltip.tsx
+++ b/src/components/charts/historicEmissions/ChartTooltip.tsx
@@ -132,13 +132,13 @@ export const ChartTooltip: React.FC<ChartTooltipProps> = ({
       "territorialFossilCarbonLaw",
       "biogenicCarbonLaw",
       "consumptionAbroadCarbonLaw",
-      "trend",
     ]);
     filteredPayload = filteredPayload.filter(
       (entry) =>
         entry.dataKey &&
         stackKeys.has(entry.dataKey) &&
-        !entry.dataKey.endsWith("TrendTop"),
+        !entry.dataKey.endsWith("TrendTop") &&
+        !entry.dataKey.endsWith("CarbonLawTop"),
     );
 
     const hasReported = filteredPayload.some(

--- a/src/components/charts/historicEmissions/ChartTooltip.tsx
+++ b/src/components/charts/historicEmissions/ChartTooltip.tsx
@@ -40,7 +40,7 @@ interface ChartTooltipProps {
   };
 
   // Municipality-specific props
-  dataView?: "overview" | "sectors";
+  dataView?: "overview" | "sectors" | "nation-overview";
   hiddenSectors?: Set<string>;
 
   // Custom formatting
@@ -112,6 +112,19 @@ export const ChartTooltip: React.FC<ChartTooltipProps> = ({
   if (dataView === "sectors" && hiddenSectors.size > 0) {
     filteredPayload = filteredPayload.filter(
       (entry) => !hiddenSectors.has(entry.dataKey as string),
+    );
+  }
+
+  if (dataView === "nation-overview") {
+    const stackKeys = new Set([
+      "territorialFossil",
+      "biogenic",
+      "consumptionAbroad",
+      "trend",
+      "carbonLaw",
+    ]);
+    filteredPayload = filteredPayload.filter(
+      (entry) => entry.dataKey && stackKeys.has(entry.dataKey),
     );
   }
 

--- a/src/components/territories/TerritoryEmissions.tsx
+++ b/src/components/territories/TerritoryEmissions.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
 import { useTranslation } from "react-i18next";
-import { DataPoint, SectorEmissions } from "@/types/emissions";
+import { DataPoint, NationDataPoint, SectorEmissions } from "@/types/emissions";
 import {
   getDynamicChartHeight,
   useDataView,
@@ -14,14 +14,16 @@ import { TerritoryEmissionsGraph } from "./emissionsGraph/TerritoryEmissionsGrap
 type DataView = "overview" | "sectors";
 
 interface TerritoryEmissionsProps {
-  emissionsData: DataPoint[];
+  emissionsData: DataPoint[] | NationDataPoint[];
   sectorEmissions: SectorEmissions | null;
   className?: string;
+  stackedOverview?: boolean;
 }
 
 export const TerritoryEmissions: FC<TerritoryEmissionsProps> = ({
   emissionsData,
   sectorEmissions,
+  stackedOverview = false,
 }) => {
   const { t } = useTranslation();
 
@@ -63,6 +65,7 @@ export const TerritoryEmissions: FC<TerritoryEmissionsProps> = ({
           dataView={dataView}
           hiddenSectors={hiddenSectors}
           setHiddenSectors={setHiddenSectors}
+          stackedOverview={stackedOverview}
         />
       </div>
     </SectionWithHelp>

--- a/src/components/territories/TerritoryEmissions.tsx
+++ b/src/components/territories/TerritoryEmissions.tsx
@@ -38,31 +38,38 @@ export const TerritoryEmissions: FC<TerritoryEmissionsProps> = ({
     !!sectorEmissions?.sectors &&
     Object.keys(sectorEmissions.sectors).length > 0;
 
-  const dataViewOptions = useMunicipalityViewOptions(hasSectorData);
+  const municipalityViewOptions = useMunicipalityViewOptions(hasSectorData);
+  const dataViewOptions = stackedOverview ? [] : municipalityViewOptions;
+  const activeDataView: DataView = stackedOverview ? "overview" : dataView;
 
   return (
     <SectionWithHelp
       helpItems={[
         "parisAgreementLine",
-        "municipalityImportanceOfEmissionSources",
+        ...(stackedOverview
+          ? []
+          : (["municipalityImportanceOfEmissionSources"] as const)),
       ]}
     >
       <CardHeader
         title={t("detailPage.emissionsDevelopment")}
         unit={t("detailPage.inTons")}
-        dataView={dataView}
-        setDataView={(value) => setDataView(value as "overview" | "sectors")}
-        dataViewOptions={dataViewOptions}
-        dataViewPlaceholder={t("municipalities.graph.selectView")}
+        {...(!stackedOverview && {
+          dataView,
+          setDataView: (value: string) =>
+            setDataView(value as "overview" | "sectors"),
+          dataViewOptions,
+          dataViewPlaceholder: t("municipalities.graph.selectView"),
+        })}
       />
       <div
         className="mt-8"
-        style={{ height: getDynamicChartHeight(dataView, false) }}
+        style={{ height: getDynamicChartHeight(activeDataView, false) }}
       >
         <TerritoryEmissionsGraph
           projectedData={emissionsData}
           sectorEmissions={sectorEmissions || undefined}
-          dataView={dataView}
+          dataView={activeDataView}
           hiddenSectors={hiddenSectors}
           setHiddenSectors={setHiddenSectors}
           stackedOverview={stackedOverview}

--- a/src/components/territories/emissionsGraph/NationOverviewChart.tsx
+++ b/src/components/territories/emissionsGraph/NationOverviewChart.tsx
@@ -36,6 +36,7 @@ const NATION_STACK_CONFIG = [
     dataKey: "territorialFossil" as const,
     historicalTopDataKey: "territorialFossilHistoricalTop" as const,
     trendTopDataKey: "territorialFossilTrendTop" as const,
+    carbonLawDataKey: "territorialFossilCarbonLaw" as const,
     carbonLawTopDataKey: "territorialFossilCarbonLawTop" as const,
     color: "var(--orange-2)",
     translationKey: "nation.detailPage.graph.territorialFossil",
@@ -45,6 +46,7 @@ const NATION_STACK_CONFIG = [
     dataKey: "biogenic" as const,
     historicalTopDataKey: "biogenicHistoricalTop" as const,
     trendTopDataKey: "biogenicTrendTop" as const,
+    carbonLawDataKey: "biogenicCarbonLaw" as const,
     carbonLawTopDataKey: "biogenicCarbonLawTop" as const,
     color: "var(--green-2)",
     translationKey: "nation.detailPage.graph.biogenic",
@@ -54,6 +56,7 @@ const NATION_STACK_CONFIG = [
     dataKey: "consumptionAbroad" as const,
     historicalTopDataKey: "consumptionAbroadHistoricalTop" as const,
     trendTopDataKey: "consumptionAbroadTrendTop" as const,
+    carbonLawDataKey: "consumptionAbroadCarbonLaw" as const,
     carbonLawTopDataKey: "consumptionAbroadCarbonLawTop" as const,
     color: "var(--blue-2)",
     translationKey: "nation.detailPage.graph.consumptionAbroad",
@@ -146,6 +149,21 @@ export const NationOverviewChart: FC<NationOverviewChartProps> = ({
                 fill={layer.color}
                 fillOpacity={0.6}
                 name={t(layer.translationKey)}
+                connectNulls={false}
+              />
+            ))}
+
+            {NATION_STACK_CONFIG.map((layer) => (
+              <Area
+                key={`paris-fill-${layer.carbonLawDataKey}`}
+                type="monotone"
+                dataKey={layer.carbonLawDataKey}
+                stackId="paris"
+                stroke="none"
+                fill={layer.color}
+                fillOpacity={0.4}
+                legendType="none"
+                name={t(layer.parisTranslationKey)}
                 connectNulls={false}
               />
             ))}

--- a/src/components/territories/emissionsGraph/NationOverviewChart.tsx
+++ b/src/components/territories/emissionsGraph/NationOverviewChart.tsx
@@ -16,7 +16,7 @@ import {
   EnhancedLegend,
   ChartYearControls,
   LegendItem,
-  getConsistentLineProps,
+  getLinePropsWithHover,
   getXAxisProps,
   getYAxisProps,
   getCurrentYearReferenceLineProps,
@@ -34,18 +34,27 @@ import { useLanguage } from "@/components/LanguageProvider";
 const NATION_STACK_CONFIG = [
   {
     dataKey: "territorialFossil" as const,
+    trendTopDataKey: "territorialFossilTrendTop" as const,
+    carbonLawDataKey: "territorialFossilCarbonLaw" as const,
     color: "var(--orange-2)",
     translationKey: "nation.detailPage.graph.territorialFossil",
+    parisTranslationKey: "nation.detailPage.graph.territorialFossilParis",
   },
   {
     dataKey: "biogenic" as const,
+    trendTopDataKey: "biogenicTrendTop" as const,
+    carbonLawDataKey: "biogenicCarbonLaw" as const,
     color: "var(--green-2)",
     translationKey: "nation.detailPage.graph.biogenic",
+    parisTranslationKey: "nation.detailPage.graph.biogenicParis",
   },
   {
     dataKey: "consumptionAbroad" as const,
+    trendTopDataKey: "consumptionAbroadTrendTop" as const,
+    carbonLawDataKey: "consumptionAbroadCarbonLaw" as const,
     color: "var(--blue-2)",
     translationKey: "nation.detailPage.graph.consumptionAbroad",
+    parisTranslationKey: "nation.detailPage.graph.consumptionAbroadParis",
   },
 ] as const;
 
@@ -66,26 +75,35 @@ export const NationOverviewChart: FC<NationOverviewChartProps> = ({
   );
 
   const legendItems: LegendItem[] = useMemo(() => {
-    const stackItems: LegendItem[] = NATION_STACK_CONFIG.map((layer) => ({
-      name: t(layer.translationKey),
-      color: layer.color,
-      isClickable: false,
-      isHidden: false,
-      isDashed: false,
-    }));
+    const layerItems: LegendItem[] = NATION_STACK_CONFIG.flatMap((layer) => [
+      {
+        name: t(layer.translationKey),
+        color: layer.color,
+        isClickable: false,
+        isHidden: false,
+        isDashed: false,
+      },
+      {
+        name: t(layer.parisTranslationKey),
+        color: layer.color,
+        isClickable: false,
+        isHidden: false,
+        isDashed: true,
+      },
+    ]);
 
     return [
-      ...stackItems,
+      ...layerItems,
       {
-        name: t("detailPage.graph.trend"),
-        color: "var(--pink-3)",
+        name: t("detailPage.graph.estimated"),
+        color: "var(--grey)",
         isClickable: false,
         isHidden: false,
         isDashed: true,
       },
       {
-        name: t("detailPage.graph.carbonLaw"),
-        color: "var(--green-3)",
+        name: t("detailPage.graph.trend"),
+        color: "var(--pink-3)",
         isClickable: false,
         isHidden: false,
         isDashed: true,
@@ -145,23 +163,45 @@ export const NationOverviewChart: FC<NationOverviewChartProps> = ({
               />
             ))}
 
-            <Line
-              type="monotone"
-              dataKey="trend"
-              {...getConsistentLineProps(
-                "trend",
-                false,
-                t("detailPage.graph.trend"),
-              )}
-            />
+            {NATION_STACK_CONFIG.map((layer) => (
+              <Line
+                key={layer.trendTopDataKey}
+                type="monotone"
+                dataKey={layer.trendTopDataKey}
+                stroke={layer.color}
+                strokeWidth={2}
+                strokeDasharray="5 5"
+                fillOpacity={0}
+                dot={false}
+                name={t("detailPage.graph.estimated")}
+                connectNulls
+              />
+            ))}
+
+            {NATION_STACK_CONFIG.map((layer) => (
+              <Line
+                key={layer.carbonLawDataKey}
+                type="monotone"
+                dataKey={layer.carbonLawDataKey}
+                stackId="paris"
+                {...getLinePropsWithHover(
+                  "secondary",
+                  layer.color,
+                  isMobile,
+                  t(layer.parisTranslationKey),
+                )}
+                connectNulls
+              />
+            ))}
 
             <Line
               type="monotone"
-              dataKey="carbonLaw"
-              {...getConsistentLineProps(
-                "paris",
-                false,
-                t("detailPage.graph.carbonLaw"),
+              dataKey="trend"
+              {...getLinePropsWithHover(
+                "trend",
+                "var(--pink-3)",
+                isMobile,
+                t("detailPage.graph.trend"),
               )}
             />
           </ComposedChart>

--- a/src/components/territories/emissionsGraph/NationOverviewChart.tsx
+++ b/src/components/territories/emissionsGraph/NationOverviewChart.tsx
@@ -155,7 +155,7 @@ export const NationOverviewChart: FC<NationOverviewChartProps> = ({
                 fill={layer.color}
                 fillOpacity={0.6}
                 name={t(layer.translationKey)}
-                connectNulls
+                connectNulls={false}
               />
             ))}
 

--- a/src/components/territories/emissionsGraph/NationOverviewChart.tsx
+++ b/src/components/territories/emissionsGraph/NationOverviewChart.tsx
@@ -16,7 +16,6 @@ import {
   EnhancedLegend,
   ChartYearControls,
   LegendItem,
-  getLinePropsWithHover,
   getXAxisProps,
   getYAxisProps,
   getCurrentYearReferenceLineProps,
@@ -36,31 +35,22 @@ const NATION_STACK_CONFIG = [
     dataKey: "territorialFossil" as const,
     historicalTopDataKey: "territorialFossilHistoricalTop" as const,
     trendTopDataKey: "territorialFossilTrendTop" as const,
-    carbonLawDataKey: "territorialFossilCarbonLaw" as const,
-    carbonLawTopDataKey: "territorialFossilCarbonLawTop" as const,
     color: "var(--orange-2)",
     translationKey: "nation.detailPage.graph.territorialFossil",
-    parisTranslationKey: "nation.detailPage.graph.territorialFossilParis",
   },
   {
     dataKey: "biogenic" as const,
     historicalTopDataKey: "biogenicHistoricalTop" as const,
     trendTopDataKey: "biogenicTrendTop" as const,
-    carbonLawDataKey: "biogenicCarbonLaw" as const,
-    carbonLawTopDataKey: "biogenicCarbonLawTop" as const,
     color: "var(--green-2)",
     translationKey: "nation.detailPage.graph.biogenic",
-    parisTranslationKey: "nation.detailPage.graph.biogenicParis",
   },
   {
     dataKey: "consumptionAbroad" as const,
     historicalTopDataKey: "consumptionAbroadHistoricalTop" as const,
     trendTopDataKey: "consumptionAbroadTrendTop" as const,
-    carbonLawDataKey: "consumptionAbroadCarbonLaw" as const,
-    carbonLawTopDataKey: "consumptionAbroadCarbonLawTop" as const,
     color: "var(--blue-2)",
     translationKey: "nation.detailPage.graph.consumptionAbroad",
-    parisTranslationKey: "nation.detailPage.graph.consumptionAbroadParis",
   },
 ] as const;
 
@@ -81,7 +71,7 @@ export const NationOverviewChart: FC<NationOverviewChartProps> = ({
   );
 
   const legendItems: LegendItem[] = useMemo(() => {
-    const layerItems: LegendItem[] = NATION_STACK_CONFIG.flatMap((layer) => [
+    return NATION_STACK_CONFIG.flatMap((layer) => [
       {
         name: t(layer.translationKey),
         color: layer.color,
@@ -90,15 +80,13 @@ export const NationOverviewChart: FC<NationOverviewChartProps> = ({
         isDashed: false,
       },
       {
-        name: t(layer.parisTranslationKey),
+        name: `${t(layer.translationKey)} (${t("detailPage.graph.trend")})`,
         color: layer.color,
         isClickable: false,
         isHidden: false,
         isDashed: true,
       },
     ]);
-
-    return layerItems;
   }, [t]);
 
   const filteredData = useMemo(() => {
@@ -154,21 +142,6 @@ export const NationOverviewChart: FC<NationOverviewChartProps> = ({
             ))}
 
             {NATION_STACK_CONFIG.map((layer) => (
-              <Area
-                key={`paris-fill-${layer.carbonLawDataKey}`}
-                type="monotone"
-                dataKey={layer.carbonLawDataKey}
-                stackId="paris"
-                stroke="none"
-                fill={layer.color}
-                fillOpacity={0.4}
-                legendType="none"
-                name={t(layer.parisTranslationKey)}
-                connectNulls={false}
-              />
-            ))}
-
-            {NATION_STACK_CONFIG.map((layer) => (
               <Line
                 key={layer.historicalTopDataKey}
                 type="monotone"
@@ -193,23 +166,8 @@ export const NationOverviewChart: FC<NationOverviewChartProps> = ({
                 fillOpacity={0}
                 dot={false}
                 legendType="none"
-                name={t("detailPage.graph.estimated")}
+                name={t("detailPage.graph.trend")}
                 connectNulls={false}
-              />
-            ))}
-
-            {NATION_STACK_CONFIG.map((layer) => (
-              <Line
-                key={layer.carbonLawTopDataKey}
-                type="monotone"
-                dataKey={layer.carbonLawTopDataKey}
-                {...getLinePropsWithHover(
-                  "secondary",
-                  layer.color,
-                  isMobile,
-                  t(layer.parisTranslationKey),
-                )}
-                connectNulls
               />
             ))}
           </ComposedChart>

--- a/src/components/territories/emissionsGraph/NationOverviewChart.tsx
+++ b/src/components/territories/emissionsGraph/NationOverviewChart.tsx
@@ -152,7 +152,7 @@ export const NationOverviewChart: FC<NationOverviewChartProps> = ({
                 fill={layer.color}
                 fillOpacity={0.6}
                 name={t(layer.translationKey)}
-                connectNulls
+                connectNulls={false}
               />
             ))}
 

--- a/src/components/territories/emissionsGraph/NationOverviewChart.tsx
+++ b/src/components/territories/emissionsGraph/NationOverviewChart.tsx
@@ -148,11 +148,11 @@ export const NationOverviewChart: FC<NationOverviewChartProps> = ({
                 type="monotone"
                 dataKey={layer.dataKey}
                 stackId="emissions"
-                stroke={layer.color}
+                stroke="none"
                 fill={layer.color}
                 fillOpacity={0.6}
                 name={t(layer.translationKey)}
-                connectNulls={false}
+                connectNulls
               />
             ))}
 
@@ -167,7 +167,7 @@ export const NationOverviewChart: FC<NationOverviewChartProps> = ({
                 fillOpacity={0}
                 dot={false}
                 name={t("detailPage.graph.estimated")}
-                connectNulls
+                connectNulls={false}
               />
             ))}
 

--- a/src/components/territories/emissionsGraph/NationOverviewChart.tsx
+++ b/src/components/territories/emissionsGraph/NationOverviewChart.tsx
@@ -95,16 +95,7 @@ export const NationOverviewChart: FC<NationOverviewChartProps> = ({
       },
     ]);
 
-    return [
-      ...layerItems,
-      {
-        name: t("detailPage.graph.estimated"),
-        color: "var(--grey)",
-        isClickable: false,
-        isHidden: false,
-        isDashed: true,
-      },
-    ];
+    return layerItems;
   }, [t]);
 
   const filteredData = useMemo(() => {
@@ -183,6 +174,7 @@ export const NationOverviewChart: FC<NationOverviewChartProps> = ({
                 strokeDasharray="5 5"
                 fillOpacity={0}
                 dot={false}
+                legendType="none"
                 name={t("detailPage.graph.estimated")}
                 connectNulls={false}
               />

--- a/src/components/territories/emissionsGraph/NationOverviewChart.tsx
+++ b/src/components/territories/emissionsGraph/NationOverviewChart.tsx
@@ -35,7 +35,7 @@ const NATION_STACK_CONFIG = [
   {
     dataKey: "territorialFossil" as const,
     trendTopDataKey: "territorialFossilTrendTop" as const,
-    carbonLawDataKey: "territorialFossilCarbonLaw" as const,
+    carbonLawTopDataKey: "territorialFossilCarbonLawTop" as const,
     color: "var(--orange-2)",
     translationKey: "nation.detailPage.graph.territorialFossil",
     parisTranslationKey: "nation.detailPage.graph.territorialFossilParis",
@@ -43,7 +43,7 @@ const NATION_STACK_CONFIG = [
   {
     dataKey: "biogenic" as const,
     trendTopDataKey: "biogenicTrendTop" as const,
-    carbonLawDataKey: "biogenicCarbonLaw" as const,
+    carbonLawTopDataKey: "biogenicCarbonLawTop" as const,
     color: "var(--green-2)",
     translationKey: "nation.detailPage.graph.biogenic",
     parisTranslationKey: "nation.detailPage.graph.biogenicParis",
@@ -51,7 +51,7 @@ const NATION_STACK_CONFIG = [
   {
     dataKey: "consumptionAbroad" as const,
     trendTopDataKey: "consumptionAbroadTrendTop" as const,
-    carbonLawDataKey: "consumptionAbroadCarbonLaw" as const,
+    carbonLawTopDataKey: "consumptionAbroadCarbonLawTop" as const,
     color: "var(--blue-2)",
     translationKey: "nation.detailPage.graph.consumptionAbroad",
     parisTranslationKey: "nation.detailPage.graph.consumptionAbroadParis",
@@ -97,13 +97,6 @@ export const NationOverviewChart: FC<NationOverviewChartProps> = ({
       {
         name: t("detailPage.graph.estimated"),
         color: "var(--grey)",
-        isClickable: false,
-        isHidden: false,
-        isDashed: true,
-      },
-      {
-        name: t("detailPage.graph.trend"),
-        color: "var(--pink-3)",
         isClickable: false,
         isHidden: false,
         isDashed: true,
@@ -180,10 +173,9 @@ export const NationOverviewChart: FC<NationOverviewChartProps> = ({
 
             {NATION_STACK_CONFIG.map((layer) => (
               <Line
-                key={layer.carbonLawDataKey}
+                key={layer.carbonLawTopDataKey}
                 type="monotone"
-                dataKey={layer.carbonLawDataKey}
-                stackId="paris"
+                dataKey={layer.carbonLawTopDataKey}
                 {...getLinePropsWithHover(
                   "secondary",
                   layer.color,
@@ -193,17 +185,6 @@ export const NationOverviewChart: FC<NationOverviewChartProps> = ({
                 connectNulls
               />
             ))}
-
-            <Line
-              type="monotone"
-              dataKey="trend"
-              {...getLinePropsWithHover(
-                "trend",
-                "var(--pink-3)",
-                isMobile,
-                t("detailPage.graph.trend"),
-              )}
-            />
           </ComposedChart>
         </ResponsiveContainer>
       </ChartArea>

--- a/src/components/territories/emissionsGraph/NationOverviewChart.tsx
+++ b/src/components/territories/emissionsGraph/NationOverviewChart.tsx
@@ -1,0 +1,180 @@
+import { FC, useState, useMemo } from "react";
+import {
+  ComposedChart,
+  Area,
+  Line,
+  ReferenceLine,
+  Tooltip,
+  ResponsiveContainer,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { useTranslation } from "react-i18next";
+import { NationDataPoint } from "@/types/emissions";
+import { useScreenSize } from "@/hooks/useScreenSize";
+import {
+  EnhancedLegend,
+  ChartYearControls,
+  LegendItem,
+  getConsistentLineProps,
+  getXAxisProps,
+  getYAxisProps,
+  getCurrentYearReferenceLineProps,
+  getChartContainerProps,
+  getComposedChartProps,
+  getResponsiveChartMargin,
+  ChartWrapper,
+  ChartArea,
+  ChartFooter,
+  filterDataByYearRange,
+  ChartTooltip,
+} from "@/components/charts";
+import { useLanguage } from "@/components/LanguageProvider";
+
+const NATION_STACK_CONFIG = [
+  {
+    dataKey: "territorialFossil" as const,
+    color: "var(--orange-2)",
+    translationKey: "nation.detailPage.graph.territorialFossil",
+  },
+  {
+    dataKey: "biogenic" as const,
+    color: "var(--green-2)",
+    translationKey: "nation.detailPage.graph.biogenic",
+  },
+  {
+    dataKey: "consumptionAbroad" as const,
+    color: "var(--blue-2)",
+    translationKey: "nation.detailPage.graph.consumptionAbroad",
+  },
+] as const;
+
+interface NationOverviewChartProps {
+  projectedData: NationDataPoint[];
+}
+
+export const NationOverviewChart: FC<NationOverviewChartProps> = ({
+  projectedData,
+}) => {
+  const { t } = useTranslation();
+  const { currentLanguage } = useLanguage();
+  const { isMobile } = useScreenSize();
+  const currentYear = new Date().getFullYear();
+
+  const [chartEndYear, setChartEndYear] = useState(
+    new Date().getFullYear() + 5,
+  );
+
+  const legendItems: LegendItem[] = useMemo(() => {
+    const stackItems: LegendItem[] = NATION_STACK_CONFIG.map((layer) => ({
+      name: t(layer.translationKey),
+      color: layer.color,
+      isClickable: false,
+      isHidden: false,
+      isDashed: false,
+    }));
+
+    return [
+      ...stackItems,
+      {
+        name: t("detailPage.graph.trend"),
+        color: "var(--pink-3)",
+        isClickable: false,
+        isHidden: false,
+        isDashed: true,
+      },
+      {
+        name: t("detailPage.graph.carbonLaw"),
+        color: "var(--green-3)",
+        isClickable: false,
+        isHidden: false,
+        isDashed: true,
+      },
+    ];
+  }, [t]);
+
+  const filteredData = useMemo(() => {
+    return filterDataByYearRange(projectedData, chartEndYear);
+  }, [projectedData, chartEndYear]);
+
+  return (
+    <ChartWrapper>
+      <ChartArea>
+        <ResponsiveContainer {...getChartContainerProps()}>
+          <ComposedChart
+            {...getComposedChartProps(
+              filteredData,
+              undefined,
+              getResponsiveChartMargin(isMobile),
+            )}
+          >
+            <XAxis
+              {...getXAxisProps(
+                "year",
+                [1990, 2050],
+                [1990, 2015, 2020, currentYear, 2030, 2040, 2050],
+              )}
+              allowDuplicatedCategory
+              tickFormatter={(year) => year}
+            />
+            <YAxis {...getYAxisProps(currentLanguage)} />
+
+            <Tooltip
+              content={
+                <ChartTooltip
+                  dataView="nation-overview"
+                  unit={t("emissionsUnit")}
+                />
+              }
+              wrapperStyle={{ outline: "none", zIndex: 60 }}
+            />
+
+            <ReferenceLine {...getCurrentYearReferenceLineProps(currentYear)} />
+
+            {NATION_STACK_CONFIG.map((layer) => (
+              <Area
+                key={layer.dataKey}
+                type="monotone"
+                dataKey={layer.dataKey}
+                stackId="emissions"
+                stroke={layer.color}
+                fill={layer.color}
+                fillOpacity={0.6}
+                name={t(layer.translationKey)}
+                connectNulls
+              />
+            ))}
+
+            <Line
+              type="monotone"
+              dataKey="trend"
+              {...getConsistentLineProps(
+                "trend",
+                false,
+                t("detailPage.graph.trend"),
+              )}
+            />
+
+            <Line
+              type="monotone"
+              dataKey="carbonLaw"
+              {...getConsistentLineProps(
+                "paris",
+                false,
+                t("detailPage.graph.carbonLaw"),
+              )}
+            />
+          </ComposedChart>
+        </ResponsiveContainer>
+      </ChartArea>
+
+      <ChartFooter>
+        <EnhancedLegend items={legendItems} />
+        <ChartYearControls
+          chartEndYear={chartEndYear}
+          setChartEndYear={setChartEndYear}
+        />
+      </ChartFooter>
+    </ChartWrapper>
+  );
+};

--- a/src/components/territories/emissionsGraph/NationOverviewChart.tsx
+++ b/src/components/territories/emissionsGraph/NationOverviewChart.tsx
@@ -34,6 +34,7 @@ import { useLanguage } from "@/components/LanguageProvider";
 const NATION_STACK_CONFIG = [
   {
     dataKey: "territorialFossil" as const,
+    historicalTopDataKey: "territorialFossilHistoricalTop" as const,
     trendTopDataKey: "territorialFossilTrendTop" as const,
     carbonLawTopDataKey: "territorialFossilCarbonLawTop" as const,
     color: "var(--orange-2)",
@@ -42,6 +43,7 @@ const NATION_STACK_CONFIG = [
   },
   {
     dataKey: "biogenic" as const,
+    historicalTopDataKey: "biogenicHistoricalTop" as const,
     trendTopDataKey: "biogenicTrendTop" as const,
     carbonLawTopDataKey: "biogenicCarbonLawTop" as const,
     color: "var(--green-2)",
@@ -50,6 +52,7 @@ const NATION_STACK_CONFIG = [
   },
   {
     dataKey: "consumptionAbroad" as const,
+    historicalTopDataKey: "consumptionAbroadHistoricalTop" as const,
     trendTopDataKey: "consumptionAbroadTrendTop" as const,
     carbonLawTopDataKey: "consumptionAbroadCarbonLawTop" as const,
     color: "var(--blue-2)",
@@ -153,6 +156,20 @@ export const NationOverviewChart: FC<NationOverviewChartProps> = ({
                 fillOpacity={0.6}
                 name={t(layer.translationKey)}
                 connectNulls
+              />
+            ))}
+
+            {NATION_STACK_CONFIG.map((layer) => (
+              <Line
+                key={layer.historicalTopDataKey}
+                type="monotone"
+                dataKey={layer.historicalTopDataKey}
+                stroke={layer.color}
+                strokeWidth={2}
+                fillOpacity={0}
+                dot={false}
+                name={t(layer.translationKey)}
+                connectNulls={false}
               />
             ))}
 

--- a/src/components/territories/emissionsGraph/TerritoryEmissionsGraph.tsx
+++ b/src/components/territories/emissionsGraph/TerritoryEmissionsGraph.tsx
@@ -1,17 +1,19 @@
 import { FC } from "react";
 import { useTranslation } from "react-i18next";
-import { DataPoint, SectorEmissions } from "@/types/emissions";
+import { DataPoint, NationDataPoint, SectorEmissions } from "@/types/emissions";
 import { OverviewChart } from "@/components/territories/emissionsGraph/OverviewChart";
+import { NationOverviewChart } from "@/components/territories/emissionsGraph/NationOverviewChart";
 import { SectorsChart } from "@/components/territories/emissionsGraph/SectorsChart";
 
 type DataView = "overview" | "sectors";
 
 interface TerritoryEmissionsGraphProps {
-  projectedData: DataPoint[];
+  projectedData: DataPoint[] | NationDataPoint[];
   sectorEmissions?: SectorEmissions;
   dataView: DataView;
   hiddenSectors: Set<string>;
   setHiddenSectors: (sectors: Set<string>) => void;
+  stackedOverview?: boolean;
 }
 
 export const TerritoryEmissionsGraph: FC<TerritoryEmissionsGraphProps> = ({
@@ -20,6 +22,7 @@ export const TerritoryEmissionsGraph: FC<TerritoryEmissionsGraphProps> = ({
   dataView,
   hiddenSectors,
   setHiddenSectors,
+  stackedOverview = false,
 }) => {
   const { t } = useTranslation();
 
@@ -30,7 +33,13 @@ export const TerritoryEmissionsGraph: FC<TerritoryEmissionsGraphProps> = ({
   return (
     <div className="h-full">
       {dataView === "overview" ? (
-        <OverviewChart projectedData={projectedData} />
+        stackedOverview ? (
+          <NationOverviewChart
+            projectedData={projectedData as NationDataPoint[]}
+          />
+        ) : (
+          <OverviewChart projectedData={projectedData as DataPoint[]} />
+        )
       ) : (
         <SectorsChart
           sectorEmissions={sectorEmissions || null}

--- a/src/hooks/nation/useNationDetails.ts
+++ b/src/hooks/nation/useNationDetails.ts
@@ -83,10 +83,36 @@ function normalizeCountry(country: ApiNationResponse["country"]): {
   return { sv: country.sv, en: country.en };
 }
 
+function warnIfNationLayerFieldsMissing(r: ApiNationResponse): void {
+  if (!import.meta.env.DEV) return;
+
+  const missing: string[] = [];
+  if (!r.territorialFossilEmissions?.length) {
+    missing.push("territorialFossilEmissions");
+  }
+  if (!r.biogenicEmissions?.length) {
+    missing.push("biogenicEmissions");
+  }
+  if (!r.consumptionAbroadEmissions?.length) {
+    missing.push("consumptionAbroadEmissions");
+  }
+
+  if (missing.length === 0) return;
+
+  console.warn(
+    `[nation] Stacked chart needs per-layer API fields (${missing.join(", ")}). ` +
+      `Received only: ${Object.keys(r).join(", ")}. ` +
+      `Use VITE_API_PROXY=http://localhost:3000/ with GARBO_PROXY_CLIENT_API_KEY, ` +
+      `and ensure Garbo NationDataSchema + nation-data.json expose the layer fields.`,
+  );
+}
+
 function transformApiNationToNationDetails(
   r: ApiNationResponse,
   currentYear: number,
 ): NationDetails {
+  warnIfNationLayerFieldsMissing(r);
+
   const territorialFossil = extractEmissionsRecord(
     r.territorialFossilEmissions ?? r.emissions,
   );

--- a/src/hooks/nation/useNationDetails.ts
+++ b/src/hooks/nation/useNationDetails.ts
@@ -12,12 +12,19 @@ import {
   calculateParisValue,
   CARBON_LAW_REDUCTION_RATE,
 } from "@/utils/calculations/emissionsCalculations";
+import { sumNationEmissionRecords } from "@/utils/data/nationTransforms";
 import type { SupportedLanguage } from "@/lib/languageDetection";
 
 export type NationDetails = {
   country: { sv: string; en: string };
   logoUrl: string | null;
   emissions: Record<string, number>;
+  territorialFossil: Record<string, number>;
+  biogenic: Record<string, number>;
+  consumptionAbroad: Record<string, number>;
+  approximatedTerritorialFossil: Record<string, number>;
+  approximatedBiogenic: Record<string, number>;
+  approximatedConsumptionAbroad: Record<string, number>;
   approximatedHistoricalEmission: Record<string, number>;
   trend: Record<string, number>;
   carbonLaw: Record<string, number>;
@@ -25,20 +32,28 @@ export type NationDetails = {
   historicalEmissionChangePercent: number;
 };
 
+type EmissionSeries = ({ year: string; value: number } | null)[] | undefined;
+
 type ApiNationResponse = {
-  country: { sv: string; en: string };
+  country: { sv: string; en: string } | string;
   logoUrl?: string | null;
-  emissions: ({ year: string; value: number } | null)[];
+  territorialFossilEmissions?: EmissionSeries;
+  biogenicEmissions?: EmissionSeries;
+  consumptionAbroadEmissions?: EmissionSeries;
+  approximatedTerritorialFossilEmissions?: EmissionSeries;
+  approximatedBiogenicEmissions?: EmissionSeries;
+  approximatedConsumptionAbroadEmissions?: EmissionSeries;
+  emissions?: EmissionSeries;
   totalTrend: number;
   totalCarbonLaw: number;
-  approximatedHistoricalEmission: ({ year: string; value: number } | null)[];
-  trend: ({ year: string; value: number } | null)[];
+  approximatedHistoricalEmission: EmissionSeries;
+  trend: EmissionSeries;
   historicalEmissionChangePercent: number;
   meetsParis: boolean;
 };
 
 function extractEmissionsRecord(
-  emissions: ({ year: string; value: number } | null)[] | undefined,
+  emissions: EmissionSeries,
 ): Record<string, number> {
   const record: Record<string, number> = {};
   if (emissions) {
@@ -56,10 +71,17 @@ function extractEmissionsRecord(
   return record;
 }
 
+function normalizeCountry(
+  country: ApiNationResponse["country"],
+): { sv: string; en: string } {
+  if (typeof country === "string") {
+    return { sv: country, en: country };
+  }
+  return { sv: country.sv, en: country.en };
+}
+
 function calculateCarbonLawRecord(
-  approximatedHistoricalEmission:
-    | ({ year: string; value: number } | null)[]
-    | undefined,
+  approximatedHistoricalEmission: EmissionSeries,
   currentYear: number,
 ): Record<string, number> {
   const carbonLawRecord: Record<string, number> = {};
@@ -92,10 +114,37 @@ function transformApiNationToNationDetails(
   r: ApiNationResponse,
   currentYear: number,
 ): NationDetails {
+  const territorialFossil = extractEmissionsRecord(
+    r.territorialFossilEmissions ?? r.emissions,
+  );
+  const biogenic = extractEmissionsRecord(r.biogenicEmissions);
+  const consumptionAbroad = extractEmissionsRecord(
+    r.consumptionAbroadEmissions,
+  );
+  const approximatedTerritorialFossil = extractEmissionsRecord(
+    r.approximatedTerritorialFossilEmissions,
+  );
+  const approximatedBiogenic = extractEmissionsRecord(
+    r.approximatedBiogenicEmissions,
+  );
+  const approximatedConsumptionAbroad = extractEmissionsRecord(
+    r.approximatedConsumptionAbroadEmissions,
+  );
+
   return {
-    country: { sv: r.country.sv, en: r.country.en },
+    country: normalizeCountry(r.country),
     logoUrl: r.logoUrl ?? null,
-    emissions: extractEmissionsRecord(r.emissions),
+    territorialFossil,
+    biogenic,
+    consumptionAbroad,
+    approximatedTerritorialFossil,
+    approximatedBiogenic,
+    approximatedConsumptionAbroad,
+    emissions: sumNationEmissionRecords(
+      territorialFossil,
+      biogenic,
+      consumptionAbroad,
+    ),
     approximatedHistoricalEmission: extractEmissionsRecord(
       r.approximatedHistoricalEmission,
     ),
@@ -197,6 +246,11 @@ export function useNationDetailHeaderStats(
     return [];
   }
 
+  const lastYearEmissions = nation.emissions[lastYear];
+  if (lastYearEmissions === undefined) {
+    return [];
+  }
+
   return [
     createMeetsParisStat(nation.meetsParis, t),
     createChangeSince2015Stat(
@@ -205,7 +259,7 @@ export function useNationDetailHeaderStats(
       t,
     ),
     createTotalEmissionsStat(
-      nation.emissions[lastYear],
+      lastYearEmissions,
       lastYear,
       currentLanguage,
       t,

--- a/src/hooks/nation/useNationDetails.ts
+++ b/src/hooks/nation/useNationDetails.ts
@@ -10,7 +10,6 @@ import { DetailStat } from "@/components/detail/DetailHeader";
 import { getNationDetails } from "@/lib/api";
 import {
   calculateCarbonLawFromApproximatedRecord,
-  calculateCarbonLawFromReportedRecord,
   sumNationEmissionRecords,
 } from "@/utils/data/nationTransforms";
 import type { SupportedLanguage } from "@/lib/languageDetection";
@@ -127,11 +126,18 @@ function transformApiNationToNationDetails(
       extractEmissionsRecord(r.approximatedHistoricalEmission),
       currentYear,
     ),
-    territorialFossilCarbonLaw:
-      calculateCarbonLawFromReportedRecord(territorialFossil),
-    biogenicCarbonLaw: calculateCarbonLawFromReportedRecord(biogenic),
-    consumptionAbroadCarbonLaw:
-      calculateCarbonLawFromReportedRecord(consumptionAbroad),
+    territorialFossilCarbonLaw: calculateCarbonLawFromApproximatedRecord(
+      approximatedTerritorialFossil,
+      currentYear,
+    ),
+    biogenicCarbonLaw: calculateCarbonLawFromApproximatedRecord(
+      approximatedBiogenic,
+      currentYear,
+    ),
+    consumptionAbroadCarbonLaw: calculateCarbonLawFromApproximatedRecord(
+      approximatedConsumptionAbroad,
+      currentYear,
+    ),
     meetsParis: r.meetsParis ?? false,
     historicalEmissionChangePercent: r.historicalEmissionChangePercent ?? 0,
   };

--- a/src/hooks/nation/useNationDetails.ts
+++ b/src/hooks/nation/useNationDetails.ts
@@ -9,10 +9,10 @@ import { useLanguage } from "@/components/LanguageProvider";
 import { DetailStat } from "@/components/detail/DetailHeader";
 import { getNationDetails } from "@/lib/api";
 import {
-  calculateParisValue,
-  CARBON_LAW_REDUCTION_RATE,
-} from "@/utils/calculations/emissionsCalculations";
-import { sumNationEmissionRecords } from "@/utils/data/nationTransforms";
+  calculateCarbonLawFromApproximatedRecord,
+  calculateCarbonLawFromReportedRecord,
+  sumNationEmissionRecords,
+} from "@/utils/data/nationTransforms";
 import type { SupportedLanguage } from "@/lib/languageDetection";
 
 export type NationDetails = {
@@ -28,6 +28,9 @@ export type NationDetails = {
   approximatedHistoricalEmission: Record<string, number>;
   trend: Record<string, number>;
   carbonLaw: Record<string, number>;
+  territorialFossilCarbonLaw: Record<string, number>;
+  biogenicCarbonLaw: Record<string, number>;
+  consumptionAbroadCarbonLaw: Record<string, number>;
   meetsParis: boolean;
   historicalEmissionChangePercent: number;
 };
@@ -71,43 +74,14 @@ function extractEmissionsRecord(
   return record;
 }
 
-function normalizeCountry(
-  country: ApiNationResponse["country"],
-): { sv: string; en: string } {
+function normalizeCountry(country: ApiNationResponse["country"]): {
+  sv: string;
+  en: string;
+} {
   if (typeof country === "string") {
     return { sv: country, en: country };
   }
   return { sv: country.sv, en: country.en };
-}
-
-function calculateCarbonLawRecord(
-  approximatedHistoricalEmission: EmissionSeries,
-  currentYear: number,
-): Record<string, number> {
-  const carbonLawRecord: Record<string, number> = {};
-  if (!approximatedHistoricalEmission) return carbonLawRecord;
-
-  const approximatedDataAtCurrentYear = approximatedHistoricalEmission
-    .filter((d) => d && parseInt(d.year) <= currentYear)
-    .sort((a, b) => parseInt(b!.year) - parseInt(a!.year))[0];
-
-  if (approximatedDataAtCurrentYear) {
-    const carbonLawBaseValue = approximatedDataAtCurrentYear.value;
-    const carbonLawBaseYear = parseInt(approximatedDataAtCurrentYear.year);
-
-    for (let year = currentYear; year <= 2050; year++) {
-      const carbonLawValue = calculateParisValue(
-        year,
-        carbonLawBaseYear,
-        carbonLawBaseValue,
-        CARBON_LAW_REDUCTION_RATE,
-      );
-      if (carbonLawValue !== null) {
-        carbonLawRecord[year.toString()] = carbonLawValue;
-      }
-    }
-  }
-  return carbonLawRecord;
 }
 
 function transformApiNationToNationDetails(
@@ -149,10 +123,15 @@ function transformApiNationToNationDetails(
       r.approximatedHistoricalEmission,
     ),
     trend: extractEmissionsRecord(r.trend),
-    carbonLaw: calculateCarbonLawRecord(
-      r.approximatedHistoricalEmission,
+    carbonLaw: calculateCarbonLawFromApproximatedRecord(
+      extractEmissionsRecord(r.approximatedHistoricalEmission),
       currentYear,
     ),
+    territorialFossilCarbonLaw:
+      calculateCarbonLawFromReportedRecord(territorialFossil),
+    biogenicCarbonLaw: calculateCarbonLawFromReportedRecord(biogenic),
+    consumptionAbroadCarbonLaw:
+      calculateCarbonLawFromReportedRecord(consumptionAbroad),
     meetsParis: r.meetsParis ?? false,
     historicalEmissionChangePercent: r.historicalEmissionChangePercent ?? 0,
   };
@@ -258,11 +237,6 @@ export function useNationDetailHeaderStats(
       currentLanguage,
       t,
     ),
-    createTotalEmissionsStat(
-      lastYearEmissions,
-      lastYear,
-      currentLanguage,
-      t,
-    ),
+    createTotalEmissionsStat(lastYearEmissions, lastYear, currentLanguage, t),
   ];
 }

--- a/src/hooks/nation/useNationPageData.ts
+++ b/src/hooks/nation/useNationPageData.ts
@@ -3,20 +3,12 @@ import {
   useNationDetails,
   useNationDetailHeaderStats,
 } from "@/hooks/nation/useNationDetails";
-import { useSectorEmissions } from "@/hooks/territories/useSectorEmissions";
-import { useSectors } from "@/hooks/territories/useSectors";
-import { useHiddenItems } from "@/components/charts";
-import { useSectorYearSelection } from "@/hooks/territories/useSectorYearSelection";
 import { useRegions } from "@/hooks/useRegions";
 import { transformNationEmissionsData } from "@/utils/data/nationTransforms";
 
 export function useNationPageData() {
   const { nation, loading, error } = useNationDetails();
   const { regions } = useRegions();
-  const { sectorEmissions } = useSectorEmissions("nation", undefined);
-  const { getSectorInfo } = useSectors();
-  const { hiddenItems: filteredSectors, setHiddenItems: setFilteredSectors } =
-    useHiddenItems<string>([]);
   const sortedRegions = useMemo(() => [...regions].sort(), [regions]);
   const calendarYear = new Date().getFullYear();
   const emissionsData = useMemo(
@@ -33,23 +25,12 @@ export function useNationPageData() {
   const lastYear = lastYearEmissions?.year;
   const headerStats = useNationDetailHeaderStats(nation, lastYear);
 
-  const { selectedYear, setSelectedYear, availableYears, currentYear } =
-    useSectorYearSelection(sectorEmissions, lastYear ?? 2023);
-
   return {
     nation,
     loading,
     error,
     sortedRegions,
     emissionsData,
-    sectorEmissions,
-    getSectorInfo,
-    filteredSectors,
-    setFilteredSectors,
-    selectedYear,
-    setSelectedYear,
     headerStats,
-    availableYears,
-    currentYear,
   };
 }

--- a/src/hooks/nation/useNationPageData.ts
+++ b/src/hooks/nation/useNationPageData.ts
@@ -12,8 +12,7 @@ export function useNationPageData() {
   const sortedRegions = useMemo(() => [...regions].sort(), [regions]);
   const calendarYear = new Date().getFullYear();
   const emissionsData = useMemo(
-    () =>
-      nation ? transformNationEmissionsData(nation, calendarYear) : [],
+    () => (nation ? transformNationEmissionsData(nation, calendarYear) : []),
     [nation, calendarYear],
   );
 

--- a/src/hooks/nation/useNationPageData.ts
+++ b/src/hooks/nation/useNationPageData.ts
@@ -18,9 +18,11 @@ export function useNationPageData() {
   const { hiddenItems: filteredSectors, setHiddenItems: setFilteredSectors } =
     useHiddenItems<string>([]);
   const sortedRegions = useMemo(() => [...regions].sort(), [regions]);
+  const calendarYear = new Date().getFullYear();
   const emissionsData = useMemo(
-    () => (nation ? transformNationEmissionsData(nation) : []),
-    [nation],
+    () =>
+      nation ? transformNationEmissionsData(nation, calendarYear) : [],
+    [nation, calendarYear],
   );
 
   const lastYearEmissions = useMemo(() => {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1458,7 +1458,10 @@
       "graph": {
         "territorialFossil": "Territorial fossil emissions",
         "biogenic": "Biogenic emissions",
-        "consumptionAbroad": "Consumption emissions abroad"
+        "consumptionAbroad": "Consumption emissions abroad",
+        "territorialFossilParis": "Territorial fossil – Paris Agreement",
+        "biogenicParis": "Biogenic – Paris Agreement",
+        "consumptionAbroadParis": "Consumption abroad – Paris Agreement"
       }
     }
   },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1454,7 +1454,12 @@
   },
   "nation": {
     "detailPage": {
-      "regions": "Regions"
+      "regions": "Regions",
+      "graph": {
+        "territorialFossil": "Territorial fossil emissions",
+        "biogenic": "Biogenic emissions",
+        "consumptionAbroad": "Consumption emissions abroad"
+      }
     }
   },
   "regions": {

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -1515,7 +1515,10 @@
       "graph": {
         "territorialFossil": "Territoriella fossila utsläpp",
         "biogenic": "Biogena utsläpp",
-        "consumptionAbroad": "Konsumtionsutsläpp utomlands"
+        "consumptionAbroad": "Konsumtionsutsläpp utomlands",
+        "territorialFossilParis": "Territoriella fossila – Parisavtalet",
+        "biogenicParis": "Biogena – Parisavtalet",
+        "consumptionAbroadParis": "Konsumtion utomlands – Parisavtalet"
       }
     }
   },

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -1511,7 +1511,12 @@
   },
   "nation": {
     "detailPage": {
-      "regions": "Län"
+      "regions": "Län",
+      "graph": {
+        "territorialFossil": "Territoriella fossila utsläpp",
+        "biogenic": "Biogena utsläpp",
+        "consumptionAbroad": "Konsumtionsutsläpp utomlands"
+      }
     }
   },
   "regions": {

--- a/src/pages/NationDetailPage.tsx
+++ b/src/pages/NationDetailPage.tsx
@@ -4,7 +4,6 @@ import { PageError } from "@/components/pageStates/Error";
 import { PageNoData } from "@/components/pageStates/NoData";
 import { DetailHeader } from "@/components/detail/DetailHeader";
 import { DetailWrapper } from "@/components/detail/DetailWrapper";
-import { SectorEmissionsChart } from "@/components/charts/sectorChart/SectorEmissions";
 import { EntityListBox } from "@/components/detail/EntityListBox";
 import { useNationPageData } from "@/hooks/nation/useNationPageData";
 import { useLanguage } from "@/components/LanguageProvider";
@@ -13,15 +12,7 @@ function NationDetailContent({
   nation,
   sortedRegions,
   emissionsData,
-  sectorEmissions,
-  getSectorInfo,
-  filteredSectors,
-  setFilteredSectors,
-  selectedYear,
-  setSelectedYear,
   headerStats,
-  availableYears,
-  currentYear,
 }: ReturnType<typeof useNationPageData>) {
   const { currentLanguage } = useLanguage();
   if (!nation) return <PageNoData />;
@@ -37,19 +28,8 @@ function NationDetailContent({
       />
       <TerritoryEmissions
         emissionsData={emissionsData}
-        sectorEmissions={sectorEmissions}
+        sectorEmissions={null}
         stackedOverview
-      />
-      <SectorEmissionsChart
-        sectorEmissions={sectorEmissions}
-        availableYears={availableYears}
-        selectedYear={selectedYear}
-        onYearChange={setSelectedYear}
-        currentYear={currentYear}
-        getSectorInfo={getSectorInfo}
-        filteredSectors={filteredSectors}
-        onFilteredSectorsChange={setFilteredSectors}
-        helpItems={["municipalityAndRegionEmissionSources"]}
       />
       <EntityListBox
         items={sortedRegions}

--- a/src/pages/NationDetailPage.tsx
+++ b/src/pages/NationDetailPage.tsx
@@ -38,6 +38,7 @@ function NationDetailContent({
       <TerritoryEmissions
         emissionsData={emissionsData}
         sectorEmissions={sectorEmissions}
+        stackedOverview
       />
       <SectorEmissionsChart
         sectorEmissions={sectorEmissions}

--- a/src/types/emissions.ts
+++ b/src/types/emissions.ts
@@ -58,4 +58,15 @@ export type NationDataPoint = DataPoint & {
   territorialFossil?: number;
   biogenic?: number;
   consumptionAbroad?: number;
+  /** Dashed trend segment from latest reported year toward current year */
+  territorialFossilTrend?: number;
+  biogenicTrend?: number;
+  consumptionAbroadTrend?: number;
+  /** Cumulative stack height at each layer top (for dashed line Y positions) */
+  territorialFossilTrendTop?: number;
+  biogenicTrendTop?: number;
+  consumptionAbroadTrendTop?: number;
+  territorialFossilCarbonLaw?: number;
+  biogenicCarbonLaw?: number;
+  consumptionAbroadCarbonLaw?: number;
 };

--- a/src/types/emissions.ts
+++ b/src/types/emissions.ts
@@ -69,4 +69,8 @@ export type NationDataPoint = DataPoint & {
   territorialFossilCarbonLaw?: number;
   biogenicCarbonLaw?: number;
   consumptionAbroadCarbonLaw?: number;
+  /** Cumulative stack height for Paris path lines */
+  territorialFossilCarbonLawTop?: number;
+  biogenicCarbonLawTop?: number;
+  consumptionAbroadCarbonLawTop?: number;
 };

--- a/src/types/emissions.ts
+++ b/src/types/emissions.ts
@@ -58,7 +58,7 @@ export type NationDataPoint = DataPoint & {
   territorialFossil?: number;
   biogenic?: number;
   consumptionAbroad?: number;
-  /** Dashed trend segment from latest reported year toward current year */
+  /** Per-layer trend segment from 2015 (linear fit, then approximated where available) */
   territorialFossilTrend?: number;
   biogenicTrend?: number;
   consumptionAbroadTrend?: number;

--- a/src/types/emissions.ts
+++ b/src/types/emissions.ts
@@ -52,3 +52,10 @@ export type DataPoint = {
   approximated: number | undefined;
   carbonLaw: number | undefined;
 };
+
+// Nation emissions data point with stacked emission categories
+export type NationDataPoint = DataPoint & {
+  territorialFossil?: number;
+  biogenic?: number;
+  consumptionAbroad?: number;
+};

--- a/src/types/emissions.ts
+++ b/src/types/emissions.ts
@@ -62,7 +62,11 @@ export type NationDataPoint = DataPoint & {
   territorialFossilTrend?: number;
   biogenicTrend?: number;
   consumptionAbroadTrend?: number;
-  /** Cumulative stack height at each layer top (for dashed line Y positions) */
+  /** Cumulative stack height at each layer top (solid lines on historical years) */
+  territorialFossilHistoricalTop?: number;
+  biogenicHistoricalTop?: number;
+  consumptionAbroadHistoricalTop?: number;
+  /** Cumulative stack height at each layer top (dashed lines on approximated years) */
   territorialFossilTrendTop?: number;
   biogenicTrendTop?: number;
   consumptionAbroadTrendTop?: number;

--- a/src/utils/data/nationTransforms.ts
+++ b/src/utils/data/nationTransforms.ts
@@ -278,6 +278,25 @@ export function transformNationEmissionsData(
         ),
       );
 
+      let territorialFossilHistoricalTop: number | undefined;
+      let biogenicHistoricalTop: number | undefined;
+      let consumptionAbroadHistoricalTop: number | undefined;
+
+      if (
+        stackAnchorYear !== null &&
+        yearNum <= stackAnchorYear &&
+        territorialFossil !== undefined
+      ) {
+        const historicalTops = getCumulativeLayerTops(
+          territorialFossil,
+          biogenic,
+          consumptionAbroad,
+        );
+        territorialFossilHistoricalTop = historicalTops.bottomTop;
+        biogenicHistoricalTop = historicalTops.middleTop;
+        consumptionAbroadHistoricalTop = historicalTops.topTop;
+      }
+
       let territorialFossilTrend: number | undefined;
       let biogenicTrend: number | undefined;
       let consumptionAbroadTrend: number | undefined;
@@ -406,6 +425,9 @@ export function transformNationEmissionsData(
         territorialFossilTrend,
         biogenicTrend,
         consumptionAbroadTrend,
+        territorialFossilHistoricalTop,
+        biogenicHistoricalTop,
+        consumptionAbroadHistoricalTop,
         territorialFossilTrendTop,
         biogenicTrendTop,
         consumptionAbroadTrendTop,

--- a/src/utils/data/nationTransforms.ts
+++ b/src/utils/data/nationTransforms.ts
@@ -70,65 +70,35 @@ export function calculateCarbonLawFromApproximatedRecord(
   return carbonLawRecord;
 }
 
-/** Paris path per layer, anchored at the latest reported (historical) value for that layer. */
-export function calculateCarbonLawFromReportedRecord(
-  reported: Record<string, number>,
-): Record<string, number> {
-  const carbonLawRecord: Record<string, number> = {};
-
-  const baseEntry = Object.entries(reported)
-    .filter(([year]) => !isNaN(Number(year)))
-    .sort(([yearA], [yearB]) => Number(yearB) - Number(yearA))[0];
-
-  if (!baseEntry) return carbonLawRecord;
-
-  const [baseYearStr, carbonLawBaseValue] = baseEntry;
-  const carbonLawBaseYear = Number(baseYearStr);
-
-  for (let year = carbonLawBaseYear; year <= EMISSIONS_DATA_END_YEAR; year++) {
-    const carbonLawValue = calculateParisValue(
-      year,
-      carbonLawBaseYear,
-      carbonLawBaseValue,
-      CARBON_LAW_REDUCTION_RATE,
-    );
-    if (carbonLawValue !== null) {
-      carbonLawRecord[year.toString()] = carbonLawValue;
-    }
-  }
-
-  return carbonLawRecord;
-}
-
-function getLatestReportedYear(
-  reported: Record<string, number>,
-): number | null {
-  const years = Object.keys(reported)
-    .map(Number)
-    .filter((year) => !isNaN(year));
-  if (years.length === 0) return null;
-  return Math.max(...years);
-}
-
 function getLayerParisValueKg(
   reported: Record<string, number>,
+  approximated: Record<string, number> | undefined,
+  stackAnchorYear: number,
   year: number,
+  currentYear: number,
 ): number | undefined {
-  const anchorYear = getLatestReportedYear(reported);
-  if (anchorYear === null || year < anchorYear) return undefined;
+  if (year < currentYear || year > EMISSIONS_DATA_END_YEAR) {
+    return undefined;
+  }
 
-  const anchorValueKg = reported[anchorYear.toString()];
-  if (anchorValueKg === undefined) return undefined;
+  const baseValueKg = getLayerTrendValueKg(
+    reported,
+    approximated,
+    currentYear,
+    stackAnchorYear,
+    currentYear,
+  );
+  if (baseValueKg === undefined) return undefined;
 
-  if (year === anchorYear) {
-    return anchorValueKg;
+  if (year === currentYear) {
+    return baseValueKg;
   }
 
   return (
     calculateParisValue(
       year,
-      anchorYear,
-      anchorValueKg,
+      currentYear,
+      baseValueKg,
       CARBON_LAW_REDUCTION_RATE,
     ) ?? undefined
   );
@@ -175,33 +145,23 @@ function getLayerTrendValueKg(
   return approximated?.[year.toString()];
 }
 
-function getCumulativeTrendTops(
-  territorialFossilTrend?: number,
-  biogenicTrend?: number,
-  consumptionAbroadTrend?: number,
+function getCumulativeLayerTops(
+  bottom?: number,
+  middle?: number,
+  top?: number,
 ): {
-  territorialFossilTrendTop?: number;
-  biogenicTrendTop?: number;
-  consumptionAbroadTrendTop?: number;
+  bottomTop?: number;
+  middleTop?: number;
+  topTop?: number;
 } {
-  if (territorialFossilTrend === undefined) {
+  if (bottom === undefined) {
     return {};
   }
 
-  const biogenicTrendTop = sumDefined(
-    territorialFossilTrend,
-    biogenicTrend,
-  );
-  const consumptionAbroadTrendTop = sumDefined(
-    territorialFossilTrend,
-    biogenicTrend,
-    consumptionAbroadTrend,
-  );
-
   return {
-    territorialFossilTrendTop: territorialFossilTrend,
-    biogenicTrendTop,
-    consumptionAbroadTrendTop,
+    bottomTop: bottom,
+    middleTop: sumDefined(bottom, middle),
+    topTop: sumDefined(bottom, middle, top),
   };
 }
 
@@ -283,14 +243,14 @@ export function transformNationEmissionsData(
 
       if (stackAnchorYear !== null) {
         if (yearNum === stackAnchorYear - 1) {
-          const bridgeTops = getCumulativeTrendTops(
+          const bridgeTops = getCumulativeLayerTops(
             territorialFossil,
             biogenic,
             consumptionAbroad,
           );
-          territorialFossilTrendTop = bridgeTops.territorialFossilTrendTop;
-          biogenicTrendTop = bridgeTops.biogenicTrendTop;
-          consumptionAbroadTrendTop = bridgeTops.consumptionAbroadTrendTop;
+          territorialFossilTrendTop = bridgeTops.bottomTop;
+          biogenicTrendTop = bridgeTops.middleTop;
+          consumptionAbroadTrendTop = bridgeTops.topTop;
         } else if (yearNum >= stackAnchorYear && yearNum <= currentYear) {
           territorialFossilTrend = toTons(
             getLayerTrendValueKg(
@@ -320,30 +280,62 @@ export function transformNationEmissionsData(
             ),
           );
 
-          const trendTops = getCumulativeTrendTops(
+          const trendTops = getCumulativeLayerTops(
             territorialFossilTrend,
             biogenicTrend,
             consumptionAbroadTrend,
           );
-          territorialFossilTrendTop = trendTops.territorialFossilTrendTop;
-          biogenicTrendTop = trendTops.biogenicTrendTop;
-          consumptionAbroadTrendTop = trendTops.consumptionAbroadTrendTop;
+          territorialFossilTrendTop = trendTops.bottomTop;
+          biogenicTrendTop = trendTops.middleTop;
+          consumptionAbroadTrendTop = trendTops.topTop;
         }
       }
 
-      const territorialFossilParisKg = getLayerParisValueKg(
-        nation.territorialFossil,
-        yearNum,
-      );
-      const biogenicParisKg = getLayerParisValueKg(nation.biogenic, yearNum);
-      const consumptionAbroadParisKg = getLayerParisValueKg(
-        nation.consumptionAbroad,
-        yearNum,
-      );
+      let territorialFossilCarbonLaw: number | undefined;
+      let biogenicCarbonLaw: number | undefined;
+      let consumptionAbroadCarbonLaw: number | undefined;
+      let territorialFossilCarbonLawTop: number | undefined;
+      let biogenicCarbonLawTop: number | undefined;
+      let consumptionAbroadCarbonLawTop: number | undefined;
 
-      const territorialFossilCarbonLaw = toTons(territorialFossilParisKg);
-      const biogenicCarbonLaw = toTons(biogenicParisKg);
-      const consumptionAbroadCarbonLaw = toTons(consumptionAbroadParisKg);
+      if (stackAnchorYear !== null) {
+        territorialFossilCarbonLaw = toTons(
+          getLayerParisValueKg(
+            nation.territorialFossil,
+            nation.approximatedTerritorialFossil,
+            stackAnchorYear,
+            yearNum,
+            currentYear,
+          ),
+        );
+        biogenicCarbonLaw = toTons(
+          getLayerParisValueKg(
+            nation.biogenic,
+            nation.approximatedBiogenic,
+            stackAnchorYear,
+            yearNum,
+            currentYear,
+          ),
+        );
+        consumptionAbroadCarbonLaw = toTons(
+          getLayerParisValueKg(
+            nation.consumptionAbroad,
+            nation.approximatedConsumptionAbroad,
+            stackAnchorYear,
+            yearNum,
+            currentYear,
+          ),
+        );
+
+        const parisTops = getCumulativeLayerTops(
+          territorialFossilCarbonLaw,
+          biogenicCarbonLaw,
+          consumptionAbroadCarbonLaw,
+        );
+        territorialFossilCarbonLawTop = parisTops.bottomTop;
+        biogenicCarbonLawTop = parisTops.middleTop;
+        consumptionAbroadCarbonLawTop = parisTops.topTop;
+      }
 
       const stackedReported = sumDefined(
         territorialFossil,
@@ -389,6 +381,9 @@ export function transformNationEmissionsData(
         territorialFossilCarbonLaw,
         biogenicCarbonLaw,
         consumptionAbroadCarbonLaw,
+        territorialFossilCarbonLawTop,
+        biogenicCarbonLawTop,
+        consumptionAbroadCarbonLawTop,
       } as NationDataPoint;
     })
     .sort((a, b) => a.year - b.year)

--- a/src/utils/data/nationTransforms.ts
+++ b/src/utils/data/nationTransforms.ts
@@ -1,4 +1,8 @@
 import { NationDataPoint } from "@/types/emissions";
+import {
+  calculateParisValue,
+  CARBON_LAW_REDUCTION_RATE,
+} from "@/utils/calculations/emissionsCalculations";
 
 const EMISSIONS_DATA_START_YEAR = 1990;
 const EMISSIONS_DATA_END_YEAR = 2050;
@@ -31,41 +35,197 @@ export type NationEmissionsInput = {
   approximatedHistoricalEmission?: Record<string, number>;
   trend?: Record<string, number>;
   carbonLaw?: Record<string, number>;
+  territorialFossilCarbonLaw?: Record<string, number>;
+  biogenicCarbonLaw?: Record<string, number>;
+  consumptionAbroadCarbonLaw?: Record<string, number>;
 };
 
-function resolveStackValues(
+export function calculateCarbonLawFromApproximatedRecord(
+  approximated: Record<string, number>,
+  currentYear: number,
+): Record<string, number> {
+  const carbonLawRecord: Record<string, number> = {};
+
+  const baseEntry = Object.entries(approximated)
+    .filter(([year]) => !isNaN(Number(year)) && Number(year) <= currentYear)
+    .sort(([yearA], [yearB]) => Number(yearB) - Number(yearA))[0];
+
+  if (!baseEntry) return carbonLawRecord;
+
+  const [baseYearStr, carbonLawBaseValue] = baseEntry;
+  const carbonLawBaseYear = Number(baseYearStr);
+
+  for (let year = currentYear; year <= EMISSIONS_DATA_END_YEAR; year++) {
+    const carbonLawValue = calculateParisValue(
+      year,
+      carbonLawBaseYear,
+      carbonLawBaseValue,
+      CARBON_LAW_REDUCTION_RATE,
+    );
+    if (carbonLawValue !== null) {
+      carbonLawRecord[year.toString()] = carbonLawValue;
+    }
+  }
+
+  return carbonLawRecord;
+}
+
+/** Paris path per layer, anchored at the latest reported (historical) value for that layer. */
+export function calculateCarbonLawFromReportedRecord(
+  reported: Record<string, number>,
+): Record<string, number> {
+  const carbonLawRecord: Record<string, number> = {};
+
+  const baseEntry = Object.entries(reported)
+    .filter(([year]) => !isNaN(Number(year)))
+    .sort(([yearA], [yearB]) => Number(yearB) - Number(yearA))[0];
+
+  if (!baseEntry) return carbonLawRecord;
+
+  const [baseYearStr, carbonLawBaseValue] = baseEntry;
+  const carbonLawBaseYear = Number(baseYearStr);
+
+  for (let year = carbonLawBaseYear; year <= EMISSIONS_DATA_END_YEAR; year++) {
+    const carbonLawValue = calculateParisValue(
+      year,
+      carbonLawBaseYear,
+      carbonLawBaseValue,
+      CARBON_LAW_REDUCTION_RATE,
+    );
+    if (carbonLawValue !== null) {
+      carbonLawRecord[year.toString()] = carbonLawValue;
+    }
+  }
+
+  return carbonLawRecord;
+}
+
+function getLatestReportedYear(
+  reported: Record<string, number>,
+): number | null {
+  const years = Object.keys(reported)
+    .map(Number)
+    .filter((year) => !isNaN(year));
+  if (years.length === 0) return null;
+  return Math.max(...years);
+}
+
+function getLayerParisValueKg(
+  reported: Record<string, number>,
+  year: number,
+): number | undefined {
+  const anchorYear = getLatestReportedYear(reported);
+  if (anchorYear === null || year < anchorYear) return undefined;
+
+  const anchorValueKg = reported[anchorYear.toString()];
+  if (anchorValueKg === undefined) return undefined;
+
+  if (year === anchorYear) {
+    return anchorValueKg;
+  }
+
+  return (
+    calculateParisValue(
+      year,
+      anchorYear,
+      anchorValueKg,
+      CARBON_LAW_REDUCTION_RATE,
+    ) ?? undefined
+  );
+}
+
+function getLatestCompleteStackYear(
+  nation: NationEmissionsInput,
+): number | null {
+  const years = collectYears(
+    nation.territorialFossil,
+    nation.biogenic,
+    nation.consumptionAbroad,
+  );
+
+  const completeYears = [...years]
+    .map(Number)
+    .filter(
+      (year) =>
+        !isNaN(year) &&
+        nation.territorialFossil[year.toString()] !== undefined &&
+        nation.biogenic[year.toString()] !== undefined &&
+        nation.consumptionAbroad[year.toString()] !== undefined,
+    )
+    .sort((a, b) => b - a);
+
+  return completeYears[0] ?? null;
+}
+
+function getLayerTrendValueKg(
+  reported: Record<string, number>,
+  approximated: Record<string, number> | undefined,
+  year: number,
+  anchorYear: number,
+  currentYear: number,
+): number | undefined {
+  if (year < anchorYear || year > currentYear) {
+    return undefined;
+  }
+
+  if (year === anchorYear) {
+    return reported[anchorYear.toString()];
+  }
+
+  return approximated?.[year.toString()];
+}
+
+function getCumulativeTrendTops(
+  territorialFossilTrend?: number,
+  biogenicTrend?: number,
+  consumptionAbroadTrend?: number,
+): {
+  territorialFossilTrendTop?: number;
+  biogenicTrendTop?: number;
+  consumptionAbroadTrendTop?: number;
+} {
+  if (territorialFossilTrend === undefined) {
+    return {};
+  }
+
+  const biogenicTrendTop = sumDefined(
+    territorialFossilTrend,
+    biogenicTrend,
+  );
+  const consumptionAbroadTrendTop = sumDefined(
+    territorialFossilTrend,
+    biogenicTrend,
+    consumptionAbroadTrend,
+  );
+
+  return {
+    territorialFossilTrendTop: territorialFossilTrend,
+    biogenicTrendTop,
+    consumptionAbroadTrendTop,
+  };
+}
+
+function resolveReportedStackValues(
   nation: NationEmissionsInput,
   year: string,
 ): {
   territorialFossil?: number;
   biogenic?: number;
   consumptionAbroad?: number;
-  isApproximated: boolean;
 } {
   const territorialFossil = nation.territorialFossil[year];
   const biogenic = nation.biogenic[year];
   const consumptionAbroad = nation.consumptionAbroad[year];
 
-  const hasHistorical =
-    territorialFossil !== undefined ||
-    biogenic !== undefined ||
-    consumptionAbroad !== undefined;
-
-  if (hasHistorical) {
-    return {
-      territorialFossil,
-      biogenic,
-      consumptionAbroad,
-      isApproximated: false,
-    };
+  if (
+    territorialFossil === undefined &&
+    biogenic === undefined &&
+    consumptionAbroad === undefined
+  ) {
+    return {};
   }
 
-  return {
-    territorialFossil: nation.approximatedTerritorialFossil?.[year],
-    biogenic: nation.approximatedBiogenic?.[year],
-    consumptionAbroad: nation.approximatedConsumptionAbroad?.[year],
-    isApproximated: true,
-  };
+  return { territorialFossil, biogenic, consumptionAbroad };
 }
 
 function sumDefined(...values: Array<number | undefined>): number | undefined {
@@ -76,6 +236,7 @@ function sumDefined(...values: Array<number | undefined>): number | undefined {
 
 export function transformNationEmissionsData(
   nation: NationEmissionsInput,
+  currentYear: number = new Date().getFullYear(),
 ): NationDataPoint[] {
   const years = collectYears(
     nation.territorialFossil,
@@ -87,31 +248,147 @@ export function transformNationEmissionsData(
     nation.approximatedHistoricalEmission,
     nation.trend,
     nation.carbonLaw,
+    nation.territorialFossilCarbonLaw,
+    nation.biogenicCarbonLaw,
+    nation.consumptionAbroadCarbonLaw,
   );
+
+  const stackAnchorYear = getLatestCompleteStackYear(nation);
 
   return Array.from(years)
     .filter((year) => !isNaN(Number(year)))
     .map((year) => {
       const yearNum = Number(year);
-      const stack = resolveStackValues(nation, year);
-      const territorialFossil = toTons(stack.territorialFossil);
-      const biogenic = toTons(stack.biogenic);
-      const consumptionAbroad = toTons(stack.consumptionAbroad);
-      const stackedTotal = sumDefined(
+      const reported = resolveReportedStackValues(nation, year);
+
+      const territorialFossil =
+        stackAnchorYear !== null && yearNum >= stackAnchorYear
+          ? undefined
+          : toTons(reported.territorialFossil);
+      const biogenic =
+        stackAnchorYear !== null && yearNum >= stackAnchorYear
+          ? undefined
+          : toTons(reported.biogenic);
+      const consumptionAbroad =
+        stackAnchorYear !== null && yearNum >= stackAnchorYear
+          ? undefined
+          : toTons(reported.consumptionAbroad);
+
+      let territorialFossilTrend: number | undefined;
+      let biogenicTrend: number | undefined;
+      let consumptionAbroadTrend: number | undefined;
+      let territorialFossilTrendTop: number | undefined;
+      let biogenicTrendTop: number | undefined;
+      let consumptionAbroadTrendTop: number | undefined;
+
+      if (stackAnchorYear !== null) {
+        if (yearNum === stackAnchorYear - 1) {
+          const bridgeTops = getCumulativeTrendTops(
+            territorialFossil,
+            biogenic,
+            consumptionAbroad,
+          );
+          territorialFossilTrendTop = bridgeTops.territorialFossilTrendTop;
+          biogenicTrendTop = bridgeTops.biogenicTrendTop;
+          consumptionAbroadTrendTop = bridgeTops.consumptionAbroadTrendTop;
+        } else if (yearNum >= stackAnchorYear && yearNum <= currentYear) {
+          territorialFossilTrend = toTons(
+            getLayerTrendValueKg(
+              nation.territorialFossil,
+              nation.approximatedTerritorialFossil,
+              yearNum,
+              stackAnchorYear,
+              currentYear,
+            ),
+          );
+          biogenicTrend = toTons(
+            getLayerTrendValueKg(
+              nation.biogenic,
+              nation.approximatedBiogenic,
+              yearNum,
+              stackAnchorYear,
+              currentYear,
+            ),
+          );
+          consumptionAbroadTrend = toTons(
+            getLayerTrendValueKg(
+              nation.consumptionAbroad,
+              nation.approximatedConsumptionAbroad,
+              yearNum,
+              stackAnchorYear,
+              currentYear,
+            ),
+          );
+
+          const trendTops = getCumulativeTrendTops(
+            territorialFossilTrend,
+            biogenicTrend,
+            consumptionAbroadTrend,
+          );
+          territorialFossilTrendTop = trendTops.territorialFossilTrendTop;
+          biogenicTrendTop = trendTops.biogenicTrendTop;
+          consumptionAbroadTrendTop = trendTops.consumptionAbroadTrendTop;
+        }
+      }
+
+      const territorialFossilParisKg = getLayerParisValueKg(
+        nation.territorialFossil,
+        yearNum,
+      );
+      const biogenicParisKg = getLayerParisValueKg(nation.biogenic, yearNum);
+      const consumptionAbroadParisKg = getLayerParisValueKg(
+        nation.consumptionAbroad,
+        yearNum,
+      );
+
+      const territorialFossilCarbonLaw = toTons(territorialFossilParisKg);
+      const biogenicCarbonLaw = toTons(biogenicParisKg);
+      const consumptionAbroadCarbonLaw = toTons(consumptionAbroadParisKg);
+
+      const stackedReported = sumDefined(
         territorialFossil,
         biogenic,
         consumptionAbroad,
       );
+      const stackedTrend = sumDefined(
+        territorialFossilTrend,
+        biogenicTrend,
+        consumptionAbroadTrend,
+      );
+      const stackedParisTotal = sumDefined(
+        territorialFossilCarbonLaw,
+        biogenicCarbonLaw,
+        consumptionAbroadCarbonLaw,
+      );
+
+      const hasApproximatedTrend =
+        stackAnchorYear !== null &&
+        yearNum > stackAnchorYear &&
+        yearNum <= currentYear &&
+        (territorialFossilTrend !== undefined ||
+          biogenicTrend !== undefined ||
+          consumptionAbroadTrend !== undefined);
 
       return {
         year: yearNum,
         territorialFossil,
         biogenic,
         consumptionAbroad,
-        total: stackedTotal,
-        approximated: stack.isApproximated ? stackedTotal : undefined,
+        territorialFossilTrend,
+        biogenicTrend,
+        consumptionAbroadTrend,
+        territorialFossilTrendTop,
+        biogenicTrendTop,
+        consumptionAbroadTrendTop,
+        total: stackedReported ?? stackedTrend ?? stackedParisTotal,
+        approximated: hasApproximatedTrend
+          ? stackedTrend
+          : undefined,
         trend: toTons(nation.trend?.[year]),
         carbonLaw: toTons(nation.carbonLaw?.[year]),
+        territorialFossilCarbonLaw,
+        biogenicCarbonLaw,
+        consumptionAbroadCarbonLaw,
       } as NationDataPoint;
     })
     .sort((a, b) => a.year - b.year)
@@ -127,11 +404,7 @@ export function sumNationEmissionRecords(
   biogenic: Record<string, number>,
   consumptionAbroad: Record<string, number>,
 ): Record<string, number> {
-  const years = collectYears(
-    territorialFossil,
-    biogenic,
-    consumptionAbroad,
-  );
+  const years = collectYears(territorialFossil, biogenic, consumptionAbroad);
   const emissions: Record<string, number> = {};
   years.forEach((year) => {
     const total = sumDefined(

--- a/src/utils/data/nationTransforms.ts
+++ b/src/utils/data/nationTransforms.ts
@@ -145,6 +145,35 @@ function getLayerTrendValueKg(
   return approximated?.[year.toString()];
 }
 
+/** Continuous stack fill: reported through anchor year, then approximated through current year. */
+function getLayerStackFillValueKg(
+  reported: Record<string, number>,
+  approximated: Record<string, number> | undefined,
+  year: number,
+  stackAnchorYear: number | null,
+  currentYear: number,
+): number | undefined {
+  if (stackAnchorYear === null) {
+    return reported[year.toString()];
+  }
+
+  if (year < stackAnchorYear) {
+    return reported[year.toString()];
+  }
+
+  if (year <= currentYear) {
+    return getLayerTrendValueKg(
+      reported,
+      approximated,
+      year,
+      stackAnchorYear,
+      currentYear,
+    );
+  }
+
+  return undefined;
+}
+
 function getCumulativeLayerTops(
   bottom?: number,
   middle?: number,
@@ -221,18 +250,33 @@ export function transformNationEmissionsData(
       const yearNum = Number(year);
       const reported = resolveReportedStackValues(nation, year);
 
-      const territorialFossil =
-        stackAnchorYear !== null && yearNum > stackAnchorYear
-          ? undefined
-          : toTons(reported.territorialFossil);
-      const biogenic =
-        stackAnchorYear !== null && yearNum > stackAnchorYear
-          ? undefined
-          : toTons(reported.biogenic);
-      const consumptionAbroad =
-        stackAnchorYear !== null && yearNum > stackAnchorYear
-          ? undefined
-          : toTons(reported.consumptionAbroad);
+      const territorialFossil = toTons(
+        getLayerStackFillValueKg(
+          nation.territorialFossil,
+          nation.approximatedTerritorialFossil,
+          yearNum,
+          stackAnchorYear,
+          currentYear,
+        ),
+      );
+      const biogenic = toTons(
+        getLayerStackFillValueKg(
+          nation.biogenic,
+          nation.approximatedBiogenic,
+          yearNum,
+          stackAnchorYear,
+          currentYear,
+        ),
+      );
+      const consumptionAbroad = toTons(
+        getLayerStackFillValueKg(
+          nation.consumptionAbroad,
+          nation.approximatedConsumptionAbroad,
+          yearNum,
+          stackAnchorYear,
+          currentYear,
+        ),
+      );
 
       let territorialFossilTrend: number | undefined;
       let biogenicTrend: number | undefined;

--- a/src/utils/data/nationTransforms.ts
+++ b/src/utils/data/nationTransforms.ts
@@ -127,6 +127,18 @@ function getLatestCompleteStackYear(
   return completeYears[0] ?? null;
 }
 
+function getApproximatedStackEndYear(
+  nation: NationEmissionsInput,
+): number | null {
+  const years = collectYears(
+    nation.approximatedTerritorialFossil,
+    nation.approximatedBiogenic,
+    nation.approximatedConsumptionAbroad,
+  );
+  const numericYears = [...years].map(Number).filter((year) => !isNaN(year));
+  return numericYears.length > 0 ? Math.max(...numericYears) : null;
+}
+
 function getLayerTrendValueKg(
   reported: Record<string, number>,
   approximated: Record<string, number> | undefined,
@@ -145,13 +157,13 @@ function getLayerTrendValueKg(
   return approximated?.[year.toString()];
 }
 
-/** Continuous stack fill: reported through anchor year, then approximated through current year. */
+/** Continuous stack fill: reported through anchor year, then approximated through API end year. */
 function getLayerStackFillValueKg(
   reported: Record<string, number>,
   approximated: Record<string, number> | undefined,
   year: number,
   stackAnchorYear: number | null,
-  currentYear: number,
+  approximatedFillEndYear: number | null,
 ): number | undefined {
   if (stackAnchorYear === null) {
     return reported[year.toString()];
@@ -161,17 +173,20 @@ function getLayerStackFillValueKg(
     return reported[year.toString()];
   }
 
-  if (year <= currentYear) {
-    return getLayerTrendValueKg(
-      reported,
-      approximated,
-      year,
-      stackAnchorYear,
-      currentYear,
-    );
+  if (
+    approximatedFillEndYear === null ||
+    year > approximatedFillEndYear
+  ) {
+    return undefined;
   }
 
-  return undefined;
+  return getLayerTrendValueKg(
+    reported,
+    approximated,
+    year,
+    stackAnchorYear,
+    approximatedFillEndYear,
+  );
 }
 
 function getCumulativeLayerTops(
@@ -243,6 +258,7 @@ export function transformNationEmissionsData(
   );
 
   const stackAnchorYear = getLatestCompleteStackYear(nation);
+  const approximatedFillEndYear = getApproximatedStackEndYear(nation);
 
   return Array.from(years)
     .filter((year) => !isNaN(Number(year)))
@@ -256,7 +272,7 @@ export function transformNationEmissionsData(
           nation.approximatedTerritorialFossil,
           yearNum,
           stackAnchorYear,
-          currentYear,
+          approximatedFillEndYear,
         ),
       );
       const biogenic = toTons(
@@ -265,7 +281,7 @@ export function transformNationEmissionsData(
           nation.approximatedBiogenic,
           yearNum,
           stackAnchorYear,
-          currentYear,
+          approximatedFillEndYear,
         ),
       );
       const consumptionAbroad = toTons(
@@ -274,7 +290,7 @@ export function transformNationEmissionsData(
           nation.approximatedConsumptionAbroad,
           yearNum,
           stackAnchorYear,
-          currentYear,
+          approximatedFillEndYear,
         ),
       );
 
@@ -306,8 +322,9 @@ export function transformNationEmissionsData(
 
       if (
         stackAnchorYear !== null &&
+        approximatedFillEndYear !== null &&
         yearNum >= stackAnchorYear &&
-        yearNum <= currentYear
+        yearNum <= approximatedFillEndYear
       ) {
         territorialFossilTrend = toTons(
           getLayerTrendValueKg(
@@ -315,7 +332,7 @@ export function transformNationEmissionsData(
             nation.approximatedTerritorialFossil,
             yearNum,
             stackAnchorYear,
-            currentYear,
+            approximatedFillEndYear,
           ),
         );
         biogenicTrend = toTons(
@@ -324,7 +341,7 @@ export function transformNationEmissionsData(
             nation.approximatedBiogenic,
             yearNum,
             stackAnchorYear,
-            currentYear,
+            approximatedFillEndYear,
           ),
         );
         consumptionAbroadTrend = toTons(
@@ -333,7 +350,7 @@ export function transformNationEmissionsData(
             nation.approximatedConsumptionAbroad,
             yearNum,
             stackAnchorYear,
-            currentYear,
+            approximatedFillEndYear,
           ),
         );
 
@@ -411,8 +428,9 @@ export function transformNationEmissionsData(
 
       const hasApproximatedTrend =
         stackAnchorYear !== null &&
+        approximatedFillEndYear !== null &&
         yearNum > stackAnchorYear &&
-        yearNum <= currentYear &&
+        yearNum <= approximatedFillEndYear &&
         (territorialFossilTrend !== undefined ||
           biogenicTrend !== undefined ||
           consumptionAbroadTrend !== undefined);

--- a/src/utils/data/nationTransforms.ts
+++ b/src/utils/data/nationTransforms.ts
@@ -222,15 +222,15 @@ export function transformNationEmissionsData(
       const reported = resolveReportedStackValues(nation, year);
 
       const territorialFossil =
-        stackAnchorYear !== null && yearNum >= stackAnchorYear
+        stackAnchorYear !== null && yearNum > stackAnchorYear
           ? undefined
           : toTons(reported.territorialFossil);
       const biogenic =
-        stackAnchorYear !== null && yearNum >= stackAnchorYear
+        stackAnchorYear !== null && yearNum > stackAnchorYear
           ? undefined
           : toTons(reported.biogenic);
       const consumptionAbroad =
-        stackAnchorYear !== null && yearNum >= stackAnchorYear
+        stackAnchorYear !== null && yearNum > stackAnchorYear
           ? undefined
           : toTons(reported.consumptionAbroad);
 
@@ -241,54 +241,47 @@ export function transformNationEmissionsData(
       let biogenicTrendTop: number | undefined;
       let consumptionAbroadTrendTop: number | undefined;
 
-      if (stackAnchorYear !== null) {
-        if (yearNum === stackAnchorYear - 1) {
-          const bridgeTops = getCumulativeLayerTops(
-            territorialFossil,
-            biogenic,
-            consumptionAbroad,
-          );
-          territorialFossilTrendTop = bridgeTops.bottomTop;
-          biogenicTrendTop = bridgeTops.middleTop;
-          consumptionAbroadTrendTop = bridgeTops.topTop;
-        } else if (yearNum >= stackAnchorYear && yearNum <= currentYear) {
-          territorialFossilTrend = toTons(
-            getLayerTrendValueKg(
-              nation.territorialFossil,
-              nation.approximatedTerritorialFossil,
-              yearNum,
-              stackAnchorYear,
-              currentYear,
-            ),
-          );
-          biogenicTrend = toTons(
-            getLayerTrendValueKg(
-              nation.biogenic,
-              nation.approximatedBiogenic,
-              yearNum,
-              stackAnchorYear,
-              currentYear,
-            ),
-          );
-          consumptionAbroadTrend = toTons(
-            getLayerTrendValueKg(
-              nation.consumptionAbroad,
-              nation.approximatedConsumptionAbroad,
-              yearNum,
-              stackAnchorYear,
-              currentYear,
-            ),
-          );
+      if (
+        stackAnchorYear !== null &&
+        yearNum >= stackAnchorYear &&
+        yearNum <= currentYear
+      ) {
+        territorialFossilTrend = toTons(
+          getLayerTrendValueKg(
+            nation.territorialFossil,
+            nation.approximatedTerritorialFossil,
+            yearNum,
+            stackAnchorYear,
+            currentYear,
+          ),
+        );
+        biogenicTrend = toTons(
+          getLayerTrendValueKg(
+            nation.biogenic,
+            nation.approximatedBiogenic,
+            yearNum,
+            stackAnchorYear,
+            currentYear,
+          ),
+        );
+        consumptionAbroadTrend = toTons(
+          getLayerTrendValueKg(
+            nation.consumptionAbroad,
+            nation.approximatedConsumptionAbroad,
+            yearNum,
+            stackAnchorYear,
+            currentYear,
+          ),
+        );
 
-          const trendTops = getCumulativeLayerTops(
-            territorialFossilTrend,
-            biogenicTrend,
-            consumptionAbroadTrend,
-          );
-          territorialFossilTrendTop = trendTops.bottomTop;
-          biogenicTrendTop = trendTops.middleTop;
-          consumptionAbroadTrendTop = trendTops.topTop;
-        }
+        const trendTops = getCumulativeLayerTops(
+          territorialFossilTrend,
+          biogenicTrend,
+          consumptionAbroadTrend,
+        );
+        territorialFossilTrendTop = trendTops.bottomTop;
+        biogenicTrendTop = trendTops.middleTop;
+        consumptionAbroadTrendTop = trendTops.topTop;
       }
 
       let territorialFossilCarbonLaw: number | undefined;

--- a/src/utils/data/nationTransforms.ts
+++ b/src/utils/data/nationTransforms.ts
@@ -6,6 +6,8 @@ import {
 
 const EMISSIONS_DATA_START_YEAR = 1990;
 const EMISSIONS_DATA_END_YEAR = 2050;
+/** Years used to fit per-layer linear trend slopes. */
+const NATION_TREND_FIT_START_YEAR = 2015;
 
 const KG_TO_TONS = 1000;
 
@@ -104,6 +106,14 @@ function getLayerParisValueKg(
   );
 }
 
+function getLatestLayerYear(reported: Record<string, number>): number | null {
+  const years = Object.keys(reported)
+    .map(Number)
+    .filter((year) => !isNaN(year) && reported[year.toString()] !== undefined);
+
+  return years.length > 0 ? Math.max(...years) : null;
+}
+
 function getLatestCompleteStackYear(
   nation: NationEmissionsInput,
 ): number | null {
@@ -157,6 +167,92 @@ function getLayerTrendValueKg(
   return approximated?.[year.toString()];
 }
 
+function computeLayerTrendSlopeKgPerYear(
+  reported: Record<string, number>,
+  startYear: number,
+  endYear: number,
+): number | null {
+  const points = Object.entries(reported)
+    .map(([year, value]) => ({ year: Number(year), value }))
+    .filter(
+      ({ year, value }) =>
+        !isNaN(year) &&
+        year >= startYear &&
+        year <= endYear &&
+        value !== undefined,
+    )
+    .sort((a, b) => a.year - b.year);
+
+  if (points.length < 2) {
+    return null;
+  }
+
+  const n = points.length;
+  const meanX = points.reduce((sum, point) => sum + point.year, 0) / n;
+  const meanY = points.reduce((sum, point) => sum + point.value, 0) / n;
+  const numerator = points.reduce(
+    (sum, point) => sum + (point.year - meanX) * (point.value - meanY),
+    0,
+  );
+  const denominator = points.reduce(
+    (sum, point) => sum + (point.year - meanX) ** 2,
+    0,
+  );
+
+  if (denominator === 0) {
+    return null;
+  }
+
+  return numerator / denominator;
+}
+
+/** Per-layer trend: slope from fit window, displayed from each layer's last reported year. */
+function getLayerStackTrendValueKg(
+  reported: Record<string, number>,
+  approximated: Record<string, number> | undefined,
+  slopeKgPerYear: number | null,
+  layerAnchorYear: number,
+  year: number,
+  approximatedFillEndYear: number | null,
+  trendDisplayStartYear: number,
+): number | undefined {
+  if (
+    slopeKgPerYear === null ||
+    year < trendDisplayStartYear ||
+    year > EMISSIONS_DATA_END_YEAR
+  ) {
+    return undefined;
+  }
+
+  const anchorValue = reported[layerAnchorYear.toString()];
+  if (anchorValue === undefined) {
+    return undefined;
+  }
+
+  if (
+    approximatedFillEndYear !== null &&
+    year > layerAnchorYear &&
+    year <= approximatedFillEndYear
+  ) {
+    const approximatedValue = approximated?.[year.toString()];
+    if (approximatedValue !== undefined) {
+      return approximatedValue;
+    }
+  }
+
+  const projectionBaseYear =
+    approximatedFillEndYear !== null && year > approximatedFillEndYear
+      ? approximatedFillEndYear
+      : layerAnchorYear;
+  const projectionBaseValue =
+    projectionBaseYear === layerAnchorYear
+      ? anchorValue
+      : (approximated?.[projectionBaseYear.toString()] ??
+        anchorValue + slopeKgPerYear * (projectionBaseYear - layerAnchorYear));
+
+  return projectionBaseValue + slopeKgPerYear * (year - projectionBaseYear);
+}
+
 /** Continuous stack fill: reported through anchor year, then approximated through API end year. */
 function getLayerStackFillValueKg(
   reported: Record<string, number>,
@@ -195,14 +291,13 @@ function getCumulativeLayerTops(
   middleTop?: number;
   topTop?: number;
 } {
-  if (bottom === undefined) {
-    return {};
-  }
+  const bottomValue = bottom ?? 0;
+  const middleValue = middle ?? 0;
 
   return {
     bottomTop: bottom,
-    middleTop: sumDefined(bottom, middle),
-    topTop: sumDefined(bottom, middle, top),
+    middleTop: middle !== undefined ? bottomValue + middleValue : undefined,
+    topTop: top !== undefined ? bottomValue + middleValue + top : undefined,
   };
 }
 
@@ -256,6 +351,37 @@ export function transformNationEmissionsData(
 
   const stackAnchorYear = getLatestCompleteStackYear(nation);
   const approximatedFillEndYear = getApproximatedStackEndYear(nation);
+  const territorialFossilAnchorYear = getLatestLayerYear(
+    nation.territorialFossil,
+  );
+  const biogenicAnchorYear = getLatestLayerYear(nation.biogenic);
+  const consumptionAbroadAnchorYear = getLatestLayerYear(
+    nation.consumptionAbroad,
+  );
+  const territorialFossilTrendSlope =
+    territorialFossilAnchorYear !== null
+      ? computeLayerTrendSlopeKgPerYear(
+          nation.territorialFossil,
+          NATION_TREND_FIT_START_YEAR,
+          territorialFossilAnchorYear,
+        )
+      : null;
+  const biogenicTrendSlope =
+    biogenicAnchorYear !== null
+      ? computeLayerTrendSlopeKgPerYear(
+          nation.biogenic,
+          NATION_TREND_FIT_START_YEAR,
+          biogenicAnchorYear,
+        )
+      : null;
+  const consumptionAbroadTrendSlope =
+    consumptionAbroadAnchorYear !== null
+      ? computeLayerTrendSlopeKgPerYear(
+          nation.consumptionAbroad,
+          NATION_TREND_FIT_START_YEAR,
+          consumptionAbroadAnchorYear,
+        )
+      : null;
 
   return Array.from(years)
     .filter((year) => !isNaN(Number(year)))
@@ -263,7 +389,7 @@ export function transformNationEmissionsData(
       const yearNum = Number(year);
       const reported = resolveReportedStackValues(nation, year);
 
-      const territorialFossil = toTons(
+      let territorialFossil = toTons(
         getLayerStackFillValueKg(
           nation.territorialFossil,
           nation.approximatedTerritorialFossil,
@@ -272,7 +398,7 @@ export function transformNationEmissionsData(
           approximatedFillEndYear,
         ),
       );
-      const biogenic = toTons(
+      let biogenic = toTons(
         getLayerStackFillValueKg(
           nation.biogenic,
           nation.approximatedBiogenic,
@@ -281,7 +407,7 @@ export function transformNationEmissionsData(
           approximatedFillEndYear,
         ),
       );
-      const consumptionAbroad = toTons(
+      let consumptionAbroad = toTons(
         getLayerStackFillValueKg(
           nation.consumptionAbroad,
           nation.approximatedConsumptionAbroad,
@@ -295,10 +421,90 @@ export function transformNationEmissionsData(
       let biogenicHistoricalTop: number | undefined;
       let consumptionAbroadHistoricalTop: number | undefined;
 
+      let territorialFossilTrend: number | undefined;
+      let biogenicTrend: number | undefined;
+      let consumptionAbroadTrend: number | undefined;
+      let territorialFossilTrendTop: number | undefined;
+      let biogenicTrendTop: number | undefined;
+      let consumptionAbroadTrendTop: number | undefined;
+
+      if (territorialFossilAnchorYear !== null) {
+        territorialFossilTrend = toTons(
+          getLayerStackTrendValueKg(
+            nation.territorialFossil,
+            nation.approximatedTerritorialFossil,
+            territorialFossilTrendSlope,
+            territorialFossilAnchorYear,
+            yearNum,
+            approximatedFillEndYear,
+            territorialFossilAnchorYear,
+          ),
+        );
+      }
+      if (biogenicAnchorYear !== null) {
+        biogenicTrend = toTons(
+          getLayerStackTrendValueKg(
+            nation.biogenic,
+            nation.approximatedBiogenic,
+            biogenicTrendSlope,
+            biogenicAnchorYear,
+            yearNum,
+            approximatedFillEndYear,
+            biogenicAnchorYear,
+          ),
+        );
+      }
+      if (consumptionAbroadAnchorYear !== null) {
+        consumptionAbroadTrend = toTons(
+          getLayerStackTrendValueKg(
+            nation.consumptionAbroad,
+            nation.approximatedConsumptionAbroad,
+            consumptionAbroadTrendSlope,
+            consumptionAbroadAnchorYear,
+            yearNum,
+            approximatedFillEndYear,
+            consumptionAbroadAnchorYear,
+          ),
+        );
+      }
+
       if (
-        stackAnchorYear !== null &&
-        yearNum <= stackAnchorYear &&
-        territorialFossil !== undefined
+        territorialFossilTrend !== undefined ||
+        biogenicTrend !== undefined ||
+        consumptionAbroadTrend !== undefined
+      ) {
+        const trendTops = getCumulativeLayerTops(
+          territorialFossilTrend,
+          biogenicTrend,
+          consumptionAbroadTrend,
+        );
+        territorialFossilTrendTop = trendTops.bottomTop;
+        biogenicTrendTop = trendTops.middleTop;
+        consumptionAbroadTrendTop = trendTops.topTop;
+      }
+
+      // Continue one stack with trend after approximated end (2026 stays on reported/approximated fill).
+      if (
+        approximatedFillEndYear !== null &&
+        yearNum > approximatedFillEndYear
+      ) {
+        if (territorialFossilTrend !== undefined) {
+          territorialFossil = territorialFossilTrend;
+        }
+        if (biogenicTrend !== undefined) {
+          biogenic = biogenicTrend;
+        }
+        if (consumptionAbroadTrend !== undefined) {
+          consumptionAbroad = consumptionAbroadTrend;
+        }
+      }
+
+      const stackOutlineEndYear = approximatedFillEndYear ?? stackAnchorYear;
+      if (
+        (stackOutlineEndYear === null || yearNum <= stackOutlineEndYear) &&
+        (territorialFossil !== undefined ||
+          biogenic !== undefined ||
+          consumptionAbroad !== undefined)
       ) {
         const historicalTops = getCumulativeLayerTops(
           territorialFossil,
@@ -310,56 +516,10 @@ export function transformNationEmissionsData(
         consumptionAbroadHistoricalTop = historicalTops.topTop;
       }
 
-      let territorialFossilTrend: number | undefined;
-      let biogenicTrend: number | undefined;
-      let consumptionAbroadTrend: number | undefined;
-      let territorialFossilTrendTop: number | undefined;
-      let biogenicTrendTop: number | undefined;
-      let consumptionAbroadTrendTop: number | undefined;
-
-      if (
-        stackAnchorYear !== null &&
-        approximatedFillEndYear !== null &&
-        yearNum >= stackAnchorYear &&
-        yearNum <= approximatedFillEndYear
-      ) {
-        territorialFossilTrend = toTons(
-          getLayerTrendValueKg(
-            nation.territorialFossil,
-            nation.approximatedTerritorialFossil,
-            yearNum,
-            stackAnchorYear,
-            approximatedFillEndYear,
-          ),
-        );
-        biogenicTrend = toTons(
-          getLayerTrendValueKg(
-            nation.biogenic,
-            nation.approximatedBiogenic,
-            yearNum,
-            stackAnchorYear,
-            approximatedFillEndYear,
-          ),
-        );
-        consumptionAbroadTrend = toTons(
-          getLayerTrendValueKg(
-            nation.consumptionAbroad,
-            nation.approximatedConsumptionAbroad,
-            yearNum,
-            stackAnchorYear,
-            approximatedFillEndYear,
-          ),
-        );
-
-        const trendTops = getCumulativeLayerTops(
-          territorialFossilTrend,
-          biogenicTrend,
-          consumptionAbroadTrend,
-        );
-        territorialFossilTrendTop = trendTops.bottomTop;
-        biogenicTrendTop = trendTops.middleTop;
-        consumptionAbroadTrendTop = trendTops.topTop;
-      }
+      // Trend fill uses the main stack; keep trend fields for dashed outlines only.
+      territorialFossilTrend = undefined;
+      biogenicTrend = undefined;
+      consumptionAbroadTrend = undefined;
 
       let territorialFossilCarbonLaw: number | undefined;
       let biogenicCarbonLaw: number | undefined;
@@ -423,14 +583,10 @@ export function transformNationEmissionsData(
         consumptionAbroadCarbonLaw,
       );
 
-      const hasApproximatedTrend =
-        stackAnchorYear !== null &&
+      const hasProjectedTrend =
         approximatedFillEndYear !== null &&
-        yearNum > stackAnchorYear &&
-        yearNum <= approximatedFillEndYear &&
-        (territorialFossilTrend !== undefined ||
-          biogenicTrend !== undefined ||
-          consumptionAbroadTrend !== undefined);
+        yearNum >= approximatedFillEndYear &&
+        stackedReported !== undefined;
 
       return {
         year: yearNum,
@@ -447,7 +603,7 @@ export function transformNationEmissionsData(
         biogenicTrendTop,
         consumptionAbroadTrendTop,
         total: stackedReported ?? stackedTrend ?? stackedParisTotal,
-        approximated: hasApproximatedTrend ? stackedTrend : undefined,
+        approximated: hasProjectedTrend ? stackedReported : undefined,
         trend: toTons(nation.trend?.[year]),
         carbonLaw: toTons(nation.carbonLaw?.[year]),
         territorialFossilCarbonLaw,

--- a/src/utils/data/nationTransforms.ts
+++ b/src/utils/data/nationTransforms.ts
@@ -1,41 +1,118 @@
-import { DataPoint } from "@/types/emissions";
+import { NationDataPoint } from "@/types/emissions";
 
 const EMISSIONS_DATA_START_YEAR = 1990;
 const EMISSIONS_DATA_END_YEAR = 2050;
 
-export function transformNationEmissionsData(nation: {
-  emissions: Record<string, number>;
+const KG_TO_TONS = 1000;
+
+function toTons(value: number | undefined): number | undefined {
+  return value !== undefined ? value / KG_TO_TONS : undefined;
+}
+
+function collectYears(
+  ...records: Array<Record<string, number> | undefined>
+): Set<string> {
+  const years = new Set<string>();
+  records.forEach((record) => {
+    if (record) {
+      Object.keys(record).forEach((year) => years.add(year));
+    }
+  });
+  return years;
+}
+
+export type NationEmissionsInput = {
+  territorialFossil: Record<string, number>;
+  biogenic: Record<string, number>;
+  consumptionAbroad: Record<string, number>;
+  approximatedTerritorialFossil?: Record<string, number>;
+  approximatedBiogenic?: Record<string, number>;
+  approximatedConsumptionAbroad?: Record<string, number>;
   approximatedHistoricalEmission?: Record<string, number>;
   trend?: Record<string, number>;
   carbonLaw?: Record<string, number>;
-}): DataPoint[] {
-  if (!nation || !nation.emissions) return [];
+};
 
-  const years = new Set<string>();
-  Object.keys(nation.emissions).forEach((year) => years.add(year));
-  Object.keys(nation.approximatedHistoricalEmission || {}).forEach((year) =>
-    years.add(year),
+function resolveStackValues(
+  nation: NationEmissionsInput,
+  year: string,
+): {
+  territorialFossil?: number;
+  biogenic?: number;
+  consumptionAbroad?: number;
+  isApproximated: boolean;
+} {
+  const territorialFossil = nation.territorialFossil[year];
+  const biogenic = nation.biogenic[year];
+  const consumptionAbroad = nation.consumptionAbroad[year];
+
+  const hasHistorical =
+    territorialFossil !== undefined ||
+    biogenic !== undefined ||
+    consumptionAbroad !== undefined;
+
+  if (hasHistorical) {
+    return {
+      territorialFossil,
+      biogenic,
+      consumptionAbroad,
+      isApproximated: false,
+    };
+  }
+
+  return {
+    territorialFossil: nation.approximatedTerritorialFossil?.[year],
+    biogenic: nation.approximatedBiogenic?.[year],
+    consumptionAbroad: nation.approximatedConsumptionAbroad?.[year],
+    isApproximated: true,
+  };
+}
+
+function sumDefined(...values: Array<number | undefined>): number | undefined {
+  const defined = values.filter((v): v is number => v !== undefined);
+  if (defined.length === 0) return undefined;
+  return defined.reduce((sum, value) => sum + value, 0);
+}
+
+export function transformNationEmissionsData(
+  nation: NationEmissionsInput,
+): NationDataPoint[] {
+  const years = collectYears(
+    nation.territorialFossil,
+    nation.biogenic,
+    nation.consumptionAbroad,
+    nation.approximatedTerritorialFossil,
+    nation.approximatedBiogenic,
+    nation.approximatedConsumptionAbroad,
+    nation.approximatedHistoricalEmission,
+    nation.trend,
+    nation.carbonLaw,
   );
-  Object.keys(nation.trend || {}).forEach((year) => years.add(year));
-  Object.keys(nation.carbonLaw || {}).forEach((year) => years.add(year));
 
   return Array.from(years)
     .filter((year) => !isNaN(Number(year)))
     .map((year) => {
       const yearNum = Number(year);
+      const stack = resolveStackValues(nation, year);
+      const territorialFossil = toTons(stack.territorialFossil);
+      const biogenic = toTons(stack.biogenic);
+      const consumptionAbroad = toTons(stack.consumptionAbroad);
+      const stackedTotal = sumDefined(
+        territorialFossil,
+        biogenic,
+        consumptionAbroad,
+      );
+
       return {
         year: yearNum,
-        total: nation.emissions[year]
-          ? nation.emissions[year] / 1000
-          : undefined,
-        approximated: nation.approximatedHistoricalEmission?.[year]
-          ? nation.approximatedHistoricalEmission[year] / 1000
-          : undefined,
-        trend: nation.trend?.[year] ? nation.trend[year] / 1000 : undefined,
-        carbonLaw: nation.carbonLaw?.[year]
-          ? nation.carbonLaw[year] / 1000
-          : undefined,
-      } as DataPoint;
+        territorialFossil,
+        biogenic,
+        consumptionAbroad,
+        total: stackedTotal,
+        approximated: stack.isApproximated ? stackedTotal : undefined,
+        trend: toTons(nation.trend?.[year]),
+        carbonLaw: toTons(nation.carbonLaw?.[year]),
+      } as NationDataPoint;
     })
     .sort((a, b) => a.year - b.year)
     .filter(
@@ -43,4 +120,28 @@ export function transformNationEmissionsData(nation: {
         d.year >= EMISSIONS_DATA_START_YEAR &&
         d.year <= EMISSIONS_DATA_END_YEAR,
     );
+}
+
+export function sumNationEmissionRecords(
+  territorialFossil: Record<string, number>,
+  biogenic: Record<string, number>,
+  consumptionAbroad: Record<string, number>,
+): Record<string, number> {
+  const years = collectYears(
+    territorialFossil,
+    biogenic,
+    consumptionAbroad,
+  );
+  const emissions: Record<string, number> = {};
+  years.forEach((year) => {
+    const total = sumDefined(
+      territorialFossil[year],
+      biogenic[year],
+      consumptionAbroad[year],
+    );
+    if (total !== undefined) {
+      emissions[year] = total;
+    }
+  });
+  return emissions;
 }

--- a/src/utils/data/nationTransforms.ts
+++ b/src/utils/data/nationTransforms.ts
@@ -173,10 +173,7 @@ function getLayerStackFillValueKg(
     return reported[year.toString()];
   }
 
-  if (
-    approximatedFillEndYear === null ||
-    year > approximatedFillEndYear
-  ) {
+  if (approximatedFillEndYear === null || year > approximatedFillEndYear) {
     return undefined;
   }
 
@@ -450,9 +447,7 @@ export function transformNationEmissionsData(
         biogenicTrendTop,
         consumptionAbroadTrendTop,
         total: stackedReported ?? stackedTrend ?? stackedParisTotal,
-        approximated: hasApproximatedTrend
-          ? stackedTrend
-          : undefined,
+        approximated: hasApproximatedTrend ? stackedTrend : undefined,
         trend: toTons(nation.trend?.[year]),
         carbonLaw: toTons(nation.carbonLaw?.[year]),
         territorialFossilCarbonLaw,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,15 @@ import { plugin as markdown, Mode } from "vite-plugin-markdown";
 
 export default ({ mode }: ConfigEnv) => {
   const env = loadEnv(mode, process.cwd(), "");
+  const apiProxyTarget = env.VITE_API_PROXY ?? "https://klimatkollen.se/";
+  const isLocalGarboProxy = /localhost|127\.0\.0\.1/.test(apiProxyTarget);
+
+  if (isLocalGarboProxy && !env.GARBO_PROXY_CLIENT_API_KEY) {
+    console.warn(
+      "[vite] GARBO_PROXY_CLIENT_API_KEY is missing. Local Garbo returns 401 without it. " +
+        "Add your key to .env.development or use VITE_API_PROXY=https://klimatkollen.se/",
+    );
+  }
 
   return defineConfig({
     plugins: [
@@ -27,7 +36,7 @@ export default ({ mode }: ConfigEnv) => {
     server: {
       proxy: {
         "/api": {
-          target: env.VITE_API_PROXY ?? "http://localhost:3000/", // Default to local, override in CI/CD
+          target: apiProxyTarget,
           changeOrigin: true,
           secure: false,
           configure: (proxy) => {


### PR DESCRIPTION
Show territorial fossil, biogenic, and consumption abroad as stacked areas with trend and Paris lines on the nation detail page.

### ✨ What’s Changed?

<!-- Describe what this PR changes and why -->

### 📸 Screenshots (if applicable)

<!-- Add before/after images or UI previews -->


### 📋 Checklist

- [ ] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [ ] I've verified the change runs locally both on mobile and desktop
- [ ] I've set the labels, issue, and milestone for the PR
- [ ] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #1487