### PR TITLE
[#1260] Add loading and error states to regional overview page.

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1020,6 +1020,8 @@
     }
   },
   "regionalOverviewPage": {
+    "errorTitle": "Failed to retrieve regional information",
+    "errorDescription": "Please try again later",
     "title": "Regional Overview",
     "description": "Overview of emissions and transition at the regional level"
   },

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -1078,6 +1078,8 @@
     }
   },
   "regionalOverviewPage": {
+    "errorTitle": "Det gick inte att hämta länsinformation",
+    "errorDescription": "Försök igen senare",
     "title": "Länsöversikt",
     "description": "Översikt över utsläpp och omställning på länsnivå"
   },

--- a/src/pages/RegionalOverviewPage.tsx
+++ b/src/pages/RegionalOverviewPage.tsx
@@ -30,7 +30,11 @@ export function RegionalOverviewPage() {
   const { t } = useTranslation();
   const regionalKPIs = useRegionalKPIs();
   const [geoData] = useState(regionGeoJson);
-  const { regionsData } = useRegionsKPIs();
+  const {
+    regionsData,
+    loading: regionsLoading,
+    error: regionsError,
+  } = useRegionsKPIs();
 
   const navigate = useNavigate();
 
@@ -87,6 +91,32 @@ export function RegionalOverviewPage() {
         typeof region.meetsParis === "boolean" ? region.meetsParis : null,
     }));
   }, [regionEntities]);
+
+  if (regionsLoading) {
+    return (
+      <div className="animate-pulse space-y-16">
+        <div className="h-12 w-1/3 bg-black-1 rounded" />
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          {[...Array(6)].map((_, i) => (
+            <div key={i} className="h-96 bg-black-1 rounded-level-2" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (regionsError) {
+    return (
+      <div className="text-center py-24">
+        <h3 className="text-red-500 mb-4 text-xl">
+          {t("regionalOverviewPage.errorTitle")}
+        </h3>
+        <p className="text-grey">
+          {t("regionalOverviewPage.errorDescription")}
+        </p>
+      </div>
+    );
+  }
 
   const regionalRankedList = (
     <RegionalRankedList


### PR DESCRIPTION
### ✨ What’s Changed?

Handle regions KPI fetch failures with the same UX pattern as the municipalities overview page.

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [ ] I've verified the change runs locally both on mobile and desktop
- [x] I've set the labels, issue, and milestone for the PR
- [ ] [OPTIONAL] I've created sub-tasks or follow-up issues as needed (check if NA)

### 🛠 Related Issue

Closes #1260 