### PR TITLE
[fix] Use the same colors in the ranked lists and visualizations

### DIFF
--- a/src/components/companies/rankedList/CompanyInsightsPanel.tsx
+++ b/src/components/companies/rankedList/CompanyInsightsPanel.tsx
@@ -7,6 +7,7 @@ import {
 import { getSortedEntityKPIValues } from "@/utils/data/sorting";
 import {
   calculateEntityStatistics,
+  createDefaultColorGetter,
   createSourceLinks,
   buildPerformerProps,
   TOP_N,
@@ -80,6 +81,15 @@ function CompanyInsightsPanel({
     { key: selectedKPI.key, unit, isBoolean: selectedKPI.isBoolean },
   );
 
+  const colorItem = selectedKPI.createKPIColorGetter
+    ? selectedKPI.createKPIColorGetter(companyData)
+    : createDefaultColorGetter(
+        companyData,
+        selectedKPI.key,
+        selectedKPI.isBoolean,
+        selectedKPI.higherIsBetter,
+      );
+
   const statsPanel = (
     <KPIDetailsPanel
       title={selectedKPI.label}
@@ -139,6 +149,7 @@ function CompanyInsightsPanel({
       entityType="companies"
       nameKey="name"
       showBars
+      colorItem={colorItem}
     />
   ) : (
     booleanSummary
@@ -158,6 +169,7 @@ function CompanyInsightsPanel({
       entityType="companies"
       nameKey="name"
       showBars
+      colorItem={colorItem}
     />
   ) : null;
 

--- a/src/components/companies/rankedList/CompanyInsightsPanel.tsx
+++ b/src/components/companies/rankedList/CompanyInsightsPanel.tsx
@@ -144,8 +144,6 @@ function CompanyInsightsPanel({
       dataPointKey={selectedKPI.key}
       unit={selectedKPI.unit}
       nullValues={selectedKPI.nullValues}
-      textColor="text-blue-3"
-      barColor={COLORS.blue3}
       entityType="companies"
       nameKey="name"
       showBars
@@ -164,8 +162,6 @@ function CompanyInsightsPanel({
       dataPointKey={selectedKPI.key}
       unit={selectedKPI.unit}
       nullValues={selectedKPI.nullValues}
-      textColor="text-pink-3"
-      barColor={COLORS.pink3}
       entityType="companies"
       nameKey="name"
       showBars

--- a/src/components/companies/rankedList/visualizations/MeetsParisVisualization.tsx
+++ b/src/components/companies/rankedList/visualizations/MeetsParisVisualization.tsx
@@ -1,25 +1,19 @@
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { CompanyWithKPIs } from "@/hooks/companies/useCompanyKPIs";
-import { calculateTrendline } from "@/lib/calculations/trends/analysis";
-import { calculateCarbonBudgetTonnes } from "@/utils/calculations/carbonBudget";
-import { createFixedRangeGradient } from "@/utils/ui/colorGradients";
 import { getBestUnit } from "@/utils/data/unitScaling";
 import { calculateCapThreshold } from "@/utils/data/capping";
 import { useScreenSize } from "@/hooks/useScreenSize";
-import type { ColorFunction } from "@/types/visualizations";
 import { getCompanyUrlSegment } from "@/utils/companyRouting";
 import { BeeswarmChart } from "./shared/BeeswarmChart";
+import {
+  createBudgetColorFunction,
+  getCompanyBudgetData,
+} from "@/utils/company/companyKPIUtils";
 
 interface MeetsParisVisualizationProps {
   companies: CompanyWithKPIs[];
   onCompanyClick?: (company: CompanyWithKPIs) => void;
-}
-
-interface CompanyBudgetData {
-  company: CompanyWithKPIs;
-  budgetTonnes: number;
-  meetsParis: boolean | null;
 }
 
 export function MeetsParisVisualization({
@@ -31,41 +25,7 @@ export function MeetsParisVisualization({
 
   // Calculate budget data and basic statistics
   const { companyBudgetData, noBudgetCompanies, minRaw, maxRaw, budgetValues } =
-    useMemo(() => {
-      const withBudget: CompanyBudgetData[] = [];
-      const withoutBudget: CompanyWithKPIs[] = [];
-
-      companies.forEach((company) => {
-        const trendAnalysis = calculateTrendline(company);
-        const budgetTonnes = calculateCarbonBudgetTonnes(
-          company,
-          trendAnalysis,
-        );
-
-        if (budgetTonnes === null) {
-          withoutBudget.push(company);
-          return;
-        }
-
-        withBudget.push({
-          company,
-          budgetTonnes,
-          meetsParis: company.meetsParis ?? null,
-        });
-      });
-
-      const values = withBudget.map((d) => d.budgetTonnes);
-      const min = values.length ? Math.min(...values) : 0;
-      const max = values.length ? Math.max(...values) : 0;
-
-      return {
-        companyBudgetData: withBudget,
-        noBudgetCompanies: withoutBudget,
-        budgetValues: values,
-        minRaw: min,
-        maxRaw: max,
-      };
-    }, [companies]);
+    useMemo(() => getCompanyBudgetData(companies), [companies]);
 
   // Calculate unit scaling, capping, and display values
   const {
@@ -95,8 +55,7 @@ export function MeetsParisVisualization({
     const legendMin = minRaw / unitScale.divisor;
     const legendMax = maxRaw / unitScale.divisor;
 
-    const colorForTonnes: ColorFunction = (value: number) =>
-      createFixedRangeGradient(-absMax, absMax, value);
+    const colorForTonnes = createBudgetColorFunction(minRaw, maxRaw);
 
     const formatTooltipValue = (value: number, _unit: string) => {
       const sign = value < 0 ? "-" : "+";

--- a/src/components/companies/rankedList/visualizations/MeetsParisVisualization.tsx
+++ b/src/components/companies/rankedList/visualizations/MeetsParisVisualization.tsx
@@ -9,7 +9,7 @@ import { BeeswarmChart } from "./shared/BeeswarmChart";
 import {
   createBudgetColorFunction,
   getCompanyBudgetData,
-} from "@/utils/company/companyKPIUtils";
+} from "@/utils/insights/kpiColorUtils";
 
 interface MeetsParisVisualizationProps {
   companies: CompanyWithKPIs[];

--- a/src/components/municipalities/rankedList/MunicipalityInsightsPanel.tsx
+++ b/src/components/municipalities/rankedList/MunicipalityInsightsPanel.tsx
@@ -5,6 +5,7 @@ import { KPIValue } from "@/types/rankings";
 import { getSortedEntityKPIValues } from "@/utils/data/sorting";
 import {
   calculateEntityStatistics,
+  createDefaultColorGetter,
   createSourceLinks,
   buildPerformerProps,
   TOP_N,
@@ -66,6 +67,14 @@ function InsightsPanel({
     statistics.validData,
     selectedKPI,
   );
+
+  const colorItem = createDefaultColorGetter(
+      municipalityData,
+      selectedKPI.key,
+      selectedKPI.isBoolean,
+      selectedKPI.higherIsBetter,
+    );
+
   const topMunicipalities = sortedData.slice(0, TOP_N);
   const bottomMunicipalities = sortedData.slice(-TOP_N).reverse();
   const sourceLinks = createSourceLinks(selectedKPI);
@@ -143,6 +152,7 @@ function InsightsPanel({
       entityType="municipalities"
       nameKey="name"
       showBars
+      colorItem={colorItem}
     />
   ) : (
     booleanSummary
@@ -162,6 +172,7 @@ function InsightsPanel({
       entityType="municipalities"
       nameKey="name"
       showBars
+      colorItem={colorItem}
     />
   ) : null;
 

--- a/src/components/municipalities/rankedList/MunicipalityInsightsPanel.tsx
+++ b/src/components/municipalities/rankedList/MunicipalityInsightsPanel.tsx
@@ -69,11 +69,11 @@ function InsightsPanel({
   );
 
   const colorItem = createDefaultColorGetter(
-      municipalityData,
-      selectedKPI.key,
-      selectedKPI.isBoolean,
-      selectedKPI.higherIsBetter,
-    );
+    municipalityData,
+    selectedKPI.key,
+    selectedKPI.isBoolean,
+    selectedKPI.higherIsBetter,
+  );
 
   const topMunicipalities = sortedData.slice(0, TOP_N);
   const bottomMunicipalities = sortedData.slice(-TOP_N).reverse();
@@ -147,8 +147,6 @@ function InsightsPanel({
       dataPointKey={selectedKPI.key as keyof Municipality}
       unit={selectedKPI.unit}
       nullValues={selectedKPI.nullValues}
-      textColor="text-blue-3"
-      barColor={COLORS.blue3}
       entityType="municipalities"
       nameKey="name"
       showBars
@@ -167,8 +165,6 @@ function InsightsPanel({
       dataPointKey={selectedKPI.key as keyof Municipality}
       unit={selectedKPI.unit}
       nullValues={selectedKPI.nullValues}
-      textColor="text-pink-3"
-      barColor={COLORS.pink3}
       entityType="municipalities"
       nameKey="name"
       showBars

--- a/src/components/ranked/InsightsList.tsx
+++ b/src/components/ranked/InsightsList.tsx
@@ -1,5 +1,6 @@
 import { LocalizedLink } from "@/components/LocalizedLink";
 import { getCompanyDetailPath } from "@/utils/companyRouting";
+import { color } from "framer-motion";
 
 function calcBarWidth(
   showBars: boolean,
@@ -23,6 +24,7 @@ interface InsightsListProps<T> {
   entityType: string;
   nameKey: keyof T;
   showBars?: boolean;
+  colorItem: (item: T) => string;
 }
 
 function InsightsList<T>({
@@ -30,14 +32,13 @@ function InsightsList<T>({
   entities,
   dataPointKey,
   unit,
-  textColor,
-  barColor,
   totalCount,
   isBottomRanking = false,
   nullValues,
   entityType,
   nameKey,
   showBars = false,
+  colorItem,
 }: InsightsListProps<T>) {
   const numericValues = entities
     .map((e) => e[dataPointKey])
@@ -57,6 +58,7 @@ function InsightsList<T>({
           const numVal =
             typeof rawValue === "number" && !isNaN(rawValue) ? rawValue : null;
           const barWidth = calcBarWidth(showBars, numVal, absMax);
+          const color = colorItem(entity);
 
           const content = (
             <div
@@ -71,7 +73,7 @@ function InsightsList<T>({
                   className="absolute inset-y-0 left-0 rounded-lg opacity-20 group-hover:opacity-30"
                   style={{
                     width: `${barWidth}%`,
-                    backgroundColor: barColor ?? "currentColor",
+                    backgroundColor: color ?? "currentColor",
                     transition: `width 0.6s ease-out ${index * 40}ms, opacity 0.3s ease`,
                   }}
                 />
@@ -84,7 +86,10 @@ function InsightsList<T>({
                   <span className="text-sm truncate">{name}</span>
                 </div>
                 <span
-                  className={`${textColor} font-semibold text-sm ml-2 shrink-0`}
+                  className={`font-semibold text-sm ml-2 shrink-0`}
+                  style={{
+                    color: color,
+                  }}
                 >
                   {numVal !== null
                     ? numVal.toFixed(1) + unit

--- a/src/components/ranked/InsightsList.tsx
+++ b/src/components/ranked/InsightsList.tsx
@@ -46,7 +46,9 @@ function InsightsList<T>({
 
   return (
     <div className="bg-black-2 border border-white/10 rounded-level-2 h-full">
-      <h3 className="text-white text-lg font-semibold m-4 md:m-6 mb-2 md:mb-2">{title}</h3>
+      <h3 className="text-white text-lg font-semibold m-4 md:m-6 mb-2 md:mb-2">
+        {title}
+      </h3>
       <div className="space-y-1 bg-black/40 mb-6 border-y border-white/10 px-4 md:px-6 py-2">
         {entities.map((entity, index) => {
           const position = isBottomRanking ? totalCount - index : index + 1;

--- a/src/components/ranked/InsightsList.tsx
+++ b/src/components/ranked/InsightsList.tsx
@@ -1,6 +1,5 @@
 import { LocalizedLink } from "@/components/LocalizedLink";
 import { getCompanyDetailPath } from "@/utils/companyRouting";
-import { color } from "framer-motion";
 
 function calcBarWidth(
   showBars: boolean,
@@ -16,8 +15,6 @@ interface InsightsListProps<T> {
   entities: T[];
   dataPointKey: keyof T;
   unit: string;
-  textColor: string;
-  barColor?: string;
   totalCount: number;
   isBottomRanking?: boolean;
   nullValues?: string;
@@ -48,9 +45,9 @@ function InsightsList<T>({
     : 1;
 
   return (
-    <div className="bg-white/10 rounded-level-2 p-4 md:p-6 h-full">
-      <h3 className="text-white text-lg font-semibold mb-3">{title}</h3>
-      <div className="space-y-1">
+    <div className="bg-black-2 border border-white/10 rounded-level-2 h-full">
+      <h3 className="text-white text-lg font-semibold m-4 md:m-6 mb-2 md:mb-2">{title}</h3>
+      <div className="space-y-1 bg-black/40 mb-6 border-y border-white/10 px-4 md:px-6 py-2">
         {entities.map((entity, index) => {
           const position = isBottomRanking ? totalCount - index : index + 1;
           const name = String(entity[nameKey]);
@@ -62,7 +59,7 @@ function InsightsList<T>({
 
           const content = (
             <div
-              className="relative rounded-lg overflow-hidden group"
+              className="relative overflow-hidden group"
               style={{
                 animation: `fadeSlideIn 0.35s ease-out both`,
                 animationDelay: `${index * 35}ms`,

--- a/src/components/ranked/InsightsList.tsx
+++ b/src/components/ranked/InsightsList.tsx
@@ -45,11 +45,11 @@ function InsightsList<T>({
     : 1;
 
   return (
-    <div className="bg-black-2 border border-white/10 rounded-level-2 h-full">
-      <h3 className="text-white text-lg font-semibold m-4 md:m-6 mb-2 md:mb-2">
+    <div className="flex flex-col bg-black-2 border border-white/10 rounded-level-2 py-6">
+      <h3 className="text-white text-lg font-semibold px-4 md:px-6 pb-2 md:pb-2">
         {title}
       </h3>
-      <div className="space-y-1 bg-black/40 mb-6 border-y border-white/10 px-4 md:px-6 py-2">
+      <div className="space-y-1 bg-black/40 h-full border-y border-white/10 px-4 md:px-6 py-2">
         {entities.map((entity, index) => {
           const position = isBottomRanking ? totalCount - index : index + 1;
           const name = String(entity[nameKey]);

--- a/src/components/ranked/OverviewSplitLayout.tsx
+++ b/src/components/ranked/OverviewSplitLayout.tsx
@@ -6,7 +6,7 @@ export type OverviewViewMode = "map" | "list" | "graph";
 const VISUALIZATION_PANEL_CLASS = "relative min-w-0 h-full";
 
 /** Mobile viewport fraction and fixed desktop pixel height for the map/list panel */
-export const OVERVIEW_PANEL_HEIGHT = "h-[85vh] md:h-[630px]" as const;
+export const OVERVIEW_PANEL_HEIGHT = "h-[85vh] md:h-[632px]" as const;
 
 interface OverviewSplitLayoutProps {
   viewMode: OverviewViewMode;

--- a/src/components/ranked/RankedList.tsx
+++ b/src/components/ranked/RankedList.tsx
@@ -3,8 +3,9 @@ import { ArrowDown, ArrowUp, Search } from "lucide-react";
 import { t } from "i18next";
 import MultiPagePagination from "@/components/ui/multi-page-pagination";
 import { DataPoint } from "@/types/rankings";
-import { cn } from "@/lib/utils";
 import { isMissingRankedValue } from "@/utils/insights/rankedListUtils";
+import { DEFAULT_KPI_COLORS } from "@/utils/ui/colors";
+import { createStatisticalGradient, DEFAULT_STATISTICAL_GRADIENT_COLORS } from "@/utils/ui/colorGradients";
 
 export interface RankedListProps<T extends Record<string, unknown>> {
   data: T[];
@@ -18,6 +19,7 @@ export interface RankedListProps<T extends Record<string, unknown>> {
     startIndex: number,
     originalRank: number,
   ) => React.ReactNode;
+  colorItem?: (item: T) => string;
   className?: string;
   searchPlaceholder?: string;
   /** Rendered to the left of the search bar in the header row */
@@ -81,24 +83,6 @@ function useSortedRankedData<T extends Record<string, unknown>>({
 
   const sortedData = [...sortedWithValue, ...sortedWithoutValue];
 
-  const validValues = sortedWithValue
-    .map((item) => item[selectedDataPoint.key])
-    .filter(
-      (value) =>
-        (selectedDataPoint.isBoolean && typeof value === "boolean") ||
-        (typeof value === "number" && !Number.isNaN(value as number)),
-    );
-
-  const average =
-    validValues.length > 0
-      ? validValues.reduce(
-          (sum, value) =>
-            sum +
-            (selectedDataPoint.isBoolean ? (value ? 1 : 0) : (value as number)),
-          0,
-        ) / validValues.length
-      : 0;
-
   const validCount = sortedWithValue.length;
   const originalRankMap = new Map<T, number>();
   sortedData.forEach((item, index) => {
@@ -129,7 +113,6 @@ function useSortedRankedData<T extends Record<string, unknown>>({
 
   return {
     sortedData,
-    average,
     originalRankMap,
     filteredData,
     totalPages,
@@ -141,7 +124,6 @@ function useSortedRankedData<T extends Record<string, unknown>>({
 
 function useRankedItemHelpers<T extends Record<string, unknown>>(
   selectedDataPoint: DataPoint<T>,
-  average: number,
   originalRankMap: Map<T, number>,
 ) {
   const formatValue = (item: T) => {
@@ -164,22 +146,33 @@ function useRankedItemHelpers<T extends Record<string, unknown>>(
 
   const getOriginalRank = (item: T) => originalRankMap.get(item) || 0;
 
-  const getColor = (item: T): string => {
+  const numericalValules = Array.from(originalRankMap.keys())
+    .filter(
+      (item) =>
+        typeof item[selectedDataPoint.key] === "number" &&
+        !isNaN(item[selectedDataPoint.key] as number),
+    )
+    .map((item) => item[selectedDataPoint.key] as number);
+
+  const defaultColorItem = (item: T): string => {
     const value = item[selectedDataPoint.key];
-    if (isMissingRankedValue(value, selectedDataPoint)) return "text-pink-3";
+    if (isMissingRankedValue(value, selectedDataPoint)) return DEFAULT_KPI_COLORS.null;
+    
     if (selectedDataPoint.isBoolean) {
       return value == selectedDataPoint.higherIsBetter
-        ? "text-blue-3"
-        : "text-pink-3";
+        ? DEFAULT_KPI_COLORS.positive
+        : DEFAULT_KPI_COLORS.negative;
     }
-    // TODO: comment out for now, wait for gradient implementation
-    // return (value as number) > average == selectedDataPoint.higherIsBetter
-    //   ? "text-blue-3"
-    //   : "text-pink-3";
-    return "text-orange-2";
+
+    return createStatisticalGradient(
+      numericalValules,
+      value as number,
+      selectedDataPoint.higherIsBetter ?? false,
+      DEFAULT_STATISTICAL_GRADIENT_COLORS,
+    );
   };
 
-  return { formatValue, getOriginalRank, getColor };
+  return { formatValue, getOriginalRank, defaultColorItem };
 }
 
 export function RankedList<T extends Record<string, unknown>>({
@@ -189,6 +182,7 @@ export function RankedList<T extends Record<string, unknown>>({
   searchKey = "name" as keyof T,
   itemsPerPage = 10,
   renderItem,
+  colorItem,
   className,
   searchPlaceholder,
   headerAction,
@@ -203,7 +197,6 @@ export function RankedList<T extends Record<string, unknown>>({
   }, [selectedDataPoint.key]);
 
   const {
-    average,
     originalRankMap,
     totalPages,
     startIndex,
@@ -219,11 +212,8 @@ export function RankedList<T extends Record<string, unknown>>({
     sortReversed,
   });
 
-  const { formatValue, getOriginalRank, getColor } = useRankedItemHelpers(
-    selectedDataPoint,
-    average,
-    originalRankMap,
-  );
+  const { formatValue, getOriginalRank, defaultColorItem } =
+    useRankedItemHelpers(selectedDataPoint, originalRankMap);
 
   const handlePageChange = (page: number) => {
     setCurrentPage(page);
@@ -231,7 +221,7 @@ export function RankedList<T extends Record<string, unknown>>({
     if (listElement) listElement.scrollTop = 0;
   };
 
-  const defaultRenderItem = (item: T, index: number) => (
+  const defaultRenderItem = (item: T, index: number, color: string) => (
     <button
       key={String(index)}
       onClick={() => onItemClick?.(item)}
@@ -246,10 +236,8 @@ export function RankedList<T extends Record<string, unknown>>({
         </span>
       </div>
       <span
-        className={cn(
-          getColor(item),
-          "text-sm md:text-base font-medium text-right",
-        )}
+        className="text-sm md:text-base font-medium text-right"
+        style={{ color: color }}
       >
         {formatValue(item)}
       </span>
@@ -315,7 +303,11 @@ export function RankedList<T extends Record<string, unknown>>({
           {paginatedData.map((item, index) =>
             renderItem
               ? renderItem(item, index, startIndex, getOriginalRank(item))
-              : defaultRenderItem(item, index),
+              : defaultRenderItem(
+                  item,
+                  index,
+                  colorItem ? colorItem(item) : defaultColorItem(item),
+                ),
           )}
         </div>
       </div>

--- a/src/components/ranked/RankedList.tsx
+++ b/src/components/ranked/RankedList.tsx
@@ -3,7 +3,11 @@ import { ArrowDown, ArrowUp, Search } from "lucide-react";
 import { t } from "i18next";
 import MultiPagePagination from "@/components/ui/multi-page-pagination";
 import { DataPoint } from "@/types/rankings";
-import { createDefaultColorGetter, isMissingRankedValue } from "@/utils/insights/rankedListUtils";
+import {
+  createDefaultColorGetter,
+  isMissingRankedValue,
+} from "@/utils/insights/rankedListUtils";
+import { cn } from "@/lib/utils";
 
 export interface RankedListProps<T extends Record<string, unknown>> {
   data: T[];
@@ -53,10 +57,16 @@ function useSortedRankedData<T extends Record<string, unknown>>({
 
   const withValue = data.filter(
     (item) =>
-      !isMissingRankedValue(item[selectedDataPoint.key], selectedDataPoint.isBoolean),
+      !isMissingRankedValue(
+        item[selectedDataPoint.key],
+        selectedDataPoint.isBoolean,
+      ),
   );
   const withoutValue = data.filter((item) =>
-    isMissingRankedValue(item[selectedDataPoint.key], selectedDataPoint.isBoolean),
+    isMissingRankedValue(
+      item[selectedDataPoint.key],
+      selectedDataPoint.isBoolean,
+    ),
   );
 
   const sortedWithValue = [...withValue].sort((a, b) => {
@@ -148,7 +158,7 @@ function useRankedItemHelpers<T extends Record<string, unknown>>(
     Array.from(originalRankMap.keys()),
     selectedDataPoint.key,
     selectedDataPoint.isBoolean,
-    selectedDataPoint.higherIsBetter
+    selectedDataPoint.higherIsBetter,
   );
 
   return { formatValue, getOriginalRank, defaultColorItem };
@@ -215,7 +225,12 @@ export function RankedList<T extends Record<string, unknown>>({
         </span>
       </div>
       <span
-        className="text-sm md:text-base font-medium text-right"
+        className={cn(
+          selectedDataPoint.isBoolean || item[selectedDataPoint.key] === null
+            ? "font-medium"
+            : "font-semibold",
+          "text-sm md:text-base text-right",
+        )}
         style={{ color: color }}
       >
         {formatValue(item)}
@@ -224,7 +239,7 @@ export function RankedList<T extends Record<string, unknown>>({
   );
 
   return (
-    <div className={`bg-black-2 rounded-2xl flex flex-col ${className}`}>
+    <div className={`bg-black-2 rounded-2xl border border-white/10 flex flex-col h-full ${className}`}>
       <div className="p-4 border-b border-white/10">
         {headerAction && <div className="mb-3 md:hidden">{headerAction}</div>}
         <div className="flex items-center gap-3">
@@ -278,7 +293,7 @@ export function RankedList<T extends Record<string, unknown>>({
         )}
       </div>
       <div className="overflow-y-auto ranked-list-items">
-        <div className="divide-y divide-white/10">
+        <div className="h-full bg-black/40 grid grid-cols-1 auto-rows-fr [&>*:not(:last-child)]:border-b [&>*:not(:last-child)]:border-white/10">
           {paginatedData.map((item, index) =>
             renderItem
               ? renderItem(item, index, startIndex, getOriginalRank(item))
@@ -288,6 +303,10 @@ export function RankedList<T extends Record<string, unknown>>({
                   colorItem ? colorItem(item) : defaultColorItem(item),
                 ),
           )}
+          {paginatedData.length < itemsPerPage &&
+            Array(itemsPerPage - paginatedData.length)
+              .fill(0)
+              .map((_, i) => <div key={`empty-${i}`} />)}
         </div>
       </div>
       {totalPages > 1 && (

--- a/src/components/ranked/RankedList.tsx
+++ b/src/components/ranked/RankedList.tsx
@@ -239,7 +239,9 @@ export function RankedList<T extends Record<string, unknown>>({
   );
 
   return (
-    <div className={`bg-black-2 rounded-2xl border border-white/10 flex flex-col h-full ${className}`}>
+    <div
+      className={`bg-black-2 rounded-2xl border border-white/10 flex flex-col ${className}`}
+    >
       <div className="p-4 border-b border-white/10">
         {headerAction && <div className="mb-3 md:hidden">{headerAction}</div>}
         <div className="flex items-center gap-3">
@@ -303,10 +305,6 @@ export function RankedList<T extends Record<string, unknown>>({
                   colorItem ? colorItem(item) : defaultColorItem(item),
                 ),
           )}
-          {paginatedData.length < itemsPerPage &&
-            Array(itemsPerPage - paginatedData.length)
-              .fill(0)
-              .map((_, i) => <div key={`empty-${i}`} />)}
         </div>
       </div>
       {totalPages > 1 && (

--- a/src/components/ranked/RankedList.tsx
+++ b/src/components/ranked/RankedList.tsx
@@ -3,9 +3,7 @@ import { ArrowDown, ArrowUp, Search } from "lucide-react";
 import { t } from "i18next";
 import MultiPagePagination from "@/components/ui/multi-page-pagination";
 import { DataPoint } from "@/types/rankings";
-import { isMissingRankedValue } from "@/utils/insights/rankedListUtils";
-import { DEFAULT_KPI_COLORS } from "@/utils/ui/colors";
-import { createStatisticalGradient, DEFAULT_STATISTICAL_GRADIENT_COLORS } from "@/utils/ui/colorGradients";
+import { createDefaultColorGetter, isMissingRankedValue } from "@/utils/insights/rankedListUtils";
 
 export interface RankedListProps<T extends Record<string, unknown>> {
   data: T[];
@@ -55,10 +53,10 @@ function useSortedRankedData<T extends Record<string, unknown>>({
 
   const withValue = data.filter(
     (item) =>
-      !isMissingRankedValue(item[selectedDataPoint.key], selectedDataPoint),
+      !isMissingRankedValue(item[selectedDataPoint.key], selectedDataPoint.isBoolean),
   );
   const withoutValue = data.filter((item) =>
-    isMissingRankedValue(item[selectedDataPoint.key], selectedDataPoint),
+    isMissingRankedValue(item[selectedDataPoint.key], selectedDataPoint.isBoolean),
   );
 
   const sortedWithValue = [...withValue].sort((a, b) => {
@@ -128,7 +126,7 @@ function useRankedItemHelpers<T extends Record<string, unknown>>(
 ) {
   const formatValue = (item: T) => {
     const value = item[selectedDataPoint.key];
-    if (isMissingRankedValue(value, selectedDataPoint)) {
+    if (isMissingRankedValue(value, selectedDataPoint.isBoolean)) {
       return selectedDataPoint.nullValues || t("noData");
     }
     if (selectedDataPoint.formatter) return selectedDataPoint.formatter(value);
@@ -146,31 +144,12 @@ function useRankedItemHelpers<T extends Record<string, unknown>>(
 
   const getOriginalRank = (item: T) => originalRankMap.get(item) || 0;
 
-  const numericalValules = Array.from(originalRankMap.keys())
-    .filter(
-      (item) =>
-        typeof item[selectedDataPoint.key] === "number" &&
-        !isNaN(item[selectedDataPoint.key] as number),
-    )
-    .map((item) => item[selectedDataPoint.key] as number);
-
-  const defaultColorItem = (item: T): string => {
-    const value = item[selectedDataPoint.key];
-    if (isMissingRankedValue(value, selectedDataPoint)) return DEFAULT_KPI_COLORS.null;
-    
-    if (selectedDataPoint.isBoolean) {
-      return value == selectedDataPoint.higherIsBetter
-        ? DEFAULT_KPI_COLORS.positive
-        : DEFAULT_KPI_COLORS.negative;
-    }
-
-    return createStatisticalGradient(
-      numericalValules,
-      value as number,
-      selectedDataPoint.higherIsBetter ?? false,
-      DEFAULT_STATISTICAL_GRADIENT_COLORS,
-    );
-  };
+  const defaultColorItem = createDefaultColorGetter(
+    Array.from(originalRankMap.keys()),
+    selectedDataPoint.key,
+    selectedDataPoint.isBoolean,
+    selectedDataPoint.higherIsBetter
+  );
 
   return { formatValue, getOriginalRank, defaultColorItem };
 }
@@ -225,7 +204,7 @@ export function RankedList<T extends Record<string, unknown>>({
     <button
       key={String(index)}
       onClick={() => onItemClick?.(item)}
-      className="w-full p-4 hover:bg-black/40 transition-colors flex items-center justify-between group"
+      className="w-full p-4 hover:bg-black/70 transition-colors flex items-center justify-between group"
     >
       <div className="flex items-center gap-4">
         <span className="text-white/30 text-sm w-8 shrink-0 tabular-nums text-left">

--- a/src/components/regions/RegionalInsightsPanel.tsx
+++ b/src/components/regions/RegionalInsightsPanel.tsx
@@ -64,11 +64,11 @@ function RegionalInsightsPanel({
   );
 
   const colorItem = createDefaultColorGetter(
-      regionData,
-      selectedKPI.key,
-      selectedKPI.isBoolean,
-      selectedKPI.higherIsBetter,
-    );
+    regionData,
+    selectedKPI.key,
+    selectedKPI.isBoolean,
+    selectedKPI.higherIsBetter,
+  );
 
   const topRegions = sortedData.slice(0, TOP_N);
   const bottomRegions = sortedData.slice(-TOP_N).reverse();

--- a/src/components/regions/RegionalInsightsPanel.tsx
+++ b/src/components/regions/RegionalInsightsPanel.tsx
@@ -142,8 +142,6 @@ function RegionalInsightsPanel({
       dataPointKey={selectedKPI.key as keyof Region}
       unit={selectedKPI.unit}
       nullValues={selectedKPI.nullValues}
-      textColor="text-blue-3"
-      barColor={COLORS.blue3}
       entityType="regions"
       nameKey="name"
       showBars
@@ -162,8 +160,6 @@ function RegionalInsightsPanel({
       dataPointKey={selectedKPI.key as keyof Region}
       unit={selectedKPI.unit}
       nullValues={selectedKPI.nullValues}
-      textColor="text-pink-3"
-      barColor={COLORS.pink3}
       entityType="regions"
       nameKey="name"
       showBars

--- a/src/components/regions/RegionalInsightsPanel.tsx
+++ b/src/components/regions/RegionalInsightsPanel.tsx
@@ -5,6 +5,7 @@ import { Region } from "@/types/region";
 import { KPIValue } from "@/types/rankings";
 import {
   calculateEntityStatistics,
+  createDefaultColorGetter,
   createSourceLinks,
   buildPerformerProps,
   TOP_N,
@@ -61,6 +62,14 @@ function RegionalInsightsPanel({
     statistics.validData,
     selectedKPI,
   );
+
+  const colorItem = createDefaultColorGetter(
+      regionData,
+      selectedKPI.key,
+      selectedKPI.isBoolean,
+      selectedKPI.higherIsBetter,
+    );
+
   const topRegions = sortedData.slice(0, TOP_N);
   const bottomRegions = sortedData.slice(-TOP_N).reverse();
   const sourceLinks = createSourceLinks(selectedKPI);
@@ -138,6 +147,7 @@ function RegionalInsightsPanel({
       entityType="regions"
       nameKey="name"
       showBars
+      colorItem={colorItem}
     />
   ) : (
     booleanSummary
@@ -157,6 +167,7 @@ function RegionalInsightsPanel({
       entityType="regions"
       nameKey="name"
       showBars
+      colorItem={colorItem}
     />
   ) : null;
 

--- a/src/hooks/companies/useCompanyKPIs.ts
+++ b/src/hooks/companies/useCompanyKPIs.ts
@@ -69,7 +69,7 @@ export const useCompanyKPIs = (): CompanyKPIValue[] => {
           false: t("companies.list.kpis.meetsParis.booleanLabels.false"),
         },
         nullValues: t("companies.list.kpis.meetsParis.nullValues"),
-        generateKPIColorGetter: (companies: CompanyWithKPIs[]) =>
+        createKPIColorGetter: (companies: CompanyWithKPIs[]) =>
           createBudgetKPIColorGetter(companies),
       },
     ];

--- a/src/hooks/companies/useCompanyKPIs.ts
+++ b/src/hooks/companies/useCompanyKPIs.ts
@@ -8,6 +8,10 @@ import {
 import { calculateTrendline } from "@/lib/calculations/trends/analysis";
 import { calculateMeetsParis } from "@/lib/calculations/trends/meetsParis";
 import { calculateEmissionsChangeFromBaseYear } from "@/utils/calculations/emissionsCalculations";
+import {
+  createBudgetKPIColorGetter,
+  createSymmetricKPIColorGetter,
+} from "@/utils/company/companyKPIUtils";
 
 // Re-export types for convenience
 export type { CompanyWithKPIs, CompanyKPIValue } from "@/types/company";
@@ -42,6 +46,11 @@ export const useCompanyKPIs = (): CompanyKPIValue[] => {
           "companies.list.kpis.emissionsChangeFromBaseYear.detailedDescription",
         ),
         higherIsBetter: false,
+        generateKPIColorGetter: (companies: CompanyWithKPIs[]) =>
+          createSymmetricKPIColorGetter(
+            companies,
+            "emissionsChangeFromBaseYear",
+          ),
       },
       {
         label: t("companies.list.kpis.meetsParis.label"),
@@ -60,6 +69,8 @@ export const useCompanyKPIs = (): CompanyKPIValue[] => {
           false: t("companies.list.kpis.meetsParis.booleanLabels.false"),
         },
         nullValues: t("companies.list.kpis.meetsParis.nullValues"),
+        generateKPIColorGetter: (companies: CompanyWithKPIs[]) =>
+          createBudgetKPIColorGetter(companies),
       },
     ];
   }, [t]);

--- a/src/hooks/companies/useCompanyKPIs.ts
+++ b/src/hooks/companies/useCompanyKPIs.ts
@@ -11,7 +11,7 @@ import { calculateEmissionsChangeFromBaseYear } from "@/utils/calculations/emiss
 import {
   createBudgetKPIColorGetter,
   createSymmetricKPIColorGetter,
-} from "@/utils/company/companyKPIUtils";
+} from "@/utils/insights/kpiColorUtils";
 
 // Re-export types for convenience
 export type { CompanyWithKPIs, CompanyKPIValue } from "@/types/company";
@@ -46,7 +46,7 @@ export const useCompanyKPIs = (): CompanyKPIValue[] => {
           "companies.list.kpis.emissionsChangeFromBaseYear.detailedDescription",
         ),
         higherIsBetter: false,
-        generateKPIColorGetter: (companies: CompanyWithKPIs[]) =>
+        createKPIColorGetter: (companies: CompanyWithKPIs[]) =>
           createSymmetricKPIColorGetter(
             companies,
             "emissionsChangeFromBaseYear",

--- a/src/index.css
+++ b/src/index.css
@@ -51,7 +51,7 @@
   --pink-2: #eea0b7;
   --pink-3: #f0759a;
   --pink-4: #97455d;
-  --pink-5: #73263d;
+  --pink-5: #9d3c59;
 
   /* Muted background colors for flip cards (20% opacity) */
   --green-3-muted: color-mix(in srgb, var(--green-3) 20%, transparent);

--- a/src/pages/CompaniesOverviewPage.tsx
+++ b/src/pages/CompaniesOverviewPage.tsx
@@ -213,7 +213,7 @@ export function CompaniesOverviewPage() {
       }}
     />
   );
-  
+
   const colorItem = selectedKPI.createKPIColorGetter
     ? selectedKPI.createKPIColorGetter(companiesWithKPIs)
     : undefined;

--- a/src/pages/CompaniesOverviewPage.tsx
+++ b/src/pages/CompaniesOverviewPage.tsx
@@ -213,6 +213,10 @@ export function CompaniesOverviewPage() {
       }}
     />
   );
+  
+  const colorItem = selectedKPI.createKPIColorGetter
+    ? selectedKPI.createKPIColorGetter(companiesWithKPIs)
+    : undefined;
 
   const companyRankedList = (
     <RankedList
@@ -223,6 +227,7 @@ export function CompaniesOverviewPage() {
       searchPlaceholder={t("rankedList.search.placeholder")}
       itemsPerPage={isMobile ? 6 : 8}
       headerAction={viewToggle}
+      colorItem={colorItem}
     />
   );
 

--- a/src/types/company.ts
+++ b/src/types/company.ts
@@ -157,5 +157,9 @@ export interface CompanyWithKPIs extends RankedCompany {
   [key: string]: unknown;
 }
 
-// KPI value type for companies (aliased to generic KPIValue for type safety)
-export type CompanyKPIValue = KPIValue<CompanyWithKPIs>;
+// Extended KPI value type for companies
+export interface CompanyKPIValue extends KPIValue<CompanyWithKPIs> {
+  generateKPIColorGetter?: (
+    companies: CompanyWithKPIs[],
+  ) => (company: CompanyWithKPIs) => string;
+}

--- a/src/types/company.ts
+++ b/src/types/company.ts
@@ -159,7 +159,7 @@ export interface CompanyWithKPIs extends RankedCompany {
 
 // Extended KPI value type for companies
 export interface CompanyKPIValue extends KPIValue<CompanyWithKPIs> {
-  generateKPIColorGetter?: (
+  createKPIColorGetter?: (
     companies: CompanyWithKPIs[],
   ) => (company: CompanyWithKPIs) => string;
 }

--- a/src/utils/company/companyKPIUtils.ts
+++ b/src/utils/company/companyKPIUtils.ts
@@ -1,0 +1,99 @@
+import type { CompanyWithKPIs } from "@/types/company";
+import { calculateTrendline } from "@/lib/calculations/trends/analysis";
+import { calculateCarbonBudgetTonnes } from "@/utils/calculations/carbonBudget";
+import {
+  createFixedRangeGradient,
+  createSymmetricRangeGradient,
+} from "@/utils/ui/colorGradients";
+import type { ColorFunction } from "@/types/visualizations";
+import { DEFAULT_KPI_COLORS } from "../ui/colors";
+
+export interface CompanyBudgetData {
+  company: CompanyWithKPIs;
+  budgetTonnes: number;
+  meetsParis: boolean | null;
+}
+
+export function getCompanyBudgetData(companies: CompanyWithKPIs[]): {
+  companyBudgetData: CompanyBudgetData[];
+  noBudgetCompanies: CompanyWithKPIs[];
+  budgetValues: number[];
+  minRaw: number;
+  maxRaw: number;
+} {
+  const withBudget: CompanyBudgetData[] = [];
+  const withoutBudget: CompanyWithKPIs[] = [];
+
+  companies.forEach((company) => {
+    const trendAnalysis = calculateTrendline(company);
+    const budgetTonnes = calculateCarbonBudgetTonnes(company, trendAnalysis);
+
+    if (budgetTonnes === null) {
+      withoutBudget.push(company);
+      return;
+    }
+
+    withBudget.push({
+      company,
+      budgetTonnes,
+      meetsParis: company.meetsParis ?? null,
+    });
+  });
+
+  const values = withBudget.map((d) => d.budgetTonnes);
+  const min = values.length ? Math.min(...values) : 0;
+  const max = values.length ? Math.max(...values) : 0;
+
+  return {
+    companyBudgetData: withBudget,
+    noBudgetCompanies: withoutBudget,
+    budgetValues: values,
+    minRaw: min,
+    maxRaw: max,
+  };
+}
+
+export function createBudgetColorFunction(
+  minRaw: number,
+  maxRaw: number,
+): ColorFunction {
+  const absMax = Math.max(Math.abs(minRaw), Math.abs(maxRaw));
+  return (value: number) => createFixedRangeGradient(-absMax, absMax, value);
+}
+
+export function createSymmetricKPIColorGetter(
+  companies: CompanyWithKPIs[],
+  kpiKey: keyof CompanyWithKPIs,
+) {
+  const values = companies
+    .map((company) => company[kpiKey])
+    .filter((value): value is number => typeof value === "number");
+
+  const min = values.length ? Math.min(...values) : 0;
+  const max = values.length ? Math.max(...values) : 0;
+
+  return (company: CompanyWithKPIs) => {
+    const value = company[kpiKey];
+    return value === null || value === undefined
+      ? DEFAULT_KPI_COLORS.null
+      : createSymmetricRangeGradient(min, max, value as number);
+  };
+}
+
+export function createBudgetKPIColorGetter(companies: CompanyWithKPIs[]) {
+  const { companyBudgetData, minRaw, maxRaw } = getCompanyBudgetData(companies);
+
+  const colorForTonnes = createBudgetColorFunction(minRaw, maxRaw);
+  const budgetTonnesByCompanyId = new Map<string, number>();
+
+  for (let data of companyBudgetData) {
+    budgetTonnesByCompanyId.set(data.company.wikidataId, data.budgetTonnes);
+  }
+
+  return (company: CompanyWithKPIs) => {
+    const budgetTonnes = budgetTonnesByCompanyId.get(company.wikidataId);
+    return budgetTonnes === undefined
+      ? DEFAULT_KPI_COLORS.null
+      : colorForTonnes(budgetTonnes);
+  };
+}

--- a/src/utils/insights/kpiColorUtils.ts
+++ b/src/utils/insights/kpiColorUtils.ts
@@ -6,7 +6,7 @@ import {
   createSymmetricRangeGradient,
 } from "@/utils/ui/colorGradients";
 import type { ColorFunction } from "@/types/visualizations";
-import { DEFAULT_KPI_COLORS } from "../ui/colors";
+import { DEFAULT_NULL_DATA_COLOR } from "../ui/colors";
 
 export interface CompanyBudgetData {
   company: CompanyWithKPIs;
@@ -61,21 +61,21 @@ export function createBudgetColorFunction(
   return (value: number) => createFixedRangeGradient(-absMax, absMax, value);
 }
 
-export function createSymmetricKPIColorGetter(
-  companies: CompanyWithKPIs[],
-  kpiKey: keyof CompanyWithKPIs,
+export function createSymmetricKPIColorGetter<T>(
+  entities: T[],
+  kpiKey: keyof T,
 ) {
-  const values = companies
-    .map((company) => company[kpiKey])
-    .filter((value): value is number => typeof value === "number");
+  const values = entities
+    .filter((entity) => typeof entity[kpiKey] === "number")
+    .map((entity) => entity[kpiKey] as number);
 
   const min = values.length ? Math.min(...values) : 0;
   const max = values.length ? Math.max(...values) : 0;
 
-  return (company: CompanyWithKPIs) => {
-    const value = company[kpiKey];
+  return (entitiy: T) => {
+    const value = entitiy[kpiKey];
     return value === null || value === undefined
-      ? DEFAULT_KPI_COLORS.null
+      ? DEFAULT_NULL_DATA_COLOR
       : createSymmetricRangeGradient(min, max, value as number);
   };
 }
@@ -93,7 +93,7 @@ export function createBudgetKPIColorGetter(companies: CompanyWithKPIs[]) {
   return (company: CompanyWithKPIs) => {
     const budgetTonnes = budgetTonnesByCompanyId.get(company.wikidataId);
     return budgetTonnes === undefined
-      ? DEFAULT_KPI_COLORS.null
+      ? DEFAULT_NULL_DATA_COLOR
       : colorForTonnes(budgetTonnes);
   };
 }

--- a/src/utils/insights/rankedListUtils.ts
+++ b/src/utils/insights/rankedListUtils.ts
@@ -230,7 +230,8 @@ export function createDefaultColorGetter<T>(
   return (entity: T) => {
     const value = entity[dataPointKey];
 
-    if (isMissingRankedValue(value, dataPointIsBoolean)) return DEFAULT_NULL_DATA_COLOR;
+    if (isMissingRankedValue(value, dataPointIsBoolean))
+      return DEFAULT_NULL_DATA_COLOR;
 
     if (dataPointIsBoolean) {
       return value == dataPointHigherIsBetter

--- a/src/utils/insights/rankedListUtils.ts
+++ b/src/utils/insights/rankedListUtils.ts
@@ -17,17 +17,25 @@ export const TOP_N = 10;
 // 4. Avoids over-complicating the codebase with excessive file splitting
 
 import { t } from "i18next";
-import { DataPoint, EntityWithKPIs, KPIValue } from "@/types/rankings";
+import { EntityWithKPIs, KPIValue } from "@/types/rankings";
+import {
+  createStatisticalGradient,
+  DEFAULT_STATISTICAL_GRADIENT_COLORS,
+} from "../ui/colorGradients";
+import {
+  DEFAULT_BOOLEAN_DATA_COLORS,
+  DEFAULT_NULL_DATA_COLOR,
+} from "../ui/colors";
 
 export function isMissingRankedValue(
   value: unknown,
-  selectedDataPoint: Pick<DataPoint<unknown>, "isBoolean">,
+  isBoolean: boolean | undefined,
 ): boolean {
   if (value === null || value === undefined) {
     return true;
   }
 
-  if (selectedDataPoint.isBoolean) {
+  if (isBoolean) {
     return typeof value !== "boolean";
   }
 
@@ -58,7 +66,7 @@ export function filterValidData<T, KPI extends KPIValue<T> = KPIValue<T>>(
 ): T[] {
   return entities.filter((entity) => {
     const value = getValue(entity);
-    return !isMissingRankedValue(value, selectedKPI);
+    return !isMissingRankedValue(value, selectedKPI.isBoolean);
   });
 }
 
@@ -99,7 +107,7 @@ export function calculateEntityStatistics<
 
   const nullCount = entities.filter((entity) => {
     const value = getValue(entity);
-    return isMissingRankedValue(value, selectedKPI);
+    return isMissingRankedValue(value, selectedKPI.isBoolean);
   }).length;
 
   const entityPlural = t("header." + entityType).toLowerCase();
@@ -203,4 +211,38 @@ export function createSourceLinks<T = EntityWithKPIs>(
         : selectedKPI.source || "",
     })) || []
   );
+}
+
+export function createDefaultColorGetter<T>(
+  entities: T[],
+  dataPointKey: keyof T,
+  dataPointIsBoolean: boolean | undefined,
+  dataPointHigherIsBetter: boolean,
+) {
+  const numericalValues = entities
+    .filter(
+      (entity) =>
+        typeof entity[dataPointKey] === "number" &&
+        !isNaN(entity[dataPointKey] as number),
+    )
+    .map((entity) => entity[dataPointKey] as number);
+
+  return (entity: T) => {
+    const value = entity[dataPointKey];
+
+    if (isMissingRankedValue(value, dataPointIsBoolean)) return DEFAULT_NULL_DATA_COLOR;
+
+    if (dataPointIsBoolean) {
+      return value == dataPointHigherIsBetter
+        ? DEFAULT_BOOLEAN_DATA_COLORS.positive
+        : DEFAULT_BOOLEAN_DATA_COLORS.negative;
+    }
+
+    return createStatisticalGradient(
+      numericalValues,
+      value as number,
+      dataPointHigherIsBetter ?? false,
+      DEFAULT_STATISTICAL_GRADIENT_COLORS,
+    );
+  };
 }

--- a/src/utils/ui/colors.ts
+++ b/src/utils/ui/colors.ts
@@ -19,3 +19,9 @@ export function getDataQualityColor(
       return "var(--pink-3)";
   }
 }
+
+export const DEFAULT_KPI_COLORS = {
+  positive: "var(--blue-3)",
+  negative: "var(--pink-3)",
+  null: "var(--grey)",
+};

--- a/src/utils/ui/colors.ts
+++ b/src/utils/ui/colors.ts
@@ -20,8 +20,9 @@ export function getDataQualityColor(
   }
 }
 
-export const DEFAULT_KPI_COLORS = {
+export const DEFAULT_BOOLEAN_DATA_COLORS = {
   positive: "var(--blue-3)",
   negative: "var(--pink-3)",
-  null: "var(--grey)",
 };
+
+export const DEFAULT_NULL_DATA_COLOR = "var(--grey)";


### PR DESCRIPTION
### ✨ What’s Changed?

Makes the ranked lists on the overview/ranking pages (both the main one and the top/bottom 5 lists) use the same colours for the KPI values as the visualisation in order to keep things consistent.

### 📸 Screenshots
Before:
<img width="685" height="646" alt="bild" src="https://github.com/user-attachments/assets/53c549b8-1eeb-4d1b-b4b1-af0164303168" />
<img width="917" height="499" alt="bild" src="https://github.com/user-attachments/assets/ff8302de-3d15-4838-8551-4e151f07f00d" />
<img width="688" height="615" alt="bild" src="https://github.com/user-attachments/assets/5ecc8c01-aaab-4c0d-bae2-45a70cc6a7d7" />

After:
<img width="687" height="645" alt="bild" src="https://github.com/user-attachments/assets/eaf5ad35-37ce-47cc-be90-6e355b68455f" />
<img width="920" height="515" alt="bild" src="https://github.com/user-attachments/assets/9ad85eed-231f-4fdb-9193-eaf733864112" />
<img width="688" height="615" alt="bild" src="https://github.com/user-attachments/assets/64f93380-9165-451e-a5db-1a72f02f8b8d" />



### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [ ] I've set the labels, issue, and milestone for the PR
- [x] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Related to #1407 