### PR TITLE
[Change]: Generation of API-types to match new id property from BE

### DIFF
--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -225,6 +225,8 @@ export interface paths {
                     };
                     content: {
                         "application/json": {
+                            /** Format: uuid */
+                            id: string;
                             wikidataId: string;
                             name: string;
                             lei?: string | null;
@@ -412,6 +414,8 @@ export interface paths {
                     };
                     content: {
                         "application/json": {
+                            /** Format: uuid */
+                            id: string;
                             wikidataId: string;
                             name: string;
                             lei?: string | null;
@@ -599,6 +603,8 @@ export interface paths {
                     };
                     content: {
                         "application/json": {
+                            /** Format: uuid */
+                            id: string;
                             wikidataId: string;
                             name: string;
                             lei?: string | null;
@@ -1148,6 +1154,8 @@ export interface paths {
                     };
                     content: {
                         "application/json": {
+                            /** Format: uuid */
+                            id: string;
                             wikidataId: string;
                             name: string;
                             lei?: string | null;
@@ -1335,6 +1343,8 @@ export interface paths {
                     };
                     content: {
                         "application/json": {
+                            /** Format: uuid */
+                            id: string;
                             wikidataId: string;
                             name: string;
                             lei?: string | null;
@@ -1520,6 +1530,8 @@ export interface paths {
                     };
                     content: {
                         "application/json": {
+                            /** Format: uuid */
+                            id: string;
                             name: string;
                             wikidataId: string;
                             reportingPeriods: {
@@ -1642,6 +1654,8 @@ export interface paths {
                     };
                     content: {
                         "application/json": {
+                            /** Format: uuid */
+                            id: string;
                             wikidataId: string;
                             name: string;
                             lei?: string | null;
@@ -3198,6 +3212,8 @@ export interface paths {
                     content: {
                         "application/json": {
                             name: string;
+                            /** Format: uuid */
+                            id?: string;
                             wikidataId?: string;
                             /** @enum {string} */
                             type: "company" | "municipality" | "region" | "nation";


### PR DESCRIPTION
### ✨ What’s Changed?

This pull request updates the OpenAPI type definitions in `src/lib/api-types.ts` to explicitly document the presence and format of `id` fields in several API response schemas. The main improvement is the addition of the `id` property, annotated as a UUID, to various response objects, enhancing type safety and API contract clarity.

Key changes to API type definitions:

**Addition of `id` fields with UUID format:**

* Added an `id: string` property (with `/** Format: uuid */` annotation) to the `application/json` response schema for multiple endpoints, ensuring each entity's identifier is explicitly typed and documented. 

**Optional `id` field in some schemas:**

* Added an optional `id?: string` field (with UUID format annotation) to a response object, supporting cases where the identifier may not always be present.

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [x] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)
