### PR TITLE
Add scroll-driven animation to oil export emissions chart bars

### DIFF
--- a/src/components/nation/ExportOfOilProductsEmissionsChart.tsx
+++ b/src/components/nation/ExportOfOilProductsEmissionsChart.tsx
@@ -172,7 +172,6 @@ function ExportOfOilProductsTooltip({
   payload,
   unit,
 }: ExportOfOilProductsTooltipProps) {
-  const { t } = useTranslation();
   const { currentLanguage } = useLanguage();
 
   if (!active || !payload?.length || !payload[0]?.payload) {
@@ -184,10 +183,6 @@ function ExportOfOilProductsTooltip({
     valueKt * 1000,
     currentLanguage,
   );
-  const citizenEquivalent = emissionsToSwedishCitizenEquivalent(
-    valueKt * 1000,
-    currentLanguage,
-  );
 
   return (
     <div className="rounded-level-2 border border-black-1 bg-black-2 px-3 py-2 shadow-md">
@@ -195,13 +190,6 @@ function ExportOfOilProductsTooltip({
       <p className="text-sm text-grey tabular-nums">
         {formattedValue} {unit}
       </p>
-      {citizenEquivalent && (
-        <p className="mt-2 border-t border-black-1 pt-2 text-sm font-medium text-yellow-3 tabular-nums">
-          {t("nation.exportOfOilProducts.citizenEquivalent", {
-            count: citizenEquivalent.formattedCount,
-          })}
-        </p>
-      )}
     </div>
   );
 }

--- a/src/components/nation/ExportOfOilProductsEmissionsChart.tsx
+++ b/src/components/nation/ExportOfOilProductsEmissionsChart.tsx
@@ -4,7 +4,6 @@ import {
   Bar,
   BarChart,
   Cell,
-  ReferenceLine,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -246,7 +245,6 @@ export function ExportOfOilProductsEmissionsChart({
       currentLanguage,
     );
   }, [latestYearPoint, currentLanguage]);
-  const baselineValueKt = chartData[0]?.valueKt;
   const xAxisTicks = useMemo(
     () => chartData.map((point) => point.year).filter((year) => year % 5 === 0),
     [chartData],
@@ -298,20 +296,6 @@ export function ExportOfOilProductsEmissionsChart({
                   cursor={{ fill: "var(--black-1)", opacity: 0.35 }}
                   wrapperStyle={{ outline: "none", zIndex: 60 }}
                 />
-
-                {baselineValueKt !== undefined && (
-                  <ReferenceLine
-                    y={baselineValueKt}
-                    stroke="var(--grey)"
-                    strokeDasharray="4 4"
-                    label={{
-                      value: "1990",
-                      position: "insideTopRight",
-                      fill: "var(--grey)",
-                      fontSize: 12,
-                    }}
-                  />
-                )}
 
                 <Bar
                   dataKey="displayValueKt"

--- a/src/components/nation/ExportOfOilProductsEmissionsChart.tsx
+++ b/src/components/nation/ExportOfOilProductsEmissionsChart.tsx
@@ -1,4 +1,5 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
+import { useMotionValueEvent, type MotionValue } from "framer-motion";
 import {
   Bar,
   BarChart,
@@ -46,8 +47,30 @@ const MAP_GRADIENT_CSS = `linear-gradient(to right,
 type ChartDatum = {
   year: number;
   valueKt: number;
+  displayValueKt: number;
   fill: string;
 };
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max);
+
+function getScrollBarScale(
+  scrollProgress: number,
+  barIndex: number,
+  barCount: number,
+): number {
+  if (barCount <= 1) {
+    return scrollProgress;
+  }
+
+  const staggerEnd = 0.92;
+  const overlap = 0.12 / barCount;
+  const segment = staggerEnd / barCount;
+  const start = barIndex * segment;
+  const end = start + segment + overlap;
+
+  return clamp((scrollProgress - start) / (end - start), 0, 1);
+}
 
 function getBarColor(
   value: number,
@@ -80,6 +103,7 @@ function toChartData(points: YearValuePoint[]): ChartDatum[] {
     return {
       year: point.year,
       valueKt,
+      displayValueKt: valueKt,
       fill: getBarColor(valueKt, minValue, maxValue),
     };
   });
@@ -185,16 +209,35 @@ function ExportOfOilProductsTooltip({
 
 export function ExportOfOilProductsEmissionsChart({
   data,
+  scrollYProgress,
   className,
 }: {
   data: YearValuePoint[];
+  scrollYProgress?: MotionValue<number>;
   className?: string;
 }) {
   const { t } = useTranslation();
   const { currentLanguage } = useLanguage();
   const { isMobile } = useScreenSize();
+  const [scrollProgress, setScrollProgress] = useState(0);
+
+  useMotionValueEvent(scrollYProgress ?? null, "change", (value) => {
+    setScrollProgress(value);
+  });
 
   const chartData = useMemo(() => toChartData(data), [data]);
+  const animatedChartData = useMemo(() => {
+    if (!scrollYProgress) {
+      return chartData;
+    }
+
+    return chartData.map((point, index) => ({
+      ...point,
+      displayValueKt:
+        point.valueKt *
+        getScrollBarScale(scrollProgress, index, chartData.length),
+    }));
+  }, [chartData, scrollProgress, scrollYProgress]);
   const latestYearPoint = useMemo(() => getLatestYearPoint(data), [data]);
   const latestCitizenEquivalent = useMemo(() => {
     if (!latestYearPoint) return null;
@@ -238,7 +281,7 @@ export function ExportOfOilProductsEmissionsChart({
           <ChartArea className="min-h-0 h-full">
             <ResponsiveContainer {...getChartContainerProps()}>
               <BarChart
-                data={chartData}
+                data={animatedChartData}
                 margin={getResponsiveChartMargin(isMobile)}
               >
                 <XAxis
@@ -271,11 +314,15 @@ export function ExportOfOilProductsEmissionsChart({
                 )}
 
                 <Bar
-                  dataKey="valueKt"
+                  dataKey="displayValueKt"
                   radius={[4, 4, 0, 0]}
                   maxBarSize={isMobile ? 10 : 16}
+                  isAnimationActive={!scrollYProgress}
+                  animationBegin={0}
+                  animationDuration={600}
+                  animationEasing="ease-out"
                 >
-                  {chartData.map((entry) => (
+                  {animatedChartData.map((entry) => (
                     <Cell key={entry.year} fill={entry.fill} />
                   ))}
                 </Bar>

--- a/src/components/nation/story/NationOilExportsSection.tsx
+++ b/src/components/nation/story/NationOilExportsSection.tsx
@@ -10,10 +10,14 @@ type NationOilExportsSectionProps = {
 
 export function NationOilExportsSection({
   oilPoints,
+  scrollYProgress,
 }: NationOilExportsSectionProps) {
   return (
     <div className="w-full max-w-4xl mx-auto">
-      <ExportOfOilProductsEmissionsChart data={oilPoints} />
+      <ExportOfOilProductsEmissionsChart
+        data={oilPoints}
+        scrollYProgress={scrollYProgress}
+      />
     </div>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds scroll-driven bar animation to the oil export emissions chart on the nation story page. As the user scrolls through the pinned oil exports section, bars grow upward in a staggered sequence — matching the animation pattern already used by other story sections like e-commerce scale and layer comparisons.

## Changes

- Pass `scrollYProgress` from `NationOilExportsSection` into `ExportOfOilProductsEmissionsChart`
- Scale each bar's displayed height based on scroll progress with a staggered timing function
- Keep tooltip values showing the full emission amount (not the animated height)
- Fall back to Recharts entrance animation when `scrollYProgress` is not provided

## Testing

- [x] TypeScript compiles cleanly
- [x] No new lint issues in changed files
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e4e49807-cdc7-45b5-90c7-b7d09ea69b1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4e49807-cdc7-45b5-90c7-b7d09ea69b1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

