### PR TITLE
Use municipality KPIs endpoint for landing page map

### DIFF
--- a/src/components/landing/useMunicipalitiesSection.ts
+++ b/src/components/landing/useMunicipalitiesSection.ts
@@ -4,11 +4,14 @@ import { useNavigate } from "react-router-dom";
 import { FeatureCollection } from "geojson";
 import municipalityGeoJson from "@/data/municipalityGeo.json";
 import regionGeoJson from "@/data/regionGeo.json";
-import { useMunicipalityKPIDefinitions } from "@/hooks/municipalities/useMunicipalityKPIs";
-import { useMunicipalities } from "@/hooks/municipalities/useMunicipalities";
+import {
+  useMunicipalityKPIDefinitions,
+  useMunicipalityKPIs,
+} from "@/hooks/municipalities/useMunicipalityKPIs";
 import { createEntityClickHandler } from "@/utils/routing";
 import { useRegionalKPIs, useRegionsKPIs } from "@/hooks/regions/useRegionKPIs";
 import { toMapRegionName } from "@/utils/regionUtils";
+import { toMunicipalityMapDataItem } from "@/utils/territoryMapData";
 
 export type TerritoryMode = "municipalities" | "regions";
 
@@ -18,7 +21,8 @@ export function useMunicipalitiesSection() {
   const municipalityKPIs = useMunicipalityKPIDefinitions();
   const regionalKPIs = useRegionalKPIs();
   const { regionsData, loading: regionsLoading } = useRegionsKPIs();
-  const { municipalities, municipalitiesLoading } = useMunicipalities();
+  const { municipalitiesData, loading: municipalitiesLoading } =
+    useMunicipalityKPIs();
 
   const [territoryMode, setTerritoryMode] =
     useState<TerritoryMode>("municipalities");
@@ -66,22 +70,12 @@ export function useMunicipalitiesSection() {
   );
 
   const handleMunicipalityAreaClick = (name: string) => {
-    const municipality = municipalities.find((m) => m.name === name);
-    if (municipality) {
-      handleMunicipalityClick(municipality);
-      return;
-    }
-
     handleMunicipalityClick(name);
   };
 
   const mapData = useMemo(
-    () =>
-      municipalities.map((m) => {
-        const { sectorEmissions, ...rest } = m;
-        return { ...rest, id: m.name };
-      }),
-    [municipalities],
+    () => municipalitiesData.map(toMunicipalityMapDataItem),
+    [municipalitiesData],
   );
 
   const regionMapData = useMemo(


### PR DESCRIPTION
## Summary
- Switch the landing page municipality map from `GET /municipalities/` to `GET /municipalities/kpis`
- Reuse `toMunicipalityMapDataItem` so map data matches the municipalities overview page
- Avoid downloading full municipality records (emission time series, political data, etc.) on every landing visit

## Test plan
- [x] Open the landing page and confirm the municipality map loads and colors correctly
- [x] Switch KPIs in the map dropdown and verify values update
- [x] Click a municipality on the map and confirm navigation to the detail page
- [x] Toggle between municipalities and regions and confirm both modes still work
- [x] Check network tab: landing page should call `/municipalities/kpis`, not `/municipalities/`


Made with [Cursor](https://cursor.com)