### PR TITLE
[#1406] Update emission types copy on methodology page

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -703,12 +703,12 @@
       "emissionTypes": {
         "title": "Different Types of Emissions",
         "description": "Learn about the various types of emissions and how they are measured",
-        "paragraph1": "Klimatkollen is an independent fact-based platform that follows established standards for emissions reporting. The climate data we present reflects the boundaries and assumptions used in carbon budget calculations. For example, carbon budgets cannot be directly linked to all greenhouse gas emissions, as other gases like methane, nitrous oxide, and water vapour are also included in overall climate impact assessments.",
-        "paragraph2": "Emissions from cement production are excluded from the IPCC's global carbon budget and, as a result, are also omitted from Sweden's carbon budget and emissions data. This specifically affects the municipalities of Gotland, Skövde, and Mörbylånga, where cement production is currently or has previously taken place.",
-        "paragraph3": "Sweden also has a significant climate impact from goods imported from other countries, leading to emissions abroad. These consumption-based emissions are not included in the carbon budget.",
-        "paragraph4": "Similarly, emissions from forests and land (known as biogenic emissions) are also excluded from the carbon budget.",
-        "paragraph5": "In reality, climate-impacting emissions are much higher than the territorial fossil carbon emissions typically reported by authorities and the media. The data currently displayed on Klimatkollen reflects these territorial emissions.",
-        "paragraph6": "Klimatkollen is actively exploring how to incorporate other greenhouse gas emissions on the website in the future, while maintaining the ability to compare current emissions with carbon budgets."
+        "paragraph1": "Klimatkollen is an independent fact-based platform that follows established standards for emissions reporting. The climate data we present reflects the boundaries used in official territorial emissions inventories. For municipalities and regions, we show emissions of all greenhouse gases (CO₂e) — including gases such as methane and nitrous oxide — sourced from SMHI's National Emissions Database.",
+        "paragraph2": "Some municipalities have unusually high emissions due to large industrial facilities, including cement production. This particularly affects municipalities such as Gotland, Skövde, and Mörbylånga, where cement production currently takes place or has taken place historically.",
+        "paragraph3": "Sweden also has a significant climate impact from goods imported from other countries, leading to emissions abroad. These consumption-based emissions are not included in territorial emissions totals, but we show them separately as a key indicator where data is available.",
+        "paragraph4": "Similarly, emissions and removals from forests and land (known as biogenic emissions) are reported separately and are not included in the territorial greenhouse gas totals shown on Klimatkollen.",
+        "paragraph5": "In reality, a municipality's full climate footprint is often larger than its territorial emissions alone suggest. The data currently displayed on Klimatkollen reflects territorial emissions — those that physically occur within each municipality's or region's borders.",
+        "paragraph6": "We compare territorial emissions against the Paris-aligned reduction rate defined by Carbon Law (approximately 12% per year from 2025). Klimatkollen continues to explore how to present a more complete picture of climate impact on the platform."
       }
     },
     "company": {

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -762,12 +762,12 @@
       "emissionTypes": {
         "title": "Olika typer av utsläpp",
         "description": "Lär dig om olika typer av utsläpp och hur de mäts",
-        "paragraph1": "Klimatkollen är en oberoende faktabaserad plattform som följer etablerade standarder för utsläppsrapportering. Klimatdata vi presenterar speglar de gränser och antaganden som används i koldioxidbudgetberäkningar. Till exempel kan koldioxidbudgetar inte direkt kopplas till alla växthusgasutsläpp, eftersom andra gaser som metan, lustgas och vattenånga också ingår i klimatpåverkan.",
-        "paragraph2": "Utsläpp från cementproduktion exkluderas från IPCC:s globala koldioxidbudget och är därför också utelämnade från Sveriges koldioxidbudget och utsläppsdata. Detta påverkar särskilt kommunerna Gotland, Skövde och Mörbylånga där cementproduktion förekommer eller har förekommit.",
-        "paragraph3": "Sverige har också en betydande klimatpåverkan från varor som importeras från andra länder, vilket leder till utsläpp utomlands. Dessa konsumtionsbaserade utsläpp ingår inte i koldioxidbudgeten.",
-        "paragraph4": "På samma sätt exkluderas utsläpp från skog och mark (så kallade biogena utsläpp) från koldioxidbudgeten.",
-        "paragraph5": "I verkligheten är klimatpåverkande utsläpp mycket högre än de territoriella fossila koldioxidutsläpp som vanligtvis rapporteras av myndigheter och media. Den data som visas på Klimatkollen speglar dessa territoriella utsläpp.",
-        "paragraph6": "Klimatkollen undersöker aktivt hur andra växthusgasutsläpp kan inkluderas på webbplatsen i framtiden, samtidigt som möjligheten att jämföra nuvarande utsläpp med koldioxidbudgetar behålls."
+        "paragraph1": "Klimatkollen är en oberoende faktabaserad plattform som följer etablerade standarder för utsläppsrapportering. Den klimatdata vi presenterar speglar de avgränsningar som används i officiella territoriella utsläppsinventeringar. För kommuner och län visar vi utsläpp av alla växthusgaser (CO₂e) — inklusive gaser som metan och lustgas — från SMHI:s Nationella emissionsdatabas.",
+        "paragraph2": "Vissa kommuner har ovanligt höga utsläpp på grund av stora industriella anläggningar, inklusive cementproduktion. Detta påverkar särskilt kommuner som Gotland, Skövde och Mörbylånga, där cementproduktion pågår eller har pågått historiskt.",
+        "paragraph3": "Sverige har också en betydande klimatpåverkan från varor som importeras från andra länder, vilket leder till utsläpp utomlands. Dessa konsumtionsbaserade utsläpp ingår inte i de territoriella utsläppssummorna, men vi visar dem separat som ett nyckeltal där data finns tillgänglig.",
+        "paragraph4": "På samma sätt rapporteras utsläpp och upptag från skog och mark (så kallade biogena utsläpp) separat och ingår inte i de territoriella växthusgasutsläpp som visas på Klimatkollen.",
+        "paragraph5": "I verkligheten är en kommuns fulla klimatavtryck ofta större än vad de territoriella utsläppen ensamma antyder. Den data som visas på Klimatkollen speglar territoriella utsläpp — det vill säga utsläpp som fysiskt sker inom respektive kommuns eller längräns.",
+        "paragraph6": "Vi jämför territoriella utsläpp med den Parisanpassade minskningstakt som definieras av Carbon Law (cirka 12 % per år från 2025). Klimatkollen fortsätter att utforska hur vi kan presentera en mer fullständig bild av klimatpåverkan på plattformen."
       }
     },
     "company": {


### PR DESCRIPTION
### ✨ What's Changed?

- Updates the **Different Types of Emissions** copy on the methodology page to reflect current territorial emissions methodology.
- Replaces outdated carbon budget references with SMHI-sourced territorial CO₂e reporting and Carbon Law alignment language.
- Updates both English and Swedish locale files.

### 📸 Screenshots (if applicable)

N/A — copy-only changes.

### 📋 Checklist

- [x] PR title starts with issue number prefix
- [ ] I've verified the change runs locally both on mobile and desktop
- [x] I've set the labels, issue, and milestone for the PR
- [ ] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #1406

### Test plan

- [ ] Open `/en/methodology?view=emissionTypes` and verify the updated copy
- [ ] Open `/sv/methodology?view=emissionTypes` and verify the Swedish translation
