### PR TITLE
[feat] Improve companies overview charts and sector filter

### DIFF
--- a/src/components/companies/rankedList/IndustryFilter.tsx
+++ b/src/components/companies/rankedList/IndustryFilter.tsx
@@ -1,7 +1,7 @@
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { cn } from "@/lib/utils";
+import { SECTOR_ORDER } from "@/lib/constants/sectors";
 import { useSectorNames } from "@/hooks/companies/useCompanySectors";
-import { useScreenSize } from "@/hooks/useScreenSize";
 import {
   Select,
   SelectContent,
@@ -10,9 +10,11 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
+export const ALL_SECTORS_VALUE = "all";
+
 interface IndustryFilterProps {
   availableSectors: string[];
-  selectedSector: string | null;
+  selectedSector: string;
   onSectorChange: (sector: string) => void;
 }
 
@@ -23,93 +25,60 @@ export function IndustryFilter({
 }: IndustryFilterProps) {
   const { t } = useTranslation();
   const sectorNames = useSectorNames();
-  const { isMobile } = useScreenSize();
 
-  const handleSectorClick = (sectorCode: string) => {
-    if (selectedSector !== sectorCode) {
-      onSectorChange(sectorCode);
-    }
-  };
+  const sectorOptions = useMemo(() => {
+    const options = SECTOR_ORDER.filter((code) =>
+      availableSectors.includes(code),
+    ).map((code) => ({
+      value: code,
+      label: sectorNames[code],
+    }));
+
+    return [
+      {
+        value: ALL_SECTORS_VALUE,
+        label: t("explorePage.companies.allSectors"),
+      },
+      ...options,
+    ];
+  }, [availableSectors, sectorNames, t]);
+
+  const selectedSectorName =
+    sectorOptions.find((option) => option.value === selectedSector)?.label ??
+    t("explorePage.companies.allSectors");
 
   if (availableSectors.length === 0) {
     return null;
   }
 
-  // Mobile: Use dropdown
-  if (isMobile) {
-    const selectedSectorName =
-      selectedSector &&
-      (sectorNames[selectedSector as keyof typeof sectorNames] ||
-        selectedSector);
-
-    return (
-      <div className="space-y-2">
-        <label className="text-sm text-grey">
-          {t("companiesOverviewPage.selectIndustry", "Select industry")}:
-        </label>
-        <Select
-          value={selectedSector || undefined}
-          onValueChange={(value) => onSectorChange(value)}
-        >
-          <SelectTrigger className="w-full bg-black-2 border-black-3 text-white">
-            <SelectValue
-              placeholder={t(
-                "companiesOverviewPage.selectIndustry",
-                "Select industry",
-              )}
-            >
-              {selectedSectorName}
-            </SelectValue>
-          </SelectTrigger>
-          <SelectContent className="bg-black-1 border-black-3">
-            {availableSectors.map((sectorCode) => {
-              const sectorName =
-                sectorNames[sectorCode as keyof typeof sectorNames] ||
-                sectorCode;
-              return (
-                <SelectItem
-                  key={sectorCode}
-                  value={sectorCode}
-                  className="text-white focus:bg-black-2"
-                >
-                  {sectorName}
-                </SelectItem>
-              );
-            })}
-          </SelectContent>
-        </Select>
-      </div>
-    );
-  }
-
-  // Desktop: Use badges
   return (
-    <div className="flex flex-wrap items-center gap-2">
-      <span className="text-sm text-grey mr-1">
+    <div className="space-y-2">
+      <label className="text-sm text-grey">
         {t("companiesOverviewPage.selectIndustry", "Select industry")}:
-      </span>
-      {availableSectors.map((sectorCode) => {
-        const isSelected = selectedSector === sectorCode;
-        const sectorName =
-          sectorNames[sectorCode as keyof typeof sectorNames] || sectorCode;
-
-        return (
-          <button
-            key={sectorCode}
-            type="button"
-            onClick={() => handleSectorClick(sectorCode)}
-            className={cn(
-              "px-3 py-1.5 rounded-level-1 text-xs font-medium transition-all",
-              "border",
-              isSelected
-                ? "bg-blue-5/30 border-blue-4 text-blue-2 hover:bg-blue-5/40"
-                : "bg-black-2 border-black-3 text-grey hover:bg-black-3 hover:border-black-4",
+      </label>
+      <Select value={selectedSector} onValueChange={onSectorChange}>
+        <SelectTrigger className="w-full md:max-w-sm bg-black-2 border-black-3 text-white">
+          <SelectValue
+            placeholder={t(
+              "companiesOverviewPage.selectIndustry",
+              "Select industry",
             )}
           >
-            {sectorName}
-          </button>
-        );
-      })}
+            {selectedSectorName}
+          </SelectValue>
+        </SelectTrigger>
+        <SelectContent className="bg-black-1 border-black-3">
+          {sectorOptions.map((option) => (
+            <SelectItem
+              key={option.value}
+              value={option.value}
+              className="text-white focus:bg-black-2"
+            >
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
     </div>
   );
 }

--- a/src/components/companies/rankedList/visualizations/EmissionsChangeVisualization.tsx
+++ b/src/components/companies/rankedList/visualizations/EmissionsChangeVisualization.tsx
@@ -41,10 +41,7 @@ export function EmissionsChangeVisualization({
 
   return (
     <div className="w-full h-full bg-black-2 rounded-level-2 p-4 md:p-6 overflow-hidden">
-      <EmissionsDistributionChart
-        values={values}
-        unknownCount={unknownCount}
-      />
+      <EmissionsDistributionChart values={values} unknownCount={unknownCount} />
     </div>
   );
 }

--- a/src/components/companies/rankedList/visualizations/EmissionsChangeVisualization.tsx
+++ b/src/components/companies/rankedList/visualizations/EmissionsChangeVisualization.tsx
@@ -1,11 +1,7 @@
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import type { CompanyWithKPIs } from "@/types/company";
-import { createSymmetricRangeGradient } from "@/utils/ui/colorGradients";
-import { useBeeswarmData } from "@/hooks/companies/useBeeswarmData";
-import { useScreenSize } from "@/hooks/useScreenSize";
-import { BeeswarmChart } from "./shared/BeeswarmChart";
-import { getCompanyUrlSegment } from "@/utils/companyRouting";
+import { EmissionsDistributionChart } from "./shared/EmissionsDistributionChart";
 
 interface EmissionsChangeVisualizationProps {
   companies: CompanyWithKPIs[];
@@ -14,38 +10,26 @@ interface EmissionsChangeVisualizationProps {
 
 export function EmissionsChangeVisualization({
   companies,
-  onCompanyClick,
 }: EmissionsChangeVisualizationProps) {
   const { t } = useTranslation();
-  const { isMobile } = useScreenSize();
-  const {
-    valid: withData,
-    invalid: noData,
-    min,
-    max,
-    colorForValue,
-  } = useBeeswarmData(
-    companies,
-    (c) => c.emissionsChangeFromBaseYear ?? null,
-    (min, max) => (value: number) =>
-      createSymmetricRangeGradient(min, max, value),
-  );
 
-  // Calculate ranks: lower is better (negative change is good)
-  const rankMap = useMemo(() => {
-    const sorted = [...withData].sort(
-      (a, b) =>
-        (a.emissionsChangeFromBaseYear ?? 0) -
-        (b.emissionsChangeFromBaseYear ?? 0),
-    );
-    const map = new Map<string, number>();
-    sorted.forEach((company, index) => {
-      map.set(company.id, index + 1);
+  const { values, unknownCount } = useMemo(() => {
+    const withData: number[] = [];
+    let missing = 0;
+
+    companies.forEach((company) => {
+      const value = company.emissionsChangeFromBaseYear;
+      if (value === null || value === undefined || Number.isNaN(value)) {
+        missing += 1;
+        return;
+      }
+      withData.push(value);
     });
-    return map;
-  }, [withData]);
 
-  if (withData.length === 0) {
+    return { values: withData, unknownCount: missing };
+  }, [companies]);
+
+  if (values.length === 0) {
     return (
       <div className="bg-black-2 rounded-level-2 p-8 h-full flex items-center justify-center">
         <p className="text-grey text-lg">
@@ -56,34 +40,11 @@ export function EmissionsChangeVisualization({
   }
 
   return (
-    <div className="w-full h-full flex flex-col gap-3">
-      {!isMobile && (
-        <div className="flex items-center justify-between">
-          <div className="text-sm text-grey">
-            {t("companiesOverviewPage.visualizations.emissionsChange.title")}
-            {" · "}
-            {t(
-              "companiesOverviewPage.visualizations.emissionsChange.unknown",
-            )}: {noData.length}
-          </div>
-        </div>
-      )}
-
-      <div className="relative flex-1 bg-black-2 rounded-level-2 p-4 overflow-hidden">
-        <BeeswarmChart
-          data={withData}
-          getValue={(c) => c.emissionsChangeFromBaseYear as number}
-          getCompanyName={(c) => c.name}
-          getCompanyId={(c) => getCompanyUrlSegment(c)}
-          colorForValue={colorForValue}
-          min={min}
-          max={max}
-          unit="%"
-          onCompanyClick={onCompanyClick}
-          getRank={(c) => rankMap.get(c.id) ?? null}
-          totalCount={withData.length}
-        />
-      </div>
+    <div className="w-full h-full bg-black-2 rounded-level-2 p-4 md:p-6 overflow-hidden">
+      <EmissionsDistributionChart
+        values={values}
+        unknownCount={unknownCount}
+      />
     </div>
   );
 }

--- a/src/components/companies/rankedList/visualizations/MeetsParisVisualization.tsx
+++ b/src/components/companies/rankedList/visualizations/MeetsParisVisualization.tsx
@@ -1,122 +1,28 @@
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { CompanyWithKPIs } from "@/hooks/companies/useCompanyKPIs";
-import { calculateTrendline } from "@/lib/calculations/trends/analysis";
-import { calculateCarbonBudgetTonnes } from "@/utils/calculations/carbonBudget";
-import { createFixedRangeGradient } from "@/utils/ui/colorGradients";
-import { getBestUnit } from "@/utils/data/unitScaling";
-import { calculateCapThreshold } from "@/utils/data/capping";
-import { useScreenSize } from "@/hooks/useScreenSize";
-import type { ColorFunction } from "@/types/visualizations";
-import { getCompanyUrlSegment } from "@/utils/companyRouting";
-import { BeeswarmChart } from "./shared/BeeswarmChart";
+import { ParisAlignmentChart } from "./shared/ParisAlignmentChart";
 
 interface MeetsParisVisualizationProps {
   companies: CompanyWithKPIs[];
   onCompanyClick?: (company: CompanyWithKPIs) => void;
 }
 
-interface CompanyBudgetData {
-  company: CompanyWithKPIs;
-  budgetTonnes: number;
-  meetsParis: boolean | null;
-}
-
 export function MeetsParisVisualization({
   companies,
-  onCompanyClick,
 }: MeetsParisVisualizationProps) {
   const { t } = useTranslation();
-  const { isMobile } = useScreenSize();
 
-  // Calculate budget data and basic statistics
-  const { companyBudgetData, noBudgetCompanies, minRaw, maxRaw, budgetValues } =
-    useMemo(() => {
-      const withBudget: CompanyBudgetData[] = [];
-      const withoutBudget: CompanyWithKPIs[] = [];
+  const values = useMemo(
+    () => companies.map((company) => company.meetsParis),
+    [companies],
+  );
 
-      companies.forEach((company) => {
-        const trendAnalysis = calculateTrendline(company);
-        const budgetTonnes = calculateCarbonBudgetTonnes(
-          company,
-          trendAnalysis,
-        );
+  const hasKnownValues = values.some(
+    (value) => value === true || value === false,
+  );
 
-        if (budgetTonnes === null) {
-          withoutBudget.push(company);
-          return;
-        }
-
-        withBudget.push({
-          company,
-          budgetTonnes,
-          meetsParis: company.meetsParis ?? null,
-        });
-      });
-
-      const values = withBudget.map((d) => d.budgetTonnes);
-      const min = values.length ? Math.min(...values) : 0;
-      const max = values.length ? Math.max(...values) : 0;
-
-      return {
-        companyBudgetData: withBudget,
-        noBudgetCompanies: withoutBudget,
-        budgetValues: values,
-        minRaw: min,
-        maxRaw: max,
-      };
-    }, [companies]);
-
-  // Calculate unit scaling, capping, and display values
-  const {
-    unitScale,
-    capThresholdRaw,
-    needsCapping,
-    min,
-    max,
-    legendMin,
-    legendMax,
-    colorForTonnes,
-    formatTooltipValue,
-  } = useMemo(() => {
-    const absMax = Math.max(Math.abs(minRaw), Math.abs(maxRaw));
-    const unitScale = getBestUnit(absMax);
-    const capThresholdRaw = calculateCapThreshold(
-      budgetValues,
-      3,
-      unitScale.divisor,
-    );
-    const needsCapping = maxRaw > capThresholdRaw;
-
-    const min = minRaw / unitScale.divisor;
-    const maxConverted = maxRaw / unitScale.divisor;
-    const capConverted = capThresholdRaw / unitScale.divisor;
-    const max = needsCapping ? capConverted : maxConverted;
-    const legendMin = minRaw / unitScale.divisor;
-    const legendMax = maxRaw / unitScale.divisor;
-
-    const colorForTonnes: ColorFunction = (value: number) =>
-      createFixedRangeGradient(-absMax, absMax, value);
-
-    const formatTooltipValue = (value: number, _unit: string) => {
-      const sign = value < 0 ? "-" : "+";
-      return `${sign}${Math.abs(value).toFixed(1)}${unitScale.unit}`;
-    };
-
-    return {
-      unitScale,
-      capThresholdRaw,
-      needsCapping,
-      min,
-      max,
-      legendMin,
-      legendMax,
-      colorForTonnes,
-      formatTooltipValue,
-    };
-  }, [minRaw, maxRaw, budgetValues]);
-
-  if (companyBudgetData.length === 0) {
+  if (!hasKnownValues) {
     return (
       <div className="bg-black-2 rounded-level-2 p-8 h-full flex items-center justify-center">
         <p className="text-grey text-lg">
@@ -129,72 +35,8 @@ export function MeetsParisVisualization({
   }
 
   return (
-    <div className="w-full h-full flex flex-col gap-3">
-      {!isMobile && (
-        <div className="flex items-center justify-between">
-          <div className="text-sm text-grey">
-            {t("companies.list.kpis.meetsParis.label")}
-            {" · "}
-            {t("companies.list.kpis.meetsParis.nullValues", "Unknown")}:{" "}
-            {noBudgetCompanies.length}
-          </div>
-        </div>
-      )}
-
-      <div className="relative flex-1 bg-black-2 rounded-level-2 p-4 overflow-hidden">
-        <BeeswarmChart
-          data={companyBudgetData}
-          getValue={(d) => {
-            const converted = d.budgetTonnes / unitScale.divisor;
-            // Cap positive values above threshold (only cap over-budget values)
-            if (
-              needsCapping &&
-              converted > capThresholdRaw / unitScale.divisor
-            ) {
-              return capThresholdRaw / unitScale.divisor;
-            }
-            return converted;
-          }}
-          getRawValue={(d) => d.budgetTonnes / unitScale.divisor}
-          getCompanyName={(d) => d.company.name}
-          getCompanyId={(d) => getCompanyUrlSegment(d.company)}
-          colorForValue={(value) => colorForTonnes(value * unitScale.divisor)}
-          getMeetsParis={(d) => d.meetsParis}
-          getBudgetValue={(d) => d.budgetTonnes / unitScale.divisor}
-          min={min}
-          max={max}
-          unit={unitScale.unit}
-          formatTooltipValue={formatTooltipValue}
-          capThreshold={
-            needsCapping ? capThresholdRaw / unitScale.divisor : undefined
-          }
-          onCompanyClick={(d) => onCompanyClick?.(d.company)}
-          xReferenceLines={[
-            {
-              value: 0,
-              label: t(
-                "companiesOverviewPage.visualizations.meetsParis.budgetThreshold",
-                {
-                  unit: unitScale.unit,
-                },
-              ),
-              color: "var(--grey)",
-            },
-          ]}
-          legendMin={legendMin}
-          legendMax={legendMax}
-        />
-      </div>
-
-      <p className="text-grey text-sm">
-        {t("companiesOverviewPage.visualizations.meetsParis.description")}{" "}
-        <a
-          href="/methodology?view=companyDataOverview"
-          className="underline hover:text-white"
-        >
-          {t("companiesOverviewPage.visualizations.meetsParis.learnMore")}
-        </a>
-      </p>
+    <div className="w-full h-full bg-black-2 rounded-level-2 p-4 md:p-6 overflow-hidden">
+      <ParisAlignmentChart values={values} />
     </div>
   );
 }

--- a/src/components/companies/rankedList/visualizations/shared/EmissionsDistributionChart.tsx
+++ b/src/components/companies/rankedList/visualizations/shared/EmissionsDistributionChart.tsx
@@ -56,18 +56,15 @@ export function EmissionsDistributionChart({
           {t("companiesOverviewPage.visualizations.emissionsChange.title")}
         </h3>
         <p className="text-sm text-grey leading-relaxed">
-          {t(
-            "companiesOverviewPage.visualizations.emissionsChange.summary",
-            {
-              reduced: summary.reducedCount,
-              total: summary.totalWithData,
-              percent: reducedPercent,
-              median:
-                summary.median !== null
-                  ? `${summary.median.toFixed(1)}%`
-                  : t("noData"),
-            },
-          )}
+          {t("companiesOverviewPage.visualizations.emissionsChange.summary", {
+            reduced: summary.reducedCount,
+            total: summary.totalWithData,
+            percent: reducedPercent,
+            median:
+              summary.median !== null
+                ? `${summary.median.toFixed(1)}%`
+                : t("noData"),
+          })}
         </p>
         <p className="text-xs text-grey">
           {t(
@@ -111,9 +108,7 @@ export function EmissionsDistributionChart({
 
       <div className="min-h-[280px] flex-1 rounded-level-2 bg-black-3/40 p-4">
         <p className="mb-3 text-xs text-grey">
-          {t(
-            "companiesOverviewPage.visualizations.emissionsChange.axisLabel",
-          )}
+          {t("companiesOverviewPage.visualizations.emissionsChange.axisLabel")}
         </p>
         <ResponsiveContainer width="100%" height="100%">
           <BarChart

--- a/src/components/companies/rankedList/visualizations/shared/EmissionsDistributionChart.tsx
+++ b/src/components/companies/rankedList/visualizations/shared/EmissionsDistributionChart.tsx
@@ -1,0 +1,200 @@
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import {
+  buildDistributionBins,
+  summarizeEmissionsChange,
+} from "@/utils/visualizations/emissionsDistribution";
+
+interface EmissionsDistributionChartProps {
+  values: number[];
+  unknownCount: number;
+}
+
+const REDUCTION_COLOR = "var(--blue-3)";
+const INCREASE_COLOR = "var(--pink-3)";
+
+export function EmissionsDistributionChart({
+  values,
+  unknownCount,
+}: EmissionsDistributionChartProps) {
+  const { t } = useTranslation();
+
+  const bins = useMemo(() => buildDistributionBins(values), [values]);
+  const summary = useMemo(() => summarizeEmissionsChange(values), [values]);
+
+  const chartData = bins.map((bin) => ({
+    id: bin.id,
+    label: t(
+      `companiesOverviewPage.visualizations.emissionsChange.bins.${bin.id}`,
+    ),
+    count: bin.count,
+    fill: bin.isReduction ? REDUCTION_COLOR : INCREASE_COLOR,
+  }));
+
+  if (values.length === 0) {
+    return null;
+  }
+
+  const reducedPercent = Math.round(
+    (summary.reducedCount / summary.totalWithData) * 100,
+  );
+
+  return (
+    <div className="flex h-full flex-col gap-4">
+      <div className="space-y-2">
+        <h3 className="text-base font-medium text-white">
+          {t("companiesOverviewPage.visualizations.emissionsChange.title")}
+        </h3>
+        <p className="text-sm text-grey leading-relaxed">
+          {t(
+            "companiesOverviewPage.visualizations.emissionsChange.summary",
+            {
+              reduced: summary.reducedCount,
+              total: summary.totalWithData,
+              percent: reducedPercent,
+              median:
+                summary.median !== null
+                  ? `${summary.median.toFixed(1)}%`
+                  : t("noData"),
+            },
+          )}
+        </p>
+        <p className="text-xs text-grey">
+          {t(
+            "companiesOverviewPage.visualizations.emissionsChange.description",
+          )}
+        </p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+        <SummaryCard
+          label={t(
+            "companiesOverviewPage.visualizations.emissionsChange.cards.reduced",
+          )}
+          value={summary.reducedCount}
+          accentClass="text-blue-3"
+        />
+        <SummaryCard
+          label={t(
+            "companiesOverviewPage.visualizations.emissionsChange.cards.increased",
+          )}
+          value={summary.increasedCount}
+          accentClass="text-pink-3"
+        />
+        <SummaryCard
+          label={t(
+            "companiesOverviewPage.visualizations.emissionsChange.cards.average",
+          )}
+          value={
+            summary.average !== null
+              ? `${summary.average.toFixed(1)}%`
+              : t("noData")
+          }
+        />
+        <SummaryCard
+          label={t(
+            "companiesOverviewPage.visualizations.emissionsChange.cards.unknown",
+          )}
+          value={unknownCount}
+        />
+      </div>
+
+      <div className="min-h-[280px] flex-1 rounded-level-2 bg-black-3/40 p-4">
+        <p className="mb-3 text-xs text-grey">
+          {t(
+            "companiesOverviewPage.visualizations.emissionsChange.axisLabel",
+          )}
+        </p>
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart
+            data={chartData}
+            margin={{ top: 8, right: 8, left: 0, bottom: 48 }}
+          >
+            <CartesianGrid
+              stroke="var(--black-4)"
+              strokeDasharray="3 3"
+              vertical={false}
+            />
+            <XAxis
+              dataKey="label"
+              tick={{ fill: "var(--grey)", fontSize: 11 }}
+              interval={0}
+              angle={-25}
+              textAnchor="end"
+              height={60}
+            />
+            <YAxis
+              allowDecimals={false}
+              tick={{ fill: "var(--grey)", fontSize: 11 }}
+              width={32}
+              label={{
+                value: t(
+                  "companiesOverviewPage.visualizations.emissionsChange.yAxis",
+                ),
+                angle: -90,
+                position: "insideLeft",
+                fill: "var(--grey)",
+                fontSize: 11,
+                dx: 10,
+              }}
+            />
+            <Tooltip
+              cursor={{ fill: "var(--black-4)" }}
+              content={({ active, payload }) => {
+                if (!active || !payload?.length) {
+                  return null;
+                }
+
+                const item = payload[0].payload as (typeof chartData)[number];
+
+                return (
+                  <div className="rounded-level-1 border border-black-4 bg-black-1 px-3 py-2 text-xs text-white shadow-lg">
+                    <p className="font-medium">{item.label}</p>
+                    <p className="text-grey">
+                      {t(
+                        "companiesOverviewPage.visualizations.emissionsChange.tooltipCount",
+                        { count: item.count },
+                      )}
+                    </p>
+                  </div>
+                );
+              }}
+            />
+            <Bar dataKey="count" radius={[4, 4, 0, 0]}>
+              {chartData.map((entry) => (
+                <Cell key={entry.id} fill={entry.fill} />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}
+
+function SummaryCard({
+  label,
+  value,
+  accentClass = "text-white",
+}: {
+  label: string;
+  value: number | string;
+  accentClass?: string;
+}) {
+  return (
+    <div className="rounded-level-2 bg-black-3/60 px-3 py-3">
+      <p className="text-xs text-grey">{label}</p>
+      <p className={`mt-1 text-xl font-semibold ${accentClass}`}>{value}</p>
+    </div>
+  );
+}

--- a/src/components/companies/rankedList/visualizations/shared/ParisAlignmentChart.tsx
+++ b/src/components/companies/rankedList/visualizations/shared/ParisAlignmentChart.tsx
@@ -1,0 +1,179 @@
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { summarizeParisAlignment } from "@/utils/visualizations/emissionsDistribution";
+
+interface ParisAlignmentChartProps {
+  values: Array<boolean | null | undefined>;
+}
+
+const COLORS = {
+  yes: "var(--blue-3)",
+  no: "var(--pink-3)",
+  unknown: "var(--grey)",
+} as const;
+
+export function ParisAlignmentChart({ values }: ParisAlignmentChartProps) {
+  const { t } = useTranslation();
+  const summary = useMemo(() => summarizeParisAlignment(values), [values]);
+
+  const chartData = [
+    {
+      id: "yes",
+      label: t("companies.list.kpis.meetsParis.booleanLabels.true"),
+      count: summary.yesCount,
+      fill: COLORS.yes,
+    },
+    {
+      id: "no",
+      label: t("companies.list.kpis.meetsParis.booleanLabels.false"),
+      count: summary.noCount,
+      fill: COLORS.no,
+    },
+    {
+      id: "unknown",
+      label: t("companies.list.kpis.meetsParis.nullValues"),
+      count: summary.unknownCount,
+      fill: COLORS.unknown,
+    },
+  ].filter((item) => item.count > 0);
+
+  const knownTotal = summary.yesCount + summary.noCount;
+  const yesPercent =
+    knownTotal > 0 ? Math.round((summary.yesCount / knownTotal) * 100) : 0;
+
+  if (summary.total === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex h-full flex-col gap-4">
+      <div className="space-y-2">
+        <h3 className="text-base font-medium text-white">
+          {t("companies.list.kpis.meetsParis.label")}
+        </h3>
+        <p className="text-sm text-grey leading-relaxed">
+          {knownTotal > 0
+            ? t("companiesOverviewPage.visualizations.meetsParis.summary", {
+                yes: summary.yesCount,
+                total: knownTotal,
+                percent: yesPercent,
+              })
+            : t(
+                "companiesOverviewPage.visualizations.meetsParis.summaryUnknownOnly",
+                { unknown: summary.unknownCount },
+              )}
+        </p>
+        <p className="text-xs text-grey">
+          {t("companiesOverviewPage.visualizations.meetsParis.description")}{" "}
+          <a
+            href="/methodology?view=companyDataOverview"
+            className="underline hover:text-white"
+          >
+            {t("companiesOverviewPage.visualizations.meetsParis.learnMore")}
+          </a>
+        </p>
+      </div>
+
+      <div className="grid grid-cols-3 gap-3">
+        <SummaryCard
+          label={t("companies.list.kpis.meetsParis.booleanLabels.true")}
+          value={summary.yesCount}
+          accentClass="text-blue-3"
+        />
+        <SummaryCard
+          label={t("companies.list.kpis.meetsParis.booleanLabels.false")}
+          value={summary.noCount}
+          accentClass="text-pink-3"
+        />
+        <SummaryCard
+          label={t("companies.list.kpis.meetsParis.nullValues")}
+          value={summary.unknownCount}
+        />
+      </div>
+
+      <div className="min-h-[220px] flex-1 rounded-level-2 bg-black-3/40 p-4">
+        <p className="mb-3 text-xs text-grey">
+          {t("companiesOverviewPage.visualizations.meetsParis.axisLabel")}
+        </p>
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart
+            data={chartData}
+            layout="vertical"
+            margin={{ top: 8, right: 16, left: 8, bottom: 8 }}
+          >
+            <CartesianGrid
+              stroke="var(--black-4)"
+              strokeDasharray="3 3"
+              horizontal={false}
+            />
+            <XAxis
+              type="number"
+              allowDecimals={false}
+              tick={{ fill: "var(--grey)", fontSize: 11 }}
+            />
+            <YAxis
+              type="category"
+              dataKey="label"
+              width={140}
+              tick={{ fill: "var(--grey)", fontSize: 11 }}
+            />
+            <Tooltip
+              cursor={{ fill: "var(--black-4)" }}
+              content={({ active, payload }) => {
+                if (!active || !payload?.length) {
+                  return null;
+                }
+
+                const item = payload[0].payload as (typeof chartData)[number];
+
+                return (
+                  <div className="rounded-level-1 border border-black-4 bg-black-1 px-3 py-2 text-xs text-white shadow-lg">
+                    <p className="font-medium">{item.label}</p>
+                    <p className="text-grey">
+                      {t(
+                        "companiesOverviewPage.visualizations.emissionsChange.tooltipCount",
+                        { count: item.count },
+                      )}
+                    </p>
+                  </div>
+                );
+              }}
+            />
+            <Bar dataKey="count" radius={[0, 4, 4, 0]}>
+              {chartData.map((entry) => (
+                <Cell key={entry.id} fill={entry.fill} />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}
+
+function SummaryCard({
+  label,
+  value,
+  accentClass = "text-white",
+}: {
+  label: string;
+  value: number;
+  accentClass?: string;
+}) {
+  return (
+    <div className="rounded-level-2 bg-black-3/60 px-3 py-3">
+      <p className="text-xs text-grey">{label}</p>
+      <p className={`mt-1 text-xl font-semibold ${accentClass}`}>{value}</p>
+    </div>
+  );
+}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -421,13 +421,35 @@
       "noDataAvailable": "No data available",
       "emissionsChange": {
         "title": "Emissions Change from Base Year",
-        "unknown": "Unknown"
+        "unknown": "Unknown",
+        "description": "Each bar shows how many companies fall in a change range from their base year to the latest reporting period. Negative values mean emissions went down.",
+        "summary": "{{reduced}} of {{total}} companies ({{percent}}%) reduced emissions. Median change: {{median}}.",
+        "axisLabel": "Change in total emissions (%)",
+        "yAxis": "Companies",
+        "tooltipCount": "{{count}} companies",
+        "cards": {
+          "reduced": "Reduced emissions",
+          "increased": "Increased emissions",
+          "average": "Average change",
+          "unknown": "Missing data"
+        },
+        "bins": {
+          "largeReduction": "< −30%",
+          "moderateReduction": "−30 to −10%",
+          "smallReduction": "−10 to 0%",
+          "smallIncrease": "0 to 10%",
+          "moderateIncrease": "10 to 30%",
+          "largeIncrease": "> 30%"
+        }
       },
       "meetsParis": {
         "legend": {
           "belowBudget": "Below budget",
           "aboveBudget": "Above budget"
         },
+        "summary": "{{yes}} of {{total}} companies with data ({{percent}}%) are on track to meet the Paris Agreement.",
+        "summaryUnknownOnly": "{{unknown}} companies lack enough data to assess Paris alignment.",
+        "axisLabel": "Number of companies by Paris alignment",
         "budgetThreshold": "Budget threshold (0{{unit}})",
         "description": "Tonnes over or under each company's carbon budget. We estimate future emissions with an LAD trendline and compare cumulative 2025–2050 emissions to a Carbon Law path (11.7% yearly reduction).",
         "learnMore": "Learn more",

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -426,13 +426,35 @@
       "noDataAvailable": "Ingen data tillgänglig",
       "emissionsChange": {
         "title": "Utsläppsförändring från basår",
-        "unknown": "Okänt"
+        "unknown": "Okänt",
+        "description": "Varje stapel visar hur många företag som ligger inom ett intervall av förändring från basår till senaste rapporteringsperiod. Negativa värden innebär minskade utsläpp.",
+        "summary": "{{reduced}} av {{total}} företag ({{percent}} %) har minskat sina utsläpp. Medianförändring: {{median}}.",
+        "axisLabel": "Förändring i totala utsläpp (%)",
+        "yAxis": "Företag",
+        "tooltipCount": "{{count}} företag",
+        "cards": {
+          "reduced": "Minskade utsläpp",
+          "increased": "Ökade utsläpp",
+          "average": "Genomsnittlig förändring",
+          "unknown": "Saknar data"
+        },
+        "bins": {
+          "largeReduction": "< −30 %",
+          "moderateReduction": "−30 till −10 %",
+          "smallReduction": "−10 till 0 %",
+          "smallIncrease": "0 till 10 %",
+          "moderateIncrease": "10 till 30 %",
+          "largeIncrease": "> 30 %"
+        }
       },
       "meetsParis": {
         "legend": {
           "belowBudget": "Under budget",
           "aboveBudget": "Över budget"
         },
+        "summary": "{{yes}} av {{total}} företag med data ({{percent}} %) ligger i fas med Parisavtalet.",
+        "summaryUnknownOnly": "{{unknown}} företag saknar tillräcklig data för att bedöma Paris-anpassning.",
+        "axisLabel": "Antal företag per Paris-status",
         "budgetThreshold": "Budgettröskel (0{{unit}})",
         "description": "Ton över eller under varje företags kolbudget. Vi uppskattar framtida utsläpp med en LAD-trendlinje och jämför kumulativa utsläpp 2025–2050 med en Carbon Law-väg (11,7% årlig minskning).",
         "learnMore": "Läs mer",

--- a/src/pages/CompaniesOverviewPage.tsx
+++ b/src/pages/CompaniesOverviewPage.tsx
@@ -97,9 +97,8 @@ export function CompaniesOverviewPage() {
   );
 
   const [selectedKPI, setSelectedKPI] = useState(getKPIFromURL());
-  const [selectedSector, setSelectedSector] = useState<string>(
-    getSectorFromURL(),
-  );
+  const [selectedSector, setSelectedSector] =
+    useState<string>(getSectorFromURL());
   const viewMode = getViewModeFromURL();
 
   useEffect(() => {

--- a/src/pages/CompaniesOverviewPage.tsx
+++ b/src/pages/CompaniesOverviewPage.tsx
@@ -9,7 +9,11 @@ import { ViewModeToggle } from "@/components/ui/view-mode-toggle";
 import RankedList from "@/components/ranked/RankedList";
 import CompanyInsightsPanel from "@/components/companies/rankedList/CompanyInsightsPanel";
 import { CompanyKPIVisualization } from "@/components/companies/rankedList/CompanyKPIVisualization";
-import { IndustryFilter } from "@/components/companies/rankedList/IndustryFilter";
+import {
+  ALL_SECTORS_VALUE,
+  IndustryFilter,
+} from "@/components/companies/rankedList/IndustryFilter";
+import { SECTOR_ORDER } from "@/lib/constants/sectors";
 import {
   useCompanyKPIs,
   CompanyKPIValue,
@@ -54,7 +58,7 @@ export function CompaniesOverviewPage() {
     navigate({ search: params.toString() }, { replace: true });
   };
 
-  // Get available sectors from companies
+  // Get available sectors from companies in canonical order
   const availableSectors = useMemo(() => {
     if (!companies) return [];
     const sectors = new Set<string>();
@@ -64,17 +68,19 @@ export function CompaniesOverviewPage() {
         sectors.add(sectorCode);
       }
     });
-    return Array.from(sectors).sort();
+    return SECTOR_ORDER.filter((code) => sectors.has(code));
   }, [companies]);
 
   const getSectorFromURL = useCallback(() => {
     const params = new URLSearchParams(location.search);
     const sectorParam = params.get("sector");
+    if (sectorParam === ALL_SECTORS_VALUE) {
+      return ALL_SECTORS_VALUE;
+    }
     if (sectorParam && availableSectors.includes(sectorParam)) {
       return sectorParam;
     }
-    // Default to first available sector if none selected
-    return availableSectors.length > 0 ? availableSectors[0] : null;
+    return ALL_SECTORS_VALUE;
   }, [location.search, availableSectors]);
 
   const setSectorInURL = useCallback(
@@ -91,19 +97,10 @@ export function CompaniesOverviewPage() {
   );
 
   const [selectedKPI, setSelectedKPI] = useState(getKPIFromURL());
-  const [selectedSector, setSelectedSector] = useState<string | null>(
+  const [selectedSector, setSelectedSector] = useState<string>(
     getSectorFromURL(),
   );
   const viewMode = getViewModeFromURL();
-
-  // Ensure a sector is selected on initial load
-  useEffect(() => {
-    if (!selectedSector && availableSectors.length > 0) {
-      const firstSector = availableSectors[0];
-      setSelectedSector(firstSector);
-      setSectorInURL(firstSector);
-    }
-  }, [availableSectors, selectedSector, setSectorInURL]);
 
   useEffect(() => {
     const kpiFromUrl = getKPIFromURL();
@@ -121,12 +118,15 @@ export function CompaniesOverviewPage() {
 
   // Filter and enrich companies with KPI values
   const companiesWithKPIs: CompanyWithKPIs[] = useMemo(() => {
-    if (!companies || !selectedSector) return [];
+    if (!companies) return [];
 
-    const filtered = companies.filter((company) => {
-      const sectorCode = company.industry?.industryGics?.sectorCode;
-      return sectorCode === selectedSector;
-    });
+    const filtered =
+      selectedSector === ALL_SECTORS_VALUE
+        ? companies
+        : companies.filter((company) => {
+            const sectorCode = company.industry?.industryGics?.sectorCode;
+            return sectorCode === selectedSector;
+          });
 
     return filtered.map((company) => enrichCompanyWithKPIs(company));
   }, [companies, selectedSector]);

--- a/src/utils/visualizations/emissionsDistribution.test.ts
+++ b/src/utils/visualizations/emissionsDistribution.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  assignValueToBin,
+  buildDistributionBins,
+  EMISSIONS_CHANGE_BIN_DEFINITIONS,
+  summarizeEmissionsChange,
+  summarizeParisAlignment,
+} from "./emissionsDistribution";
+
+describe("emissionsDistribution", () => {
+  it("assigns values to the expected change bins", () => {
+    expect(assignValueToBin(-40, EMISSIONS_CHANGE_BIN_DEFINITIONS).id).toBe(
+      "largeReduction",
+    );
+    expect(assignValueToBin(-15, EMISSIONS_CHANGE_BIN_DEFINITIONS).id).toBe(
+      "moderateReduction",
+    );
+    expect(assignValueToBin(-2, EMISSIONS_CHANGE_BIN_DEFINITIONS).id).toBe(
+      "smallReduction",
+    );
+    expect(assignValueToBin(0, EMISSIONS_CHANGE_BIN_DEFINITIONS).id).toBe(
+      "smallIncrease",
+    );
+    expect(assignValueToBin(20, EMISSIONS_CHANGE_BIN_DEFINITIONS).id).toBe(
+      "moderateIncrease",
+    );
+    expect(assignValueToBin(45, EMISSIONS_CHANGE_BIN_DEFINITIONS).id).toBe(
+      "largeIncrease",
+    );
+  });
+
+  it("summarizes emissions change counts", () => {
+    const summary = summarizeEmissionsChange([-20, -5, 0, 10, 40]);
+
+    expect(summary.totalWithData).toBe(5);
+    expect(summary.reducedCount).toBe(2);
+    expect(summary.increasedCount).toBe(2);
+    expect(summary.unchangedCount).toBe(1);
+    expect(summary.median).toBe(0);
+  });
+
+  it("builds histogram bins with counts", () => {
+    const bins = buildDistributionBins([-40, -15, 5, 25]);
+
+    expect(bins.find((bin) => bin.id === "largeReduction")?.count).toBe(1);
+    expect(bins.find((bin) => bin.id === "moderateReduction")?.count).toBe(1);
+    expect(bins.find((bin) => bin.id === "smallIncrease")?.count).toBe(1);
+    expect(bins.find((bin) => bin.id === "moderateIncrease")?.count).toBe(1);
+  });
+
+  it("summarizes Paris alignment counts", () => {
+    const summary = summarizeParisAlignment([true, true, false, null]);
+
+    expect(summary.yesCount).toBe(2);
+    expect(summary.noCount).toBe(1);
+    expect(summary.unknownCount).toBe(1);
+    expect(summary.total).toBe(4);
+  });
+});

--- a/src/utils/visualizations/emissionsDistribution.ts
+++ b/src/utils/visualizations/emissionsDistribution.ts
@@ -1,0 +1,137 @@
+export interface DistributionBinDefinition {
+  id: string;
+  min: number;
+  max: number;
+  isReduction: boolean;
+}
+
+export interface DistributionBin extends DistributionBinDefinition {
+  count: number;
+  midpoint: number;
+}
+
+export const EMISSIONS_CHANGE_BIN_DEFINITIONS: DistributionBinDefinition[] = [
+  { id: "largeReduction", min: -Infinity, max: -30, isReduction: true },
+  { id: "moderateReduction", min: -30, max: -10, isReduction: true },
+  { id: "smallReduction", min: -10, max: 0, isReduction: true },
+  { id: "smallIncrease", min: 0, max: 10, isReduction: false },
+  { id: "moderateIncrease", min: 10, max: 30, isReduction: false },
+  { id: "largeIncrease", min: 30, max: Infinity, isReduction: false },
+];
+
+export function assignValueToBin(
+  value: number,
+  definitions: DistributionBinDefinition[],
+): DistributionBinDefinition {
+  for (const definition of definitions) {
+    const inMin = value >= definition.min;
+    const inMax = definition.max === Infinity || value < definition.max;
+    if (inMin && inMax) {
+      return definition;
+    }
+  }
+
+  return definitions[definitions.length - 1];
+}
+
+export function buildDistributionBins(
+  values: number[],
+  definitions: DistributionBinDefinition[] = EMISSIONS_CHANGE_BIN_DEFINITIONS,
+): DistributionBin[] {
+  const counts = new Map<string, number>(
+    definitions.map((definition) => [definition.id, 0]),
+  );
+
+  values.forEach((value) => {
+    const bin = assignValueToBin(value, definitions);
+    counts.set(bin.id, (counts.get(bin.id) ?? 0) + 1);
+  });
+
+  return definitions.map((definition) => ({
+    ...definition,
+    count: counts.get(definition.id) ?? 0,
+    midpoint:
+      definition.min === -Infinity
+        ? definition.max - 5
+        : definition.max === Infinity
+          ? definition.min + 5
+          : (definition.min + definition.max) / 2,
+  }));
+}
+
+export function calculateMedian(values: number[]): number | null {
+  if (values.length === 0) {
+    return null;
+  }
+
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+
+  if (sorted.length % 2 === 0) {
+    return (sorted[middle - 1] + sorted[middle]) / 2;
+  }
+
+  return sorted[middle];
+}
+
+export interface EmissionsChangeSummary {
+  totalWithData: number;
+  reducedCount: number;
+  increasedCount: number;
+  unchangedCount: number;
+  average: number | null;
+  median: number | null;
+}
+
+export function summarizeEmissionsChange(
+  values: number[],
+): EmissionsChangeSummary {
+  if (values.length === 0) {
+    return {
+      totalWithData: 0,
+      reducedCount: 0,
+      increasedCount: 0,
+      unchangedCount: 0,
+      average: null,
+      median: null,
+    };
+  }
+
+  const reducedCount = values.filter((value) => value < 0).length;
+  const increasedCount = values.filter((value) => value > 0).length;
+  const unchangedCount = values.filter((value) => value === 0).length;
+  const average = values.reduce((sum, value) => sum + value, 0) / values.length;
+
+  return {
+    totalWithData: values.length,
+    reducedCount,
+    increasedCount,
+    unchangedCount,
+    average,
+    median: calculateMedian(values),
+  };
+}
+
+export interface ParisAlignmentSummary {
+  yesCount: number;
+  noCount: number;
+  unknownCount: number;
+  total: number;
+}
+
+export function summarizeParisAlignment(
+  values: Array<boolean | null | undefined>,
+): ParisAlignmentSummary {
+  const yesCount = values.filter((value) => value === true).length;
+  const noCount = values.filter((value) => value === false).length;
+  const unknownCount = values.filter(
+    (value) => value === null || value === undefined,
+  ).length;
+
+  return {
+    yesCount,
+    noCount,
+    unknownCount,
+    total: values.length,
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### ✨ What’s Changed?

The companies overview graph at `/sv/companies` was hard to read: a beeswarm plot stacked dots in the center of the panel, with no clear axis labels or headline answer for the selected KPI.

This PR replaces those charts with answer-focused distribution visuals and fixes sector filtering UX:

- **Emissions change KPI** — histogram with labeled bins (reduction vs increase), summary cards (reduced / increased / average / missing), and a plain-language headline (e.g. “42 of 120 companies reduced emissions”)
- **Paris alignment KPI** — horizontal bar chart showing yes / no / unknown counts, with a headline answer instead of a carbon-budget beeswarm
- **Sector filter** — defaults to **All sectors** instead of forcing the first GICS sector; always uses a dropdown (desktop and mobile)

### Why this chart type?

| Old (beeswarm) | New (distribution) |
|---|---|
| Each dot = one company, hard to see overall pattern | Bins show how many companies fall in each change range |
| Most dots clustered vertically in unused space | Full panel used for bars + summary stats |
| No direct answer to “how many reduced emissions?” | Headline + cards answer the question immediately |
| Paris view showed budget tonnes, not yes/no alignment | Paris view shows alignment counts directly |

### 📋 Checklist

- [x] Change runs locally (unit tests + TypeScript)
- [ ] Verified on mobile and desktop in browser
- [ ] Labels, issue, and milestone set

### 🛠 Related Issue

Related to companies overview UX feedback on graph readability and sector defaults.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87a59f11-1adc-4b09-84b1-d69a5c2d72d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87a59f11-1adc-4b09-84b1-d69a5c2d72d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

