### PR TITLE
Use /companies/kpis for overview and landing KPI stats

### DIFF
--- a/src/hooks/companies/useCompaniesKPIs.ts
+++ b/src/hooks/companies/useCompaniesKPIs.ts
@@ -1,0 +1,45 @@
+import { useQuery } from "@tanstack/react-query";
+import { getCompaniesKPIs } from "@/lib/api";
+import type { CompanyKpiData, CompanyWithKPIs, RankedCompany } from "@/types/company";
+
+export type { CompanyKpiData } from "@/types/company";
+
+/** Fetches company KPIs from `/companies/kpis` (overview / landing). */
+export function useCompaniesKPIs(options?: { enabled?: boolean }) {
+  const {
+    data: companiesKpiData = [],
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ["companies-kpis"],
+    queryFn: getCompaniesKPIs,
+    enabled: options?.enabled ?? true,
+    staleTime: 1800000,
+  });
+
+  return {
+    companiesKpiData,
+    loading: isLoading,
+    error,
+  };
+}
+
+export function buildCompanyKpiLookup(
+  companiesKpiData: CompanyKpiData[],
+): Map<string, CompanyKpiData> {
+  return new Map(companiesKpiData.map((kpi) => [kpi.wikidataId, kpi]));
+}
+
+/** Merge API KPI values onto a ranked company (replaces client-side KPI calculation). */
+export function mergeApiKpisOntoCompany(
+  company: RankedCompany,
+  kpiLookup: Map<string, CompanyKpiData>,
+): CompanyWithKPIs {
+  const kpi = kpiLookup.get(company.wikidataId);
+
+  return {
+    ...company,
+    meetsParis: kpi?.meetsParis ?? null,
+    emissionsChangeFromBaseYear: kpi?.emissionsChangeFromBaseYear ?? null,
+  };
+}

--- a/src/hooks/companies/useCompaniesKPIs.ts
+++ b/src/hooks/companies/useCompaniesKPIs.ts
@@ -1,6 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import { getCompaniesKPIs } from "@/lib/api";
-import type { CompanyKpiData, CompanyWithKPIs, RankedCompany } from "@/types/company";
+import type {
+  CompanyKpiData,
+  CompanyWithKPIs,
+  RankedCompany,
+} from "@/types/company";
 
 export type { CompanyKpiData } from "@/types/company";
 

--- a/src/hooks/landing/useDidYouKnowStats.ts
+++ b/src/hooks/landing/useDidYouKnowStats.ts
@@ -38,8 +38,7 @@ function toKpiDataFromCompanies(
       wikidataId: company.wikidataId,
       name: company.name,
       meetsParis: enriched.meetsParis ?? null,
-      emissionsChangeFromBaseYear:
-        enriched.emissionsChangeFromBaseYear ?? null,
+      emissionsChangeFromBaseYear: enriched.emissionsChangeFromBaseYear ?? null,
     };
   });
 }

--- a/src/hooks/landing/useDidYouKnowStats.ts
+++ b/src/hooks/landing/useDidYouKnowStats.ts
@@ -10,9 +10,10 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { useCompanies } from "@/hooks/companies/useCompanies";
-import { useMunicipalities } from "@/hooks/municipalities/useMunicipalities";
+import { useCompaniesKPIs } from "@/hooks/companies/useCompaniesKPIs";
 import { enrichCompanyWithKPIs } from "@/hooks/companies/useCompanyKPIs";
