### PR TITLE
[1488] Add e-handel vs Gävle emissions comparison

### DIFF
--- a/src/components/nation/EmissionsComparisonBubbles.tsx
+++ b/src/components/nation/EmissionsComparisonBubbles.tsx
@@ -1,0 +1,160 @@
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { Text } from "@/components/ui/text";
+import { CardHeader } from "@/components/layout/CardHeader";
+import { SectionWithHelp } from "@/data-guide/SectionWithHelp";
+import { useLanguage } from "@/components/LanguageProvider";
+import { useMunicipalities } from "@/hooks/municipalities/useMunicipalities";
+import { LocalizedLink } from "@/components/LocalizedLink";
+import { getMunicipalityEmissionByName } from "@/utils/data/findClosestMunicipalityEmission";
+import { formatEmissionsAbsolute } from "@/utils/formatting/localization";
+import { cn } from "@/lib/utils";
+
+const E_HANDEL_FRAN_UTLANDET_EMISSIONS = 310_079;
+const COMPARISON_YEAR = 2025;
+const COMPARISON_MUNICIPALITY = "Gävle";
+const MAX_BUBBLE_DIAMETER = 260;
+
+type BubbleItem = {
+  id: string;
+  label: string;
+  value: number;
+  color: string;
+  href?: string;
+};
+
+function getBubbleDiameter(
+  value: number,
+  maxValue: number,
+  maxDiameter: number,
+): number {
+  return Math.sqrt(value / maxValue) * maxDiameter;
+}
+
+function ComparisonBubble({
+  item,
+  maxValue,
+}: {
+  item: BubbleItem;
+  maxValue: number;
+}) {
+  const { t } = useTranslation();
+  const { currentLanguage } = useLanguage();
+  const diameter = getBubbleDiameter(item.value, maxValue, MAX_BUBBLE_DIAMETER);
+  const formattedValue = formatEmissionsAbsolute(item.value, currentLanguage);
+  const valueFontSize = Math.max(16, Math.min(diameter * 0.13, 34));
+  const labelFontSize = Math.max(12, Math.min(diameter * 0.08, 18));
+
+  const bubble = (
+    <div
+      className={cn(
+        "rounded-full shrink-0 flex flex-col items-center justify-center gap-1 px-3 text-center",
+        item.href && "transition-transform hover:scale-[1.03]",
+      )}
+      style={{
+        width: diameter,
+        height: diameter,
+        background: item.color,
+        border: "2px solid var(--black-4)",
+        boxShadow: "0 2px 4px var(--black-4)",
+      }}
+    >
+      <span
+        className="font-bold tabular-nums leading-none text-black"
+        style={{ fontSize: valueFontSize }}
+      >
+        {formattedValue}
+      </span>
+      <span
+        className="font-bold leading-tight text-black"
+        style={{ fontSize: labelFontSize }}
+      >
+        {item.label}
+      </span>
+    </div>
+  );
+
+  return (
+    <div className="flex flex-col items-center gap-3 px-1">
+      <Text className="text-sm font-bold text-black">{t("emissionsUnit")}</Text>
+      {item.href ? (
+        <LocalizedLink
+          to={item.href}
+          className="no-underline hover:no-underline"
+          aria-label={item.label}
+        >
+          {bubble}
+        </LocalizedLink>
+      ) : (
+        bubble
+      )}
+    </div>
+  );
+}
+
+export function EmissionsComparisonBubbles({ className }: { className?: string }) {
+  const { t } = useTranslation();
+  const { municipalities, municipalitiesLoading } = useMunicipalities();
+
+  const comparisonMunicipality = useMemo(
+    () =>
+      getMunicipalityEmissionByName(
+        municipalities,
+        COMPARISON_MUNICIPALITY,
+        COMPARISON_YEAR,
+      ),
+    [municipalities],
+  );
+
+  const bubbles = useMemo((): BubbleItem[] => {
+    if (!comparisonMunicipality) return [];
+
+    return [
+      {
+        id: "e-handel",
+        label: t("nation.comparisonBubbles.eHandelLabel"),
+        value: E_HANDEL_FRAN_UTLANDET_EMISSIONS,
+        color: "var(--orange-3)",
+      },
+      {
+        id: "municipality",
+        label: comparisonMunicipality.name,
+        value: comparisonMunicipality.value,
+        color: "var(--blue-2)",
+        href: `/municipalities/${encodeURIComponent(comparisonMunicipality.name)}`,
+      },
+    ];
+  }, [comparisonMunicipality, t]);
+
+  const maxValue = useMemo(
+    () => Math.max(...bubbles.map((bubble) => bubble.value), 1),
+    [bubbles],
+  );
+
+  if (municipalitiesLoading) {
+    return (
+      <SectionWithHelp helpItems={[]} className={className}>
+        <div className="min-h-[280px] animate-pulse bg-black-1/30 rounded-level-2" />
+      </SectionWithHelp>
+    );
+  }
+
+  if (!comparisonMunicipality || bubbles.length === 0) {
+    return null;
+  }
+
+  return (
+    <SectionWithHelp helpItems={[]} className={className}>
+      <CardHeader
+        title={t("nation.comparisonBubbles.title")}
+        description={t("nation.comparisonBubbles.description")}
+      />
+
+      <div className="flex flex-col sm:flex-row items-center justify-center gap-8 sm:gap-0 sm:-space-x-10">
+        {bubbles.map((bubble) => (
+          <ComparisonBubble key={bubble.id} item={bubble} maxValue={maxValue} />
+        ))}
+      </div>
+    </SectionWithHelp>
+  );
+}

--- a/src/components/nation/EmissionsComparisonBubbles.tsx
+++ b/src/components/nation/EmissionsComparisonBubbles.tsx
@@ -19,8 +19,7 @@ type BubbleItem = {
   id: string;
   label: string;
   value: number;
-  color: string;
-  valueClassName: string;
+  fillColor: string;
   href?: string;
 };
 
@@ -45,7 +44,6 @@ function ComparisonBubble({
   item: BubbleItem;
   maxValue: number;
 }) {
-  const { t } = useTranslation();
   const { currentLanguage } = useLanguage();
   const diameter = getBubbleDiameter(item.value, maxValue, MAX_BUBBLE_DIAMETER);
   const formattedValue = formatEmissionsAbsolute(item.value, currentLanguage);
@@ -53,24 +51,24 @@ function ComparisonBubble({
   const bubble = (
     <div
       className={cn(
-        "rounded-full shrink-0 flex flex-col items-center justify-center gap-2 px-4 text-center bg-black-2",
+        "rounded-full shrink-0 flex flex-col items-center justify-center gap-2 px-4 text-center text-black",
         item.href && "transition-transform hover:scale-[1.03]",
       )}
       style={{
         width: diameter,
         height: diameter,
-        border: `2px solid ${item.color}`,
+        backgroundColor: item.fillColor,
+        border: "2px solid var(--black-4)",
         boxShadow: "0 2px 4px var(--black-4)",
       }}
     >
-      <Text className="text-sm md:text-base font-light leading-snug">
+      <Text className="text-sm md:text-base font-semibold leading-snug">
         {item.label}
       </Text>
       <Text
         className={cn(
-          "font-light tracking-tighter tabular-nums leading-none",
+          "font-bold tracking-tighter tabular-nums leading-none",
           getValueTextClass(diameter),
-          item.valueClassName,
         )}
       >
         {formattedValue}
@@ -79,10 +77,7 @@ function ComparisonBubble({
   );
 
   return (
-    <div className="flex flex-col items-center gap-1.5 px-1">
-      <Text variant="small" className="text-grey">
-        {t("emissionsUnit")}
-      </Text>
+    <div className="flex flex-col items-center px-1">
       {item.href ? (
         <LocalizedLink
           to={item.href}
@@ -120,15 +115,13 @@ export function EmissionsComparisonBubbles({ className }: { className?: string }
         id: "e-handel",
         label: t("nation.comparisonBubbles.eHandelLabel"),
         value: E_HANDEL_FRAN_UTLANDET_EMISSIONS,
-        color: "var(--orange-3)",
-        valueClassName: "text-orange-2",
+        fillColor: "var(--orange-3)",
       },
       {
         id: "municipality",
         label: comparisonMunicipality.name,
         value: comparisonMunicipality.value,
-        color: "var(--blue-2)",
-        valueClassName: "text-blue-2",
+        fillColor: "var(--blue-2)",
         href: `/municipalities/${encodeURIComponent(comparisonMunicipality.name)}`,
       },
     ];

--- a/src/components/nation/EmissionsComparisonBubbles.tsx
+++ b/src/components/nation/EmissionsComparisonBubbles.tsx
@@ -20,6 +20,7 @@ type BubbleItem = {
   label: string;
   value: number;
   color: string;
+  valueClassName: string;
   href?: string;
 };
 
@@ -29,6 +30,12 @@ function getBubbleDiameter(
   maxDiameter: number,
 ): number {
   return Math.sqrt(value / maxValue) * maxDiameter;
+}
+
+function getValueTextClass(diameter: number) {
+  if (diameter >= 240) return "text-2xl md:text-3xl";
+  if (diameter >= 200) return "text-xl md:text-2xl";
+  return "text-lg md:text-xl";
 }
 
 function ComparisonBubble({
@@ -42,41 +49,40 @@ function ComparisonBubble({
   const { currentLanguage } = useLanguage();
   const diameter = getBubbleDiameter(item.value, maxValue, MAX_BUBBLE_DIAMETER);
   const formattedValue = formatEmissionsAbsolute(item.value, currentLanguage);
-  const valueFontSize = Math.max(16, Math.min(diameter * 0.13, 34));
-  const labelFontSize = Math.max(12, Math.min(diameter * 0.08, 18));
 
   const bubble = (
     <div
       className={cn(
-        "rounded-full shrink-0 flex flex-col items-center justify-center gap-1 px-3 text-center",
+        "rounded-full shrink-0 flex flex-col items-center justify-center gap-2 px-4 text-center bg-black-2",
         item.href && "transition-transform hover:scale-[1.03]",
       )}
       style={{
         width: diameter,
         height: diameter,
-        background: item.color,
-        border: "2px solid var(--black-4)",
+        border: `2px solid ${item.color}`,
         boxShadow: "0 2px 4px var(--black-4)",
       }}
     >
-      <span
-        className="font-bold tabular-nums leading-none text-black"
-        style={{ fontSize: valueFontSize }}
+      <Text className="text-sm md:text-base font-light leading-snug">
+        {item.label}
+      </Text>
+      <Text
+        className={cn(
+          "font-light tracking-tighter tabular-nums leading-none",
+          getValueTextClass(diameter),
+          item.valueClassName,
+        )}
       >
         {formattedValue}
-      </span>
-      <span
-        className="font-bold leading-tight text-black"
-        style={{ fontSize: labelFontSize }}
-      >
-        {item.label}
-      </span>
+      </Text>
     </div>
   );
 
   return (
     <div className="flex flex-col items-center gap-1.5 px-1">
-      <Text className="text-sm font-bold text-black">{t("emissionsUnit")}</Text>
+      <Text variant="small" className="text-grey">
+        {t("emissionsUnit")}
+      </Text>
       {item.href ? (
         <LocalizedLink
           to={item.href}
@@ -115,12 +121,14 @@ export function EmissionsComparisonBubbles({ className }: { className?: string }
         label: t("nation.comparisonBubbles.eHandelLabel"),
         value: E_HANDEL_FRAN_UTLANDET_EMISSIONS,
         color: "var(--orange-3)",
+        valueClassName: "text-orange-2",
       },
       {
         id: "municipality",
         label: comparisonMunicipality.name,
         value: comparisonMunicipality.value,
         color: "var(--blue-2)",
+        valueClassName: "text-blue-2",
         href: `/municipalities/${encodeURIComponent(comparisonMunicipality.name)}`,
       },
     ];

--- a/src/components/nation/EmissionsComparisonBubbles.tsx
+++ b/src/components/nation/EmissionsComparisonBubbles.tsx
@@ -75,7 +75,7 @@ function ComparisonBubble({
   );
 
   return (
-    <div className="flex flex-col items-center gap-3 px-1">
+    <div className="flex flex-col items-center gap-1.5 px-1">
       <Text className="text-sm font-bold text-black">{t("emissionsUnit")}</Text>
       {item.href ? (
         <LocalizedLink
@@ -144,13 +144,17 @@ export function EmissionsComparisonBubbles({ className }: { className?: string }
   }
 
   return (
-    <SectionWithHelp helpItems={[]} className={className}>
+    <SectionWithHelp
+      helpItems={[]}
+      className={cn("[&>div:first-child]:pb-2 [&>div:first-child]:md:mb-2", className)}
+    >
       <CardHeader
         title={t("nation.comparisonBubbles.title")}
         description={t("nation.comparisonBubbles.description")}
+        className="[&>div]:mb-4 [&>div]:@lg:mb-6"
       />
 
-      <div className="flex flex-col sm:flex-row items-center justify-center gap-8 sm:gap-0 sm:-space-x-10">
+      <div className="flex flex-col sm:flex-row items-center justify-center gap-8 sm:gap-0 sm:-space-x-10 -mt-1">
         {bubbles.map((bubble) => (
           <ComparisonBubble key={bubble.id} item={bubble} maxValue={maxValue} />
         ))}

--- a/src/components/nation/EmissionsComparisonBubbles.tsx
+++ b/src/components/nation/EmissionsComparisonBubbles.tsx
@@ -155,7 +155,7 @@ export function EmissionsComparisonBubbles({ className }: { className?: string }
         className="[&>div]:mb-4 [&>div]:@lg:mb-6"
       />
 
-      <div className="flex flex-col sm:flex-row items-center justify-center gap-8 sm:gap-0 sm:-space-x-10 -mt-1">
+      <div className="flex flex-col sm:flex-row items-center justify-center gap-8 sm:gap-6 -mt-1">
         {bubbles.map((bubble) => (
           <ComparisonBubble key={bubble.id} item={bubble} maxValue={maxValue} />
         ))}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1455,6 +1455,12 @@
   "nation": {
     "detailPage": {
       "regions": "Regions"
+    },
+    "comparisonBubbles": {
+      "title": "How much is that?",
+      "description": "Sweden's emissions from e-commerce abroad (2025) compared to a municipality's estimated territorial emissions for the same year.",
+      "eHandelLabel": "e-handel",
+      "municipalityLabel": "{{municipality}}"
     }
   },
   "regions": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1457,8 +1457,8 @@
       "regions": "Regions"
     },
     "comparisonBubbles": {
-      "title": "How much is that?",
-      "description": "Sweden's emissions from e-commerce abroad (2025) compared to a municipality's estimated territorial emissions for the same year.",
+      "title": "Emissions from e-commerce abroad",
+      "description": "Sweden's emissions from e-commerce abroad (2025), stated in tonnes CO₂e (tCO₂e), compared to a municipality's estimated territorial emissions for the same year.",
       "eHandelLabel": "e-handel",
       "municipalityLabel": "{{municipality}}"
     }

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -1514,8 +1514,8 @@
       "regions": "Län"
     },
     "comparisonBubbles": {
-      "title": "Hur mycket är det?",
-      "description": "Sveriges utsläpp från e-handel från utlandet (2025) jämfört med en kommuns uppskattade territoriella utsläpp samma år.",
+      "title": "Utsläpp från e-handel från utlandet",
+      "description": "Sveriges utsläpp från e-handel från utlandet (2025), uppgivna i ton CO₂e (tCO₂e), jämfört med en kommuns uppskattade territoriella utsläpp samma år.",
       "eHandelLabel": "e-handel",
       "municipalityLabel": "{{municipality}}"
     }

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -1512,6 +1512,12 @@
   "nation": {
     "detailPage": {
       "regions": "Län"
+    },
+    "comparisonBubbles": {
+      "title": "Hur mycket är det?",
+      "description": "Sveriges utsläpp från e-handel från utlandet (2025) jämfört med en kommuns uppskattade territoriella utsläpp samma år.",
+      "eHandelLabel": "e-handel",
+      "municipalityLabel": "{{municipality}}"
     }
   },
   "regions": {

--- a/src/pages/NationDetailPage.tsx
+++ b/src/pages/NationDetailPage.tsx
@@ -6,6 +6,7 @@ import { DetailHeader } from "@/components/detail/DetailHeader";
 import { DetailWrapper } from "@/components/detail/DetailWrapper";
 import { SectorEmissionsChart } from "@/components/charts/sectorChart/SectorEmissions";
 import { EntityListBox } from "@/components/detail/EntityListBox";
+import { EmissionsComparisonBubbles } from "@/components/nation/EmissionsComparisonBubbles";
 import { useNationPageData } from "@/hooks/nation/useNationPageData";
 import { useLanguage } from "@/components/LanguageProvider";
 
@@ -39,6 +40,7 @@ function NationDetailContent({
         emissionsData={emissionsData}
         sectorEmissions={sectorEmissions}
       />
+      <EmissionsComparisonBubbles />
       <SectorEmissionsChart
         sectorEmissions={sectorEmissions}
         availableYears={availableYears}

--- a/src/utils/data/findClosestMunicipalityEmission.ts
+++ b/src/utils/data/findClosestMunicipalityEmission.ts
@@ -1,0 +1,57 @@
+import type { Municipality } from "@/types/municipality";
+
+export type ClosestMunicipalityEmission = {
+  name: string;
+  year: number;
+  value: number;
+};
+
+export function getEmissionForYear(
+  municipality: Municipality,
+  year: number,
+): number | null {
+  const point = municipality.approximatedHistoricalEmission.find(
+    (entry) => entry?.year === year,
+  );
+  return point?.value ?? null;
+}
+
+export function getMunicipalityEmissionByName(
+  municipalities: Municipality[],
+  name: string,
+  year: number,
+): ClosestMunicipalityEmission | null {
+  const municipality = municipalities.find((entry) => entry.name === name);
+  if (!municipality) return null;
+
+  const value = getEmissionForYear(municipality, year);
+  if (value === null) return null;
+
+  return { name: municipality.name, year, value };
+}
+
+export function findClosestMunicipalityEmission(
+  municipalities: Municipality[],
+  targetValue: number,
+  year: number,
+): ClosestMunicipalityEmission | null {
+  let closest: ClosestMunicipalityEmission | null = null;
+  let smallestDiff = Infinity;
+
+  for (const municipality of municipalities) {
+    const value = getEmissionForYear(municipality, year);
+    if (value === null) continue;
+
+    const diff = Math.abs(value - targetValue);
+    if (diff < smallestDiff) {
+      smallestDiff = diff;
+      closest = {
+        name: municipality.name,
+        year,
+        value,
+      };
+    }
+  }
+
+  return closest;
+}


### PR DESCRIPTION
### ✨ What's Changed?

Adds a comparison section on the nation detail page (`/nation`) with two proportional bubbles:

- **E-handel från utlandet** — 310,079 tCO₂e (2025)
- **Gävle** — territorial emissions from `approximatedHistoricalEmission` for 2025 (from municipalities API)

Includes Swedish/English copy with an updated title and description that states the unit (tCO₂e). Gävle's bubble links to its municipality page.

### 📸 Screenshots (if applicable)

<!-- Add before/after images or UI previews -->


### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [ ] I've verified the change runs locally both on mobile and desktop
- [ ] I've set the labels, issue, and milestone for the PR
- [ ] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #1488
