### PR TITLE
Add Europe emissions time series KPIs (meets Paris + change since 2015)

### DIFF
--- a/src/hooks/europe/useClimateTraceEmissions.ts
+++ b/src/hooks/europe/useClimateTraceEmissions.ts
@@ -3,7 +3,7 @@ import { getClimateTraceCountryEmissions } from "@/lib/climateTrace";
 
 export function useClimateTraceEmissions() {
   const { data, isLoading, error } = useQuery({
-    queryKey: ["climate-trace-country-emissions"],
+    queryKey: ["climate-trace-country-emissions-time-series"],
     queryFn: getClimateTraceCountryEmissions,
     staleTime: 1000 * 60 * 60,
   });

--- a/src/hooks/europe/useEuropeKPIs.ts
+++ b/src/hooks/europe/useEuropeKPIs.ts
@@ -30,5 +30,34 @@ export const useEuropeanKPIs = (): KPIValue<EuropeanCountry>[] => {
       source: "europe.list.kpis.emissionsPercentChange.source",
       sourceUrls: ["https://climatetrace.org/"],
     },
+    {
+      label: t("europe.list.kpis.historicalEmissionChangePercent.label"),
+      key: "historicalEmissionChangePercent",
+      unit: "%",
+      description: t(
+        "europe.list.kpis.historicalEmissionChangePercent.description",
+      ),
+      detailedDescription: t(
+        "europe.list.kpis.historicalEmissionChangePercent.detailedDescription",
+      ),
+      higherIsBetter: false,
+      source: "europe.list.kpis.historicalEmissionChangePercent.source",
+      sourceUrls: ["https://climatetrace.org/"],
+    },
+    {
+      label: t("europe.list.kpis.meetsParis.label"),
+      key: "meetsParis",
+      unit: "",
+      description: t("europe.list.kpis.meetsParis.description"),
+      detailedDescription: t("europe.list.kpis.meetsParis.detailedDescription"),
+      higherIsBetter: true,
+      isBoolean: true,
+      booleanLabels: {
+        true: t("europe.list.kpis.meetsParis.booleanLabels.true"),
+        false: t("europe.list.kpis.meetsParis.booleanLabels.false"),
+      },
+      source: "europe.list.kpis.meetsParis.source",
+      sourceUrls: ["https://climatetrace.org/"],
+    },
   ];
 };

--- a/src/hooks/europe/useEuropeanData.ts
+++ b/src/hooks/europe/useEuropeanData.ts
@@ -84,6 +84,9 @@ function buildClimateTraceEntities(
         {
           emissionsPerCapita: ranking.emissionsPerCapita,
           emissionsPercentChange: ranking.emissionsPercentChange,
+          historicalEmissionChangePercent:
+            ranking.historicalEmissionChangePercent,
+          meetsParis: ranking.meetsParis,
         },
       ),
     ];
@@ -124,8 +127,12 @@ function toEuropeanCountries(
       typeof country.emissionsPercentChange === "number"
         ? country.emissionsPercentChange
         : null,
-    historicalEmissionChangePercent: null,
-    meetsParis: null,
+    historicalEmissionChangePercent:
+      typeof country.historicalEmissionChangePercent === "number"
+        ? country.historicalEmissionChangePercent
+        : null,
+    meetsParis:
+      typeof country.meetsParis === "boolean" ? country.meetsParis : null,
   }));
 }
 