-import { calculateEmissionsChangeFromBaseYear } from "@/utils/calculations/emissionsCalculations";
+import { useMunicipalities } from "@/hooks/municipalities/useMunicipalities";
+import type { CompanyKpiData } from "@/types/company";
 
 interface StatCard {
   icon: LucideIcon;
@@ -28,9 +29,25 @@ interface StatCard {
 const REDUCTION_THRESHOLD = -20;
 const MILLION_DIVISOR = 1_000_000;
 
+function toKpiDataFromCompanies(
+  companies: ReturnType<typeof useCompanies>["companies"],
+): CompanyKpiData[] {
+  return companies.map((company) => {
+    const enriched = enrichCompanyWithKPIs(company);
+    return {
+      wikidataId: company.wikidataId,
+      name: company.name,
+      meetsParis: enriched.meetsParis ?? null,
+      emissionsChangeFromBaseYear:
+        enriched.emissionsChangeFromBaseYear ?? null,
+    };
+  });
+}
+
 export function useDidYouKnowStats() {
   const { t } = useTranslation();
   const { companies } = useCompanies();
+  const { companiesKpiData } = useCompaniesKPIs();
   const { municipalities } = useMunicipalities();
 
   const stats = useMemo(() => {
@@ -38,30 +55,29 @@ export function useDidYouKnowStats() {
       return [];
     }
 
-    const enrichedCompanies = companies.map(enrichCompanyWithKPIs);
+    const kpiSource =
+      companiesKpiData.length > 0
+        ? companiesKpiData
+        : toKpiDataFromCompanies(companies);
 
-    // Stat #1: Companies with >20% reduction since base year
-    const companiesWithSignificantReduction = enrichedCompanies.filter(
-      (company) => {
-        const changePercent = calculateEmissionsChangeFromBaseYear(company, {
-          useLastPeriod: false,
-        });
-        return changePercent !== null && changePercent < REDUCTION_THRESHOLD;
-      },
+    const companyCount = kpiSource.length;
+
+    // Stat #1: Companies with >20% reduction since base year (from /companies/kpis)
+    const companiesWithSignificantReduction = kpiSource.filter(
+      (company) =>
+        company.emissionsChangeFromBaseYear !== null &&
+        company.emissionsChangeFromBaseYear < REDUCTION_THRESHOLD,
     );
 
-    // Stat #2: Companies with increased emissions from base year
-    const companiesWithIncreasedEmissions = enrichedCompanies.filter(
-      (company) => {
-        const changePercent = calculateEmissionsChangeFromBaseYear(company, {
-          useLastPeriod: false,
-        });
-        return changePercent !== null && changePercent > 0;
-      },
+    // Stat #2: Companies with increased emissions from base year (from /companies/kpis)
+    const companiesWithIncreasedEmissions = kpiSource.filter(
+      (company) =>
+        company.emissionsChangeFromBaseYear !== null &&
+        company.emissionsChangeFromBaseYear > 0,
     );
 
     // Stat #3: Combined Paris alignment (companies + municipalities)
-    const companiesMeetingParis = enrichedCompanies.filter(
+    const companiesMeetingParis = kpiSource.filter(
       (company) => company.meetsParis === true,
     );
     const municipalitiesOnTrack = municipalities.filter(
@@ -70,7 +86,7 @@ export function useDidYouKnowStats() {
     const totalParisAligned =
       companiesMeetingParis.length + municipalitiesOnTrack.length;
 
-    // Stat #4: Companies reporting Scope 3 categories
+    // Stat #4: Companies reporting Scope 3 categories (requires full /companies/ data)
     const companiesWithScope3Categories = companies.filter((company) => {
       const latestPeriod = company.reportingPeriods?.[0];
       const scope3Categories =
@@ -123,7 +139,7 @@ export function useDidYouKnowStats() {
         headline: `${companiesWithSignificantReduction.length}`,
         description: t("landingPage.didYouKnow.stat1.description", {
           count: companiesWithSignificantReduction.length,
-          total: companies.length,
+          total: companyCount,
         }),
         bgColor: "bg-green-4",
         iconBgColor: "bg-green-3",
@@ -136,7 +152,7 @@ export function useDidYouKnowStats() {
         headline: `${companiesWithIncreasedEmissions.length}`,
         description: t("landingPage.didYouKnow.stat2.description", {
           count: companiesWithIncreasedEmissions.length,
-          total: companies.length,
+          total: companyCount,
         }),
         bgColor: "bg-pink-4",
         iconBgColor: "bg-pink-3",
@@ -149,7 +165,7 @@ export function useDidYouKnowStats() {
         headline: `${totalParisAligned}`,
         description: t("landingPage.didYouKnow.stat3.description", {
           companyCount: companiesMeetingParis.length,
-          companyTotal: companies.length,
+          companyTotal: companyCount,
           municipalityCount: municipalitiesOnTrack.length,
           municipalityTotal: municipalities.length,
         }),
@@ -201,7 +217,7 @@ export function useDidYouKnowStats() {
     ];
 
     return statCards;
-  }, [companies, municipalities, t]);
+  }, [companies, companiesKpiData, municipalities, t]);
 
   return stats;
 }

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -477,6 +477,50 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/companies/kpis": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get company KPIs
+         * @description Retrieve key performance indicators for all companies, including Paris agreement compliance and emissions change from base year.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            wikidataId: string;
+                            name: string;
+                            meetsParis: boolean | null;
+                            emissionsChangeFromBaseYear: number | null;
+                        }[];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/companies/search": {
         parameters: {
             query?: never;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -82,6 +82,21 @@ export async function getCompanies() {
   }
 }
 
+export async function getCompaniesKPIs(): Promise<
+  NonNullable<
+    paths["/companies/kpis"]["get"]["responses"][200]["content"]["application/json"]
+  >
+> {
+  try {
+    const { data, error } = await GET("/companies/kpis", {});
+    if (error) throw error;
+    return data ?? [];
+  } catch (error) {
+    console.error("Error fetching company KPIs:", error);
+    return [];
+  }
+}
+
 export async function getCompanyDetails(id: string) {
   const { data, error } = await client.GET("/companies/{wikidataId}", {
     params: {

--- a/src/pages/CompaniesOverviewPage.tsx
+++ b/src/pages/CompaniesOverviewPage.tsx
@@ -16,6 +16,11 @@ import {
   CompanyWithKPIs,
   enrichCompanyWithKPIs,
 } from "@/hooks/companies/useCompanyKPIs";
+import {
+  useCompaniesKPIs,
+  buildCompanyKpiLookup,
+  mergeApiKpisOntoCompany,
+} from "@/hooks/companies/useCompaniesKPIs";
 import { DataPoint } from "@/types/rankings";
 import {
   OverviewSplitLayout,
@@ -26,6 +31,7 @@ import { getCompanyDetailPath } from "@/utils/companyRouting";
 export function CompaniesOverviewPage() {
   const { t } = useTranslation();
   const { companies, companiesLoading, companiesError } = useCompanies();
+  const { companiesKpiData } = useCompaniesKPIs();
   const companyKPIs = useCompanyKPIs();
 
   const location = useLocation();
@@ -119,17 +125,25 @@ export function CompaniesOverviewPage() {
     }
   }, [getSectorFromURL, selectedSector]);
 
-  // Filter and enrich companies with KPI values
+  // Filter companies by sector and merge API KPI values (fallback to client calc if KPI API unavailable)
   const companiesWithKPIs: CompanyWithKPIs[] = useMemo(() => {
-    if (!companies || !selectedSector) return [];
+    if (!companies || !selectedSector) {
+      return [];
+    }
 
     const filtered = companies.filter((company) => {
       const sectorCode = company.industry?.industryGics?.sectorCode;
       return sectorCode === selectedSector;
     });
 
-    return filtered.map((company) => enrichCompanyWithKPIs(company));
-  }, [companies, selectedSector]);
+    if (companiesKpiData.length === 0) {
+      return filtered.map((company) => enrichCompanyWithKPIs(company));
+    }
+
+    const kpiLookup = buildCompanyKpiLookup(companiesKpiData);
+
+    return filtered.map((company) => mergeApiKpisOntoCompany(company, kpiLookup));
+  }, [companies, companiesKpiData, selectedSector]);
 
   const handleSectorChange = (sector: string) => {
     setSelectedSector(sector);

--- a/src/pages/CompaniesOverviewPage.tsx
+++ b/src/pages/CompaniesOverviewPage.tsx
@@ -142,7 +142,9 @@ export function CompaniesOverviewPage() {
 
     const kpiLookup = buildCompanyKpiLookup(companiesKpiData);
 
-    return filtered.map((company) => mergeApiKpisOntoCompany(company, kpiLookup));
+    return filtered.map((company) =>
+      mergeApiKpisOntoCompany(company, kpiLookup),
+    );
   }, [companies, companiesKpiData, selectedSector]);
 
   const handleSectorChange = (sector: string) => {

--- a/src/types/company.ts
+++ b/src/types/company.ts
@@ -80,6 +80,11 @@ export type CompanyListItem = NonNullable<
   paths["/companies/"]["get"]["responses"][200]["content"]["application/json"][number]
 >;
 
+// Company KPI type from the KPI endpoint (/companies/kpis)
+export type CompanyKpiData = NonNullable<
+  paths["/companies/kpis"]["get"]["responses"][200]["content"]["application/json"][number]
+>;
+
 // Extended company type with metrics and optional rankings
 export interface RankedCompany
   extends Omit<CompanyListItem, "reportingPeriods"> {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What's changed

Adds a `/companies/kpis` API client and `useCompaniesKPIs` hook (same pattern as municipalities and regions KPI endpoints).

**Companies overview page** — `meetsParis` and `emissionsChangeFromBaseYear` now come from the KPI endpoint instead of client-side `enrichCompanyWithKPIs`. Full `/companies/` data is still fetched for sector filtering and the Meets Paris carbon-budget visualization, which need reporting periods and industry metadata.

**Landing page (Did You Know)** — Paris alignment and emissions-change stats use KPI data from `/companies/kpis`. Scope 3 reporting and total emissions stats still use `/companies/` because those fields are not in the KPI payload.

Both pages fall back to client-side KPI calculation when the KPI endpoint returns no data (e.g. before Garbo deploys the route).

## API types

`/companies/kpis` is added manually to `api-types.ts` ahead of the published OpenAPI schema (the route exists in Garbo `main` but is not yet in production OpenAPI).

## Not changed

Explore, sectors, comparison, and internal dashboards still use `/companies/` where they need full company payloads (emissions history, scope 3, sorting, etc.).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0aefe52d-d905-44c6-8d52-ea910c3a7889"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0aefe52d-d905-44c6-8d52-ea910c3a7889"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

