### PR TITLE
[feat] Add label-gated PR preview deploys to stage Garbo.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/general.md
+++ b/.github/PULL_REQUEST_TEMPLATE/general.md
@@ -7,6 +7,10 @@
 <!-- Add before/after images or UI previews -->
 
 
+### 🌐 PR preview (optional)
+
+Add the **`preview`** label to deploy this branch to `https://pr-<number>.stage.klimatkollen.se` (Garbo stage). See [`k8s/preview/README.md`](../../k8s/preview/README.md) for cluster setup.
+
 ### 📋 Checklist
 
 - [ ] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,189 @@
+name: PR Preview Deploy
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: klimatbyran/frontend
+  PREVIEW_DOMAIN: stage.klimatkollen.se
+  VITE_MAILCHIMP_URL: https://klimatkollen.us14.list-manage.com/subscribe/post?u=05a01ccba58f4e27fc277b621&amp;id=133270842a
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed, labeled, unlabeled]
+
+permissions:
+  contents: read
+  packages: write
+  pull-requests: write
+
+concurrency:
+  group: pr-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy preview
+    if: >
+      github.event.action != 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'preview')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set preview metadata
+        id: meta
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          SHORT_SHA="${{ github.event.pull_request.head.sha }}"
+          SHORT_SHA="${SHORT_SHA:0:7}"
+          IMAGE_TAG="pr-${PR_NUMBER}-${SHORT_SHA}"
+          PREVIEW_HOST="pr-${PR_NUMBER}.${PREVIEW_DOMAIN}"
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "image_tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "preview_host=${PREVIEW_HOST}" >> "$GITHUB_OUTPUT"
+          echo "preview_url=https://${PREVIEW_HOST}" >> "$GITHUB_OUTPUT"
+
+      - name: Login to container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push preview image
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.image_tag }}
+          build-args: |
+            VITE_MAILCHIMP_URL=${{ env.VITE_MAILCHIMP_URL }}
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Configure kubeconfig
+        run: |
+          mkdir -p "$HOME/.kube"
+          echo "${{ secrets.KUBE_CONFIG }}" | base64 -d > "$HOME/.kube/config"
+          chmod 600 "$HOME/.kube/config"
+
+      - name: Ensure preview namespace
+        run: kubectl apply -f k8s/preview/namespace.yaml
+
+      - name: Ensure shared backend service
+        run: kubectl apply -f k8s/preview/backend-service.yaml
+
+      - name: Render and apply preview manifests
+        env:
+          PR_NUMBER: ${{ steps.meta.outputs.pr_number }}
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.image_tag }}
+          PREVIEW_HOST: ${{ steps.meta.outputs.preview_host }}
+        run: |
+          chmod +x k8s/preview/render.sh
+          k8s/preview/render.sh | kubectl apply -f -
+          kubectl rollout status deployment/frontend-pr-${PR_NUMBER} \
+            -n frontend-preview \
+            --timeout=300s
+
+      - name: Comment preview URL on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const previewUrl = "${{ steps.meta.outputs.preview_url }}";
+            const imageTag = "${{ steps.meta.outputs.image_tag }}";
+            const marker = "<!-- pr-preview-deploy -->";
+            const body = [
+              marker,
+              "### PR preview",
+              "",
+              `**URL:** ${previewUrl}`,
+              "",
+              `**Image:** \`ghcr.io/klimatbyran/frontend:${imageTag}\``,
+              "",
+              "Uses **Garbo stage** (`garbo.garbo-stage`). Add the `preview` label to redeploy; remove the label or close the PR to tear down.",
+            ].join("\n");
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const existing = comments.find((c) =>
+              c.user.type === "Bot" && c.body.includes(marker),
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }
+
+  cleanup:
+    name: Remove preview
+    if: >
+      github.event.action == 'closed' ||
+      (github.event.action == 'unlabeled' && github.event.label.name == 'preview')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Configure kubeconfig
+        run: |
+          mkdir -p "$HOME/.kube"
+          echo "${{ secrets.KUBE_CONFIG }}" | base64 -d > "$HOME/.kube/config"
+          chmod 600 "$HOME/.kube/config"
+
+      - name: Delete preview resources
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          kubectl delete deployment,service,ingress \
+            -n frontend-preview \
+            -l "preview-pr=${PR_NUMBER}" \
+            --ignore-not-found=true
+          kubectl delete secret "frontend-pr-${PR_NUMBER}-tls" \
+            -n frontend-preview \
+            --ignore-not-found=true
+
+      - name: Comment preview removed
+        if: github.event.action == 'closed' || github.event.action == 'unlabeled'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const marker = "<!-- pr-preview-deploy -->";
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const existing = comments.find((c) =>
+              c.user.type === "Bot" && c.body.includes(marker),
+            );
+            if (existing) {
+              await github.rest.issues.deleteComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+              });
+            }

--- a/k8s/preview/README.md
+++ b/k8s/preview/README.md
@@ -1,0 +1,62 @@
+# PR preview environments
+
+Pull requests labeled **`preview`** get a temporary frontend deployment at:
+
+`https://pr-<number>.stage.klimatkollen.se`
+
+The preview uses the same **Garbo stage** API as `stage.klimatkollen.se` (`garbo.garbo-stage.svc.cluster.local`).
+
+Deployment is handled by [`.github/workflows/pr-preview.yml`](../../.github/workflows/pr-preview.yml). Removing the `preview` label or closing the PR deletes the preview resources.
+
+## One-time cluster setup
+
+### 1. GitHub Actions secret
+
+Add repository secret **`KUBE_CONFIG`**: base64-encoded kubeconfig for a service account that can create/update/delete resources in namespace `frontend-preview`.
+
+```bash
+cat ~/.kube/config | base64 | pbcopy   # macOS; paste into GitHub → Settings → Secrets
+```
+
+### 2. Namespace and API key secret
+
+```bash
+kubectl apply -f k8s/preview/namespace.yaml
+kubectl apply -f k8s/preview/backend-service.yaml
+
+# Copy the same env secret used by staging (Garbo API key for nginx proxy)
+kubectl get secret env -n frontend-stage -o yaml \
+  | sed 's/namespace: frontend-stage/namespace: frontend-preview/' \
+  | kubectl apply -f -
+```
+
+### 3. DNS
+
+Point wildcard hostnames at your ingress load balancer (same target as `stage.klimatkollen.se`):
+
+| Record | Example |
+|--------|---------|
+| `*.stage.klimatkollen.se` | `pr-42.stage.klimatkollen.se` |
+
+cert-manager issues a certificate per preview host via the `letsencrypt-prod` cluster issuer (HTTP-01), same as staging.
+
+### 4. GitHub label
+
+Create label **`preview`** in the repository (Issues → Labels → New label).
+
+## Usage
+
+1. Open a PR from a branch in **this repository** (fork PRs are skipped for security).
+2. Add the **`preview`** label.
+3. Wait for the **PR Preview Deploy** workflow; a bot comment will link the URL.
+4. Push new commits — the preview redeploys while the label remains.
+5. Remove the label or merge/close the PR to tear down.
+
+## Manual render (debugging)
+
+```bash
+export PR_NUMBER=42
+export IMAGE=ghcr.io/klimatbyran/frontend:pr-42-abc1234
+export PREVIEW_HOST=pr-42.stage.klimatkollen.se
+./k8s/preview/render.sh | kubectl apply -f -
+```

--- a/k8s/preview/backend-service.yaml
+++ b/k8s/preview/backend-service.yaml
@@ -1,0 +1,18 @@
+# Shared Garbo stage API proxy for all PR previews in this namespace.
+# Apply once with namespace.yaml (see k8s/preview/README.md).
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  namespace: frontend-preview
+  labels:
+    app.kubernetes.io/name: frontend-preview
+    app.kubernetes.io/component: backend
+spec:
+  type: ExternalName
+  externalName: garbo.garbo-stage.svc.cluster.local
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+      name: http

--- a/k8s/preview/manifest.template.yaml
+++ b/k8s/preview/manifest.template.yaml
@@ -1,0 +1,102 @@
+# Rendered per PR by k8s/preview/render.sh — do not apply this file directly.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend-pr-__PR_NUMBER__
+  namespace: frontend-preview
+  labels:
+    app: frontend-preview
+    preview-pr: "__PR_NUMBER__"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: frontend-preview
+      preview-pr: "__PR_NUMBER__"
+  template:
+    metadata:
+      labels:
+        app: frontend-preview
+        preview-pr: "__PR_NUMBER__"
+    spec:
+      containers:
+        - name: frontend
+          image: __IMAGE__
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 80
+              name: http
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          env:
+            - name: VITE_NODE_ENV
+              value: "staging"
+            - name: GARBO_ALL_ACCESS_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: env
+                  key: GARBO_ALL_ACCESS_API_KEY
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend-pr-__PR_NUMBER__
+  namespace: frontend-preview
+  labels:
+    app: frontend-preview
+    preview-pr: "__PR_NUMBER__"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+      name: http
+  selector:
+    app: frontend-preview
+    preview-pr: "__PR_NUMBER__"
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: frontend-pr-__PR_NUMBER__
+  namespace: frontend-preview
+  labels:
+    app: frontend-preview
+    preview-pr: "__PR_NUMBER__"
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - __PREVIEW_HOST__
+      secretName: frontend-pr-__PR_NUMBER__-tls
+  rules:
+    - host: __PREVIEW_HOST__
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend-pr-__PR_NUMBER__
+                port:
+                  number: 80

--- a/k8s/preview/namespace.yaml
+++ b/k8s/preview/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: frontend-preview
+  labels:
+    app.kubernetes.io/name: frontend-preview
+    app.kubernetes.io/component: pr-preview

--- a/k8s/preview/render.sh
+++ b/k8s/preview/render.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Renders k8s/preview/manifest.template.yaml for a single PR preview environment.
+set -euo pipefail
+
+PR_NUMBER="${PR_NUMBER:?PR_NUMBER is required}"
+IMAGE="${IMAGE:?IMAGE is required}"
+PREVIEW_HOST="${PREVIEW_HOST:?PREVIEW_HOST is required}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEMPLATE="${SCRIPT_DIR}/manifest.template.yaml"
+
+sed \
+  -e "s|__PR_NUMBER__|${PR_NUMBER}|g" \
+  -e "s|__IMAGE__|${IMAGE}|g" \
+  -e "s|__PREVIEW_HOST__|${PREVIEW_HOST}|g" \
+  "${TEMPLATE}"


### PR DESCRIPTION
Deploy pr-<n>.stage.klimatkollen.se when a PR has the preview label; document one-time cluster setup and update the PR template.

@kaylawoodbury @CarlWiren90 investigated a bit after our discussion today, found this as a possible way forward if we want to deploy certain PRs in order to enable review without running things locally/merging to stage. Thoughts?