--- a/src/lib/climateTrace.ts
+++ b/src/lib/climateTrace.ts
@@ -1,9 +1,16 @@
+import { getCurrentYear } from "@/utils/calculations/emissionsCalculations";
+import {
+  calculateClimateTraceCountryKpis,
+  CLIMATE_TRACE_BASE_YEAR,
+  EmissionsByYear,
+} from "@/utils/europe/climateTraceKpis";
+
 const CLIMATE_TRACE_API_BASE = "https://api.climatetrace.org/v7";
 
 export const CLIMATE_TRACE_EMISSIONS_PARAMS = {
   gas: "co2e_100yr",
-  start: "2025-01-01",
-  end: "2025-12-31",
+  startYear: CLIMATE_TRACE_BASE_YEAR,
+  endYear: getCurrentYear(),
 } as const;
 
 export type ClimateTraceCountryRanking = {
@@ -17,17 +24,27 @@ export type ClimateTraceCountryRanking = {
   emissionsPercentChange: number;
 };
 
+export type ClimateTraceCountryData = ClimateTraceCountryRanking & {
+  emissionsByYear: EmissionsByYear;
+  historicalEmissionChangePercent: number | null;
+  meetsParis: boolean | null;
+};
+
 type ClimateTraceCountryRankingsResponse = {
   rankings: ClimateTraceCountryRanking[];
 };
 
 export type ClimateTraceKpiKey =
   | "emissionsPerCapita"
-  | "emissionsPercentChange";
+  | "emissionsPercentChange"
+  | "historicalEmissionChangePercent"
+  | "meetsParis";
 
 export const CLIMATE_TRACE_KPI_KEYS = new Set<ClimateTraceKpiKey>([
   "emissionsPerCapita",
   "emissionsPercentChange",
+  "historicalEmissionChangePercent",
+  "meetsParis",
 ]);
 
 export function isClimateTraceKpiKey(
@@ -38,14 +55,24 @@ export function isClimateTraceKpiKey(
 
 export type ClimateTraceEmissionsByIso = Record<
   string,
-  ClimateTraceCountryRanking
+  ClimateTraceCountryData
 >;
 
-export async function getClimateTraceCountryEmissions(): Promise<ClimateTraceEmissionsByIso> {
+function buildYearDateRange(year: number): { start: string; end: string } {
+  return {
+    start: `${year}-01-01`,
+    end: `${year}-12-31`,
+  };
+}
+
+async function fetchClimateTraceCountryRankingsForYear(
+  year: number,
+): Promise<ClimateTraceCountryRanking[]> {
+  const { start, end } = buildYearDateRange(year);
   const url = new URL(`${CLIMATE_TRACE_API_BASE}/rankings/countries`);
   url.searchParams.set("gas", CLIMATE_TRACE_EMISSIONS_PARAMS.gas);
-  url.searchParams.set("start", CLIMATE_TRACE_EMISSIONS_PARAMS.start);
-  url.searchParams.set("end", CLIMATE_TRACE_EMISSIONS_PARAMS.end);
+  url.searchParams.set("start", start);
+  url.searchParams.set("end", end);
   url.searchParams.set("sectors", "");
   url.searchParams.set("subsectors", "");
   url.searchParams.set("countryGroup", "");
@@ -54,13 +81,77 @@ export async function getClimateTraceCountryEmissions(): Promise<ClimateTraceEmi
   const response = await fetch(url.toString());
   if (!response.ok) {
     throw new Error(
-      `Climate TRACE API request failed: ${response.status} ${response.statusText}`,
+      `Climate TRACE API request failed for ${year}: ${response.status} ${response.statusText}`,
     );
   }
 
   const data = (await response.json()) as ClimateTraceCountryRankingsResponse;
+  return data.rankings;
+}
 
+function buildEmissionsByYearFromRankings(
+  rankingsByYear: Record<number, ClimateTraceCountryRanking[]>,
+): Record<string, EmissionsByYear> {
+  const emissionsByIso: Record<string, EmissionsByYear> = {};
+
+  for (const [year, rankings] of Object.entries(rankingsByYear)) {
+    const numericYear = Number(year);
+
+    for (const ranking of rankings) {
+      if (!emissionsByIso[ranking.country]) {
+        emissionsByIso[ranking.country] = {};
+      }
+
+      emissionsByIso[ranking.country][numericYear] = ranking.emissionsQuantity;
+    }
+  }
+
+  return emissionsByIso;
+}
+
+function enrichRankingsWithTimeSeries(
+  latestRankings: ClimateTraceCountryRanking[],
+  emissionsByIso: Record<string, EmissionsByYear>,
+): ClimateTraceEmissionsByIso {
   return Object.fromEntries(
-    data.rankings.map((ranking) => [ranking.country, ranking]),
+    latestRankings.map((ranking) => {
+      const emissionsByYear = emissionsByIso[ranking.country] ?? {};
+      const kpis = calculateClimateTraceCountryKpis(emissionsByYear);
+
+      return [
+        ranking.country,
+        {
+          ...ranking,
+          emissionsByYear,
+          ...kpis,
+        },
+      ];
+    }),
   );
+}
+
+export async function getClimateTraceCountryEmissions(): Promise<ClimateTraceEmissionsByIso> {
+  const years = Array.from(
+    {
+      length:
+        CLIMATE_TRACE_EMISSIONS_PARAMS.endYear -
+        CLIMATE_TRACE_EMISSIONS_PARAMS.startYear +
+        1,
+    },
+    (_, index) => CLIMATE_TRACE_EMISSIONS_PARAMS.startYear + index,
+  );
+
+  const rankingsByYearEntries = await Promise.all(
+    years.map(
+      async (year) =>
+        [year, await fetchClimateTraceCountryRankingsForYear(year)] as const,
+    ),
+  );
+
+  const rankingsByYear = Object.fromEntries(rankingsByYearEntries);
+  const latestYear = years[years.length - 1];
+  const latestRankings = rankingsByYear[latestYear] ?? [];
+  const emissionsByIso = buildEmissionsByYearFromRankings(rankingsByYear);
+
+  return enrichRankingsWithTimeSeries(latestRankings, emissionsByIso);
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1535,6 +1535,22 @@
           "description": "Year-over-year change in emissions under 2025",
           "detailedDescription": "Percentage change in CO₂e emissions under 2025.",
           "source": "Climate TRACE"
+        },
+        "historicalEmissionChangePercent": {
+          "label": "Emissions change since 2015",
+          "description": "Annual change in emissions since 2015",
+          "detailedDescription": "Average annual percentage change in CO₂e emissions since 2015, based on Climate TRACE data from 2015 to the latest available year.",
+          "source": "Climate TRACE"
+        },
+        "meetsParis": {
+          "label": "Paris Agreement",
+          "description": "Emissions trend compared to the Paris Agreement",
+          "detailedDescription": "Whether a country's projected emissions path meets the Paris Agreement, based on a trendline from 2015 and a Carbon Law pathway (11.7% annual reduction from 2025).",
+          "source": "Klimatkollen Analysis",
+          "booleanLabels": {
+            "true": "Meets Paris Agreement",
+            "false": "Fails Paris Agreement"
+          }
         }
       }
     }

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -1594,6 +1594,22 @@
           "description": "Förändring i utsläpp under 2025",
           "detailedDescription": "Procentuell förändring i CO₂e-utsläpp under 2025.",
           "source": "Climate TRACE"
+        },
+        "historicalEmissionChangePercent": {
+          "label": "Utsläppsförändring sedan 2015",
+          "description": "Årlig utsläppsförändring sedan 2015",
+          "detailedDescription": "Genomsnittlig årlig procentuell förändring i CO₂e-utsläpp sedan 2015, baserad på Climate TRACE-data från 2015 till senaste tillgängliga år.",
+          "source": "Climate TRACE"
+        },
+        "meetsParis": {
+          "label": "Parisavtalet",
+          "description": "Utsläppstrend jämfört med Parisavtalet",
+          "detailedDescription": "Om landets projicerade utsläppsbana klarar Parisavtalet, baserat på en trendlinje från 2015 och en Carbon Law-väg (11,7% årlig minskning från 2025).",
+          "source": "Klimatkollen Analys",
+          "booleanLabels": {
+            "true": "Klarar Parisavtalet",
+            "false": "Missar Parisavtalet"
+          }
         }
       }
     }

