### PR TITLE
[1031] Implement route and image lazy loading

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,14 @@
+import { Suspense } from "react";
+import { PageLoading } from "@/components/pageStates/Loading";
 import { ToastProvider } from "./contexts/ToastContext";
 import { AppRoutes } from "./routes";
 
 function App() {
   return (
     <ToastProvider>
-      <AppRoutes />
+      <Suspense fallback={<PageLoading />}>
+        <AppRoutes />
+      </Suspense>
     </ToastProvider>
   );
 }

--- a/src/components/MembersGrid.tsx
+++ b/src/components/MembersGrid.tsx
@@ -25,6 +25,7 @@ export function MembersGrid({ members }: MembersGridProps) {
                 src={member.imageUrl}
                 alt={member.name}
                 className="w-16 h-16 rounded-full object-cover mb-2"
+                loading="lazy"
               />
               <div>
                 <Text variant="body">{member.name}</Text>

--- a/src/components/companies/CompanyLogo.tsx
+++ b/src/components/companies/CompanyLogo.tsx
@@ -42,6 +42,7 @@ export function CompanyLogo({ src, className }: CompanyLogoProps) {
         alt=""
         className={className + (padding ? " p-1" : "")}
         crossOrigin="anonymous"
+        loading="lazy"
         style={{
           backgroundColor: `rgba(${backgroundColor.r}, ${backgroundColor.g}, ${backgroundColor.b}, ${backgroundColor.a / 255})`,
         }}
@@ -58,6 +59,7 @@ export function CompanyLogo({ src, className }: CompanyLogoProps) {
         src={url.toString()}
         alt=""
         className={className + " bg-white p-1"}
+        loading="lazy"
       />
     );
   }

--- a/src/components/layout/ContentCard.tsx
+++ b/src/components/layout/ContentCard.tsx
@@ -34,6 +34,7 @@ export function ContentCard({ item, basePath }: ContentCardProps) {
           src={item.image}
           alt={item.title}
           className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
+          loading="lazy"
         />
       </div>
       <div className="p-8 space-y-4">

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -22,6 +22,7 @@ function SocialLinks() {
               src={Icon}
               alt={title}
               className="h-5 w-5 opacity-80 transition-opacity duration-300 group-hover:opacity-100"
+              loading="lazy"
             />
           ) : (
             <Icon

--- a/src/components/learnMore/LearnMoreCard.tsx
+++ b/src/components/learnMore/LearnMoreCard.tsx
@@ -23,6 +23,7 @@ export function LearnMoreCard({
           src={article.image}
           alt={t(article.titleKey)}
           className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
+          loading="lazy"
         />
       </div>
       <div className="p-8 space-y-4">

--- a/src/hooks/useListCardHeader.tsx
+++ b/src/hooks/useListCardHeader.tsx
@@ -27,7 +27,12 @@ export function useListCardHeader({
 
   const logo = logoUrl ? (
     isMunicipality || isRegion ? (
-      <img src={logoUrl} alt="logo" className="h-[50px]" />
+      <img
+        src={logoUrl}
+        alt="logo"
+        className="h-[50px]"
+        loading="lazy"
+      />
     ) : (
       <CompanyLogo
         src={logoUrl}

--- a/src/lazyPages.ts
+++ b/src/lazyPages.ts
@@ -1,0 +1,134 @@
+import { lazy } from "react";
+
+export const AboutPage = lazy(() =>
+  import("./pages/AboutPage").then((m) => ({ default: m.AboutPage })),
+);
+export const BlogDetailPage = lazy(() =>
+  import("./pages/BlogDetailPage").then((m) => ({ default: m.BlogDetailPage })),
+);
+export const CompanyEditPage = lazy(() =>
+  import("./pages/CompanyEditPage").then((m) => ({
+    default: m.CompanyEditPage,
+  })),
+);
+export const CompanyDetailPage = lazy(() =>
+  import("./pages/CompanyDetailPage").then((m) => ({
+    default: m.CompanyDetailPage,
+  })),
+);
+export const SectorsOverviewPage = lazy(() =>
+  import("./pages/SectorsOverviewPage").then((m) => ({
+    default: m.SectorsOverviewPage,
+  })),
+);
+export const DownloadsPage = lazy(() => import("./pages/DownloadsPage"));
+export const ErrorPage = lazy(() =>
+  import("./pages/ErrorPage").then((m) => ({ default: m.ErrorPage })),
+);
+export const InsightsPage = lazy(() =>
+  import("./pages/InsightsPage").then((m) => ({ default: m.InsightsPage })),
+);
+export const LearnMoreOverview = lazy(() =>
+  import("./pages/LearnMoreOverview").then((m) => ({
+    default: m.LearnMoreOverview,
+  })),
+);
+export const LearnMoreArticle = lazy(() =>
+  import("./pages/LearnMoreArticle").then((m) => ({
+    default: m.LearnMoreArticle,
+  })),
+);
+export const MethodsPage = lazy(() =>
+  import("./pages/MethodsPage").then((m) => ({ default: m.MethodsPage })),
+);
+export const MunicipalitiesOverviewPage = lazy(() =>
+  import("./pages/MunicipalitiesOverviewPage").then((m) => ({
+    default: m.MunicipalitiesOverviewPage,
+  })),
+);
+export const MunicipalityDetailPage = lazy(() =>
+  import("./pages/MunicipalityDetailPage").then((m) => ({
+    default: m.MunicipalityDetailPage,
+  })),
+);
+export const NotFoundPage = lazy(() =>
+  import("./pages/NotFoundPage").then((m) => ({ default: m.NotFoundPage })),
+);
+export const ReportsPage = lazy(() =>
+  import("./pages/ReportsPage").then((m) => ({ default: m.ReportsPage })),
+);
+export const PrivacyPage = lazy(() =>
+  import("./pages/PrivacyPage").then((m) => ({ default: m.PrivacyPage })),
+);
+export const DataDownloadPage = lazy(() => import("./pages/DataDownloadPage"));
+export const UnauthorizedErrorPage = lazy(() =>
+  import("./pages/error/UnauthorizedErrorPage").then((m) => ({
+    default: m.UnauthorizedErrorPage,
+  })),
+);
+export const SupportPage = lazy(() =>
+  import("./pages/SupportPage").then((m) => ({ default: m.SupportPage })),
+);
+export const ValidationDashboard = lazy(() =>
+  import("./pages/internal-pages/ValidationDashboard").then((m) => ({
+    default: m.ValidationDashboard,
+  })),
+);
+export const InternalDashboard = lazy(() =>
+  import("./pages/internal-pages/InternalDashboard").then((m) => ({
+    default: m.InternalDashboard,
+  })),
+);
+export const ReportLandingPage = lazy(() =>
+  import("./pages/ReportLandingPage").then((m) => ({
+    default: m.ReportLandingPage,
+  })),
+);
+export const RequestsDashboard = lazy(() =>
+  import("./pages/internal-pages/RequestsDashboard").then((m) => ({
+    default: m.RequestsDashboard,
+  })),
+);
+export const TrendAnalysisDashboard = lazy(() =>
+  import("./pages/internal-pages/TrendAnalysisDashboard").then((m) => ({
+    default: m.TrendAnalysisDashboard,
+  })),
+);
+export const ParisAlignedStatisticsPage = lazy(() =>
+  import("./pages/internal-pages/ParisAlignedStatisticsPage").then((m) => ({
+    default: m.ParisAlignedStatisticsPage,
+  })),
+);
+export const AddCompanyPage = lazy(() =>
+  import("./pages/internal-pages/AddCompanyPage").then((m) => ({
+    default: m.AddCompanyPage,
+  })),
+);
+export const NewsLetterArchivePage = lazy(() =>
+  import("./pages/NewslettersPage").then((m) => ({
+    default: m.NewsLetterArchivePage,
+  })),
+);
+export const RegionalOverviewPage = lazy(() =>
+  import("./pages/RegionalOverviewPage").then((m) => ({
+    default: m.RegionalOverviewPage,
+  })),
+);
+export const RegionDetailPage = lazy(() =>
+  import("./pages/RegionDetailPage").then((m) => ({
+    default: m.RegionDetailPage,
+  })),
+);
+export const NationDetailPage = lazy(() =>
+  import("./pages/NationDetailPage").then((m) => ({
+    default: m.NationDetailPage,
+  })),
+);
+export const CompaniesOverviewPage = lazy(() =>
+  import("./pages/CompaniesOverviewPage").then((m) => ({
+    default: m.CompaniesOverviewPage,
+  })),
+);
+export const ExplorePage = lazy(() =>
+  import("./pages/ExplorePage").then((m) => ({ default: m.ExplorePage })),
+);

--- a/src/pages/BlogDetailPage.tsx
+++ b/src/pages/BlogDetailPage.tsx
@@ -145,6 +145,7 @@ export function BlogDetailPage() {
             src={blogPost.metadata.author.avatar}
             alt={blogPost.metadata.author.name}
             className="w-16 h-16 rounded-full object-cover"
+            loading="lazy"
           />
           <div>
             <Text variant="body">{blogPost.metadata.author.name}</Text>
@@ -162,6 +163,7 @@ export function BlogDetailPage() {
               <img
                 {...props}
                 className="w-2/3 mx-auto shadow-lg !rounded-lg !overflow-hidden"
+                loading="lazy"
               />
             ),
             a: ({ node, ...props }) => (
@@ -213,6 +215,7 @@ export function BlogDetailPage() {
                         src={post.image}
                         alt={post.title}
                         className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
+                        loading="lazy"
                       />
                     </div>
                     <div className="p-8 space-y-4">

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -6,40 +6,42 @@ import StagingProtectedRoute from "./components/StagingProtectedRoute";
 // Wrap the route(s) in <Route element={<StagingProtectedRoute />}> and nest your path(s) inside.
 // When ready for prod, remove the wrapper. Keep this import so dead-code scripts don't remove the component.
 import { useLanguage } from "./components/LanguageProvider";
-import { AboutPage } from "./pages/AboutPage";
+import {
+  AboutPage,
+  AddCompanyPage,
+  BlogDetailPage,
+  CompaniesOverviewPage,
+  CompanyDetailPage,
+  CompanyEditPage,
+  DataDownloadPage,
+  DownloadsPage,
+  ErrorPage,
+  ExplorePage,
+  InsightsPage,
+  InternalDashboard,
+  LearnMoreArticle,
+  LearnMoreOverview,
+  MethodsPage,
+  MunicipalitiesOverviewPage,
+  MunicipalityDetailPage,
+  NationDetailPage,
+  NewsLetterArchivePage,
+  NotFoundPage,
+  ParisAlignedStatisticsPage,
+  PrivacyPage,
+  RegionalOverviewPage,
+  RegionDetailPage,
+  ReportLandingPage,
+  ReportsPage,
+  RequestsDashboard,
+  SectorsOverviewPage,
+  SupportPage,
+  TrendAnalysisDashboard,
+  UnauthorizedErrorPage,
+  ValidationDashboard,
+} from "./lazyPages";
 import { AuthCallback } from "./pages/AuthCallback";
-import { BlogDetailPage } from "./pages/BlogDetailPage";
-import { CompanyEditPage } from "./pages/CompanyEditPage";
-import { CompanyDetailPage } from "./pages/CompanyDetailPage";
-import { SectorsOverviewPage } from "./pages/SectorsOverviewPage";
-import DownloadsPage from "./pages/DownloadsPage";
-import { ErrorPage } from "./pages/ErrorPage";
-import { InsightsPage } from "./pages/InsightsPage";
 import { LandingPage } from "./pages/LandingPage";
-import { LearnMoreOverview } from "./pages/LearnMoreOverview";
-import { LearnMoreArticle } from "./pages/LearnMoreArticle";
-import { MethodsPage } from "./pages/MethodsPage";
-import { MunicipalitiesOverviewPage } from "./pages/MunicipalitiesOverviewPage";
-import { MunicipalityDetailPage } from "./pages/MunicipalityDetailPage";
-import { NotFoundPage } from "./pages/NotFoundPage";
-import { ReportsPage } from "./pages/ReportsPage";
-import { PrivacyPage } from "./pages/PrivacyPage";
-import DataDownloadPage from "./pages/DataDownloadPage";
-import { UnauthorizedErrorPage } from "./pages/error/UnauthorizedErrorPage";
-import { SupportPage } from "./pages/SupportPage";
-import { ValidationDashboard } from "./pages/internal-pages/ValidationDashboard";
-import { InternalDashboard } from "./pages/internal-pages/InternalDashboard";
-import { ReportLandingPage } from "./pages/ReportLandingPage";
-import { RequestsDashboard } from "./pages/internal-pages/RequestsDashboard";
-import { TrendAnalysisDashboard } from "./pages/internal-pages/TrendAnalysisDashboard";
-import { ParisAlignedStatisticsPage } from "./pages/internal-pages/ParisAlignedStatisticsPage";
-import { AddCompanyPage } from "./pages/internal-pages/AddCompanyPage";
-import { NewsLetterArchivePage } from "./pages/NewslettersPage";
-import { RegionalOverviewPage } from "./pages/RegionalOverviewPage";
-import { RegionDetailPage } from "./pages/RegionDetailPage";
-import { NationDetailPage } from "./pages/NationDetailPage";
-import { CompaniesOverviewPage } from "./pages/CompaniesOverviewPage";
-import { ExplorePage } from "./pages/ExplorePage";
 
 void StagingProtectedRoute; // referenced so dead-code scripts keep the component; eslint/ts unused-import satisfied
 


### PR DESCRIPTION
### ✨ What’s Changed?

Split page routes into lazy-loaded chunks and defer below-the-fold images so users only download code and media when needed.

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [x] I've set the labels, issue, and milestone for the PR
- [ ] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #1031