### PR TITLE
[fix] remove failing audit from pre push

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,2 +1,1 @@
 npm run format-prettier
-npm audit --omit=dev


### PR DESCRIPTION
### ✨ What’s Changed?

Remove failing audit from pre push. Turns out it's not a great idea to have it in the pre push when breaking changes happen