--- a/src/utils/europe/climateTraceKpis.test.ts
+++ b/src/utils/europe/climateTraceKpis.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+  calculateClimateTraceCountryKpis,
+  calculateHistoricalEmissionChangePercent,
+  calculateMeetsParisFromTimeSeries,
+  CLIMATE_TRACE_BASE_YEAR,
+} from "./climateTraceKpis";
+
+describe("climateTraceKpis", () => {
+  it("calculates annualized emissions change since 2015 (CAGR)", () => {
+    const emissionsByYear = {
+      2015: 100,
+      2016: 95,
+      2017: 90,
+      2018: 85,
+      2019: 80,
+      2020: 75,
+      2021: 70,
+      2022: 65,
+      2023: 60,
+      2024: 55,
+    };
+
+    const change = calculateHistoricalEmissionChangePercent(emissionsByYear);
+
+    expect(change).not.toBeNull();
+    expect(change!).toBeCloseTo(-6.43, 1);
+  });
+
+  it("returns null when base year data is missing", () => {
+    expect(
+      calculateHistoricalEmissionChangePercent({
+        2016: 100,
+        2024: 80,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns true for steeply declining emissions trajectories", () => {
+    const emissionsByYear = Object.fromEntries(
+      Array.from({ length: 11 }, (_, index) => {
+        const year = CLIMATE_TRACE_BASE_YEAR + index;
+        return [year, 1_000_000 * 0.92 ** index];
+      }),
+    );
+
+    expect(calculateMeetsParisFromTimeSeries(emissionsByYear)).toBe(true);
+  });
+
+  it("returns false for steeply increasing emissions trajectories", () => {
+    const emissionsByYear = Object.fromEntries(
+      Array.from({ length: 11 }, (_, index) => {
+        const year = CLIMATE_TRACE_BASE_YEAR + index;
+        return [year, 1_000_000 * 1.05 ** index];
+      }),
+    );
+
+    expect(calculateMeetsParisFromTimeSeries(emissionsByYear)).toBe(false);
+  });
+
+  it("calculates both KPIs together", () => {
+    const emissionsByYear = {
+      2015: 1_000_000,
+      2016: 980_000,
+      2017: 960_000,
+      2018: 940_000,
+      2019: 920_000,
+      2020: 900_000,
+      2021: 880_000,
+      2022: 860_000,
+      2023: 840_000,
+      2024: 820_000,
+      2025: 800_000,
+    };
+
+    const kpis = calculateClimateTraceCountryKpis(emissionsByYear);
+
+    expect(kpis.historicalEmissionChangePercent).not.toBeNull();
+    expect(typeof kpis.meetsParis).toBe("boolean");
+  });
+});

--- a/src/utils/europe/climateTraceKpis.ts
+++ b/src/utils/europe/climateTraceKpis.ts
@@ -1,0 +1,156 @@
+import {
+  calculateCarbonLawCumulativeEmissions,
+  calculateCumulativeEmissions,
+} from "@/lib/calculations/trends/meetsParis";
+
+export const CLIMATE_TRACE_BASE_YEAR = 2015;
+export const PARIS_PROJECTION_START_YEAR = 2025;
+export const PARIS_PROJECTION_END_YEAR = 2050;
+
+export type EmissionsByYear = Record<number, number>;
+
+export function calculateLinearRegressionSlope(
+  points: { year: number; value: number }[],
+): number | null {
+  if (points.length < 2) {
+    return null;
+  }
+
+  const meanX =
+    points.reduce((sum, point) => sum + point.year, 0) / points.length;
+  const meanY =
+    points.reduce((sum, point) => sum + point.value, 0) / points.length;
+
+  const numerator = points.reduce(
+    (sum, point) => sum + (point.year - meanX) * (point.value - meanY),
+    0,
+  );
+  const denominator = points.reduce(
+    (sum, point) => sum + (point.year - meanX) ** 2,
+    0,
+  );
+
+  if (denominator === 0) {
+    return null;
+  }
+
+  return numerator / denominator;
+}
+
+export function getEmissionsPointsFromBaseYear(
+  emissionsByYear: EmissionsByYear,
+  baseYear: number = CLIMATE_TRACE_BASE_YEAR,
+): { year: number; value: number }[] {
+  return Object.entries(emissionsByYear)
+    .map(([year, value]) => ({ year: Number(year), value }))
+    .filter(
+      (point) =>
+        point.year >= baseYear &&
+        Number.isFinite(point.value) &&
+        point.value > 0,
+    )
+    .sort((a, b) => a.year - b.year);
+}
+
+export function calculateHistoricalEmissionChangePercent(
+  emissionsByYear: EmissionsByYear,
+  baseYear: number = CLIMATE_TRACE_BASE_YEAR,
+): number | null {
+  const baseYearEmissions = emissionsByYear[baseYear];
+  if (!baseYearEmissions || baseYearEmissions <= 0) {
+    return null;
+  }
+
+  const latestYear = Math.max(...Object.keys(emissionsByYear).map(Number));
+  if (latestYear <= baseYear) {
+    return null;
+  }
+
+  const latestEmissions = emissionsByYear[latestYear];
+  if (!latestEmissions || latestEmissions <= 0) {
+    return null;
+  }
+
+  const yearSpan = latestYear - baseYear;
+  const cagr = (latestEmissions / baseYearEmissions) ** (1 / yearSpan) - 1;
+
+  return cagr * 100;
+}
+
+export function getEmissionsForParisProjection(
+  emissionsByYear: EmissionsByYear,
+  slope: number,
+  projectionYear: number = PARIS_PROJECTION_START_YEAR,
+): number | null {
+  const actualProjectionYearEmissions = emissionsByYear[projectionYear];
+  if (actualProjectionYearEmissions && actualProjectionYearEmissions > 0) {
+    return actualProjectionYearEmissions;
+  }
+
+  const points = getEmissionsPointsFromBaseYear(emissionsByYear);
+  if (points.length === 0) {
+    return null;
+  }
+
+  const latestPoint = points[points.length - 1];
+  if (latestPoint.year >= projectionYear) {
+    return latestPoint.value > 0 ? latestPoint.value : null;
+  }
+
+  const yearsFromLatest = projectionYear - latestPoint.year;
+  const projectedEmissions = latestPoint.value + slope * yearsFromLatest;
+
+  return projectedEmissions > 0 ? projectedEmissions : null;
+}
+
+export function calculateMeetsParisFromTimeSeries(
+  emissionsByYear: EmissionsByYear,
+  baseYear: number = CLIMATE_TRACE_BASE_YEAR,
+): boolean | null {
+  const points = getEmissionsPointsFromBaseYear(emissionsByYear, baseYear);
+  if (points.length < 2) {
+    return null;
+  }
+
+  const slope = calculateLinearRegressionSlope(points);
+  if (slope === null) {
+    return null;
+  }
+
+  const emissions2025 = getEmissionsForParisProjection(emissionsByYear, slope);
+  if (emissions2025 === null) {
+    return null;
+  }
+
+  if (emissions2025 <= 0) {
+    return true;
+  }
+
+  const trendCumulativeEmissions = calculateCumulativeEmissions(
+    emissions2025,
+    slope,
+    PARIS_PROJECTION_START_YEAR,
+    PARIS_PROJECTION_END_YEAR,
+  );
+
+  const carbonLawCumulativeEmissions = calculateCarbonLawCumulativeEmissions(
+    emissions2025,
+    PARIS_PROJECTION_START_YEAR,
+    PARIS_PROJECTION_END_YEAR,
+  );
+
+  return trendCumulativeEmissions <= carbonLawCumulativeEmissions;
+}
+
+export function calculateClimateTraceCountryKpis(
+  emissionsByYear: EmissionsByYear,
+): {
+  historicalEmissionChangePercent: number | null;
+  meetsParis: boolean | null;
+} {
+  return {
+    historicalEmissionChangePercent:
+      calculateHistoricalEmissionChangePercent(emissionsByYear),
+    meetsParis: calculateMeetsParisFromTimeSeries(emissionsByYear),
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extends the Europe Climate TRACE integration (#1337) to fetch emissions time series data from 2015 through the current year, and derive two additional KPIs used elsewhere on Klimatkollen:

- **Emissions change since 2015** (`historicalEmissionChangePercent`) — compound annual growth rate (CAGR) from 2015 to the latest available year, matching the methodology used for Swedish municipalities and regions
- **Meets Paris Agreement** (`meetsParis`) — compares a linear trendline (from 2015 data) against a Carbon Law pathway (11.7% annual reduction from 2025–2050)

## Implementation

- Fetches Climate TRACE country rankings for each year from 2015 to the current year in parallel
- Builds per-country time series and computes KPIs client-side in `src/utils/europe/climateTraceKpis.ts`
- Adds the two new KPIs to the Europe ranked page selector, map, list, and insights panel
- Adds EN/SV translations and unit tests for the KPI calculations

## Testing

- `npm test -- src/utils/europe/climateTraceKpis.test.ts` — all 5 tests pass
- `npm run build` — succeeds

## Notes

This PR targets `feat-europe` and should be merged after or together with #1337.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a7215cde-16f4-4186-879a-3fdcecd8e1ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a7215cde-16f4-4186-879a-3fdcecd8e1ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

