### PR TITLE
[#1413] Add Scope 1 text to methodology emission categories page

### DIFF
--- a/src/components/methods/content/EmissionsCategories.tsx
+++ b/src/components/methods/content/EmissionsCategories.tsx
@@ -7,6 +7,12 @@ export const EmissionsAndCategoriesContent = () => {
   return (
     <div className="prose prose-invert mx-auto space-y-8">
       <MethodSection
+        title={t("methodsPage.company.emissionCategories.scope1.title")}
+      >
+        <p>{t("methodsPage.company.emissionCategories.scope1.paragraph1")}</p>
+      </MethodSection>
+
+      <MethodSection
         title={t("methodsPage.company.emissionCategories.scope2.title")}
       >
         <p>{t("methodsPage.company.emissionCategories.scope2.paragraph1")}</p>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -772,6 +772,10 @@
         "title": "Emissions and Categories",
         "description": "Understanding different types of emissions and how they are categorized",
         "paragraph1": "Companies report their emissions according to the GHG Protocol's three scopes:",
+        "scope1": {
+          "title": "Scope 1: Direct Emissions",
+          "paragraph1": "Scope 1 emissions are direct greenhouse gas emissions from sources owned or controlled by the company, such as fuel burned in company vehicles, on-site boilers, and manufacturing processes. Klimatkollen presents scope 1 emissions as reported by companies."
+        },
         "scope2": {
           "title": "Scope 2: Indirect Energy Emissions",
           "paragraph1": "Scope 2 emissions are primarily calculated using the market-based method, which takes into account whether companies purchase renewable electricity. If such data is missing, we use data from the location-based method instead."

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -831,6 +831,10 @@
         "title": "Utsläpp och utsläppskategorier",
         "description": "Förstå olika typer av utsläpp och hur de kategoriseras",
         "paragraph1": "Företag rapporterar sina utsläpp enligt GHG-protokollets tre scope:",
+        "scope1": {
+          "title": "Scope 1: Direkta utsläpp",
+          "paragraph1": "Scope 1-utsläpp är direkta växthusgasutsläpp från källor som ägs eller kontrolleras av företaget, till exempel bränsleförbränning i företagsfordon, värmepannor på plats och tillverkningsprocesser. Klimatkollen presenterar scope 1-utsläpp som de rapporteras av företagen."
+        },
         "scope2": {
           "title": "Scope 2: Indirekta energiutsläpp",
           "paragraph1": "Scope 2-utsläpp beräknas primärt med marknadsbaserad metod, där det tas hänsyn till om företagen köper förnybar el. Om sådan data saknas används platsbaserad metod istället."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### ✨ What’s Changed?

Adds a missing Scope 1 section to the **Emissions and Categories** methodology page (`/methodology?view=emissionCategories`), which previously only explained Scope 2 and Scope 3.

- Added a new Scope 1 section in `EmissionsCategories.tsx`, placed before Scope 2 and Scope 3
- Added English and Swedish translations describing what Scope 1 covers (direct emissions from sources owned or controlled by the company) and how Klimatkollen presents Scope 1 data (as reported by companies)

### 📸 Screenshots (if applicable)

N/A — copy-only change

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [ ] I've verified the change runs locally both on mobile and desktop
- [ ] I've set the labels, issue, and milestone for the PR

### 🛠 Related Issue

Closes #1413 
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [KLI-98](https://linear.app/klimatkollen/issue/KLI-98/copy-add-text-about-scope-1)

<div><a href="https://cursor.com/agents/bc-05e942dd-d779-469c-a1ac-7b13a527e85e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05e942dd-d779-469c-a1ac-7b13a527e85e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

