### PR TITLE
[feat] Adapt nation page to garbo PR #1311 territorial data schema

### DIFF
--- a/src/hooks/nation/useNationDetails.ts
+++ b/src/hooks/nation/useNationDetails.ts
@@ -2,6 +2,11 @@ import { useQuery } from "@tanstack/react-query";
 import { getNationDetails } from "@/lib/api";
 import type { EmissionDataPoint } from "@/types/municipality";
 import { mapEmissionArray } from "@/utils/data/emissionArrayUtils";
+import {
+  computeNationDerivedMetrics,
+  extractYearRecord,
+  type NationEmissionBreakdown,
+} from "@/utils/data/nationTerritorialTransforms";
 
 export type NationDetails = {
   country: { sv: string; en: string };
@@ -11,51 +16,108 @@ export type NationDetails = {
   trend: (EmissionDataPoint | null)[];
   meetsParis: boolean;
   historicalEmissionChangePercent: number;
+  emissionBreakdown: NationEmissionBreakdown;
 };
 
-type ApiEmissionsSeries = ({ year: string; value: number } | null)[];
+type EmissionSeries =
+  | ({ year: string | number; value: number } | null)[]
+  | Record<string, number>
+  | undefined;
 
 type ApiNationResponse = {
   country: { sv: string; en: string } | string;
   logoUrl?: string | null;
-  emissions?: ApiEmissionsSeries;
-  territorialFossilEmissions?: ApiEmissionsSeries;
-  approximatedHistoricalEmission: ApiEmissionsSeries;
-  trend: ApiEmissionsSeries;
-  historicalEmissionChangePercent: number;
-  meetsParis: boolean;
+  territorialFossilEmissions?: EmissionSeries;
+  biogenicEmissions?: EmissionSeries;
+  consumptionAbroadEmissions?: EmissionSeries;
+  exportOfOilProductsEmissions?: EmissionSeries;
+  eCommerceEmissions?: EmissionSeries;
+  emissions?: EmissionSeries;
+  approximatedHistoricalEmission?: EmissionSeries;
+  trend?: EmissionSeries;
+  historicalEmissionChangePercent?: number;
+  meetsParis?: boolean;
 };
 
 function normalizeCountry(
   country: ApiNationResponse["country"],
 ): NationDetails["country"] {
   if (typeof country === "string") {
-    return { sv: country, en: country };
+    return { sv: country, en: country === "Sverige" ? "Sweden" : country };
   }
 
   return { sv: country.sv, en: country.en };
 }
 
-function getPrimaryEmissionsSeries(
+function getTerritorialFossilSeries(
   response: ApiNationResponse,
-): ApiEmissionsSeries | undefined {
-  return response.emissions ?? response.territorialFossilEmissions;
+): EmissionSeries | undefined {
+  return response.territorialFossilEmissions ?? response.emissions;
+}
+
+function hasLegacyTrendFields(response: ApiNationResponse): boolean {
+  return (
+    Array.isArray(response.approximatedHistoricalEmission) &&
+    Array.isArray(response.trend)
+  );
+}
+
+function buildEmissionBreakdown(
+  response: ApiNationResponse,
+): NationEmissionBreakdown {
+  return {
+    territorialFossil: extractYearRecord(getTerritorialFossilSeries(response)),
+    biogenic: extractYearRecord(response.biogenicEmissions),
+    consumptionAbroad: extractYearRecord(response.consumptionAbroadEmissions),
+    exportOfOilProducts: extractYearRecord(response.exportOfOilProductsEmissions),
+    eCommerce: extractYearRecord(response.eCommerceEmissions),
+  };
+}
+
+function transformLegacyNationResponse(
+  response: ApiNationResponse,
+): NationDetails {
+  return {
+    country: normalizeCountry(response.country),
+    logoUrl: response.logoUrl ?? null,
+    emissions: mapEmissionArray(getTerritorialFossilSeries(response)),
+    approximatedHistoricalEmission: mapEmissionArray(
+      response.approximatedHistoricalEmission,
+    ),
+    trend: mapEmissionArray(response.trend),
+    meetsParis: response.meetsParis ?? false,
+    historicalEmissionChangePercent:
+      response.historicalEmissionChangePercent ?? 0,
+    emissionBreakdown: buildEmissionBreakdown(response),
+  };
+}
+
+function transformNewNationResponse(
+  response: ApiNationResponse,
+): NationDetails {
+  const territorialFossil = extractYearRecord(getTerritorialFossilSeries(response));
+  const derived = computeNationDerivedMetrics(territorialFossil);
+
+  return {
+    country: normalizeCountry(response.country),
+    logoUrl: response.logoUrl ?? null,
+    emissions: derived.emissions,
+    approximatedHistoricalEmission: derived.approximatedHistoricalEmission,
+    trend: derived.trend,
+    meetsParis: derived.meetsParis,
+    historicalEmissionChangePercent: derived.historicalEmissionChangePercent,
+    emissionBreakdown: buildEmissionBreakdown(response),
+  };
 }
 
 function transformApiNationToNationDetails(
-  r: ApiNationResponse,
+  response: ApiNationResponse,
 ): NationDetails {
-  return {
-    country: normalizeCountry(r.country),
-    logoUrl: r.logoUrl ?? null,
-    emissions: mapEmissionArray(getPrimaryEmissionsSeries(r)),
-    approximatedHistoricalEmission: mapEmissionArray(
-      r.approximatedHistoricalEmission,
-    ),
-    trend: mapEmissionArray(r.trend),
-    meetsParis: r.meetsParis ?? false,
-    historicalEmissionChangePercent: r.historicalEmissionChangePercent ?? 0,
-  };
+  if (hasLegacyTrendFields(response)) {
+    return transformLegacyNationResponse(response);
+  }
+
+  return transformNewNationResponse(response);
 }
 
 export function useNationDetails() {
@@ -65,11 +127,17 @@ export function useNationDetails() {
     error,
   } = useQuery({
     queryKey: ["nation"],
-    queryFn: () => getNationDetails(),
+    queryFn: async () => {
+      const data = await getNationDetails();
+      const response = (
+        Array.isArray(data) ? data[0] : data
+      ) as ApiNationResponse;
+      return transformApiNationToNationDetails(response);
+    },
   });
 
   return {
-    nation: nation ? transformApiNationToNationDetails(nation) : null,
+    nation: nation ?? null,
     loading: isLoading,
     error: error as Error | null,
   };

--- a/src/hooks/nation/useNationDetails.ts
+++ b/src/hooks/nation/useNationDetails.ts
@@ -69,7 +69,9 @@ function buildEmissionBreakdown(
     territorialFossil: extractYearRecord(getTerritorialFossilSeries(response)),
     biogenic: extractYearRecord(response.biogenicEmissions),
     consumptionAbroad: extractYearRecord(response.consumptionAbroadEmissions),
-    exportOfOilProducts: extractYearRecord(response.exportOfOilProductsEmissions),
+    exportOfOilProducts: extractYearRecord(
+      response.exportOfOilProductsEmissions,
+    ),
     eCommerce: extractYearRecord(response.eCommerceEmissions),
   };
 }
@@ -95,7 +97,9 @@ function transformLegacyNationResponse(
 function transformNewNationResponse(
   response: ApiNationResponse,
 ): NationDetails {
-  const territorialFossil = extractYearRecord(getTerritorialFossilSeries(response));
+  const territorialFossil = extractYearRecord(
+    getTerritorialFossilSeries(response),
+  );
   const derived = computeNationDerivedMetrics(territorialFossil);
 
   return {

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -2812,7 +2812,7 @@ export interface paths {
         };
         /**
          * Get national data
-         * @description Retrieve national (Sweden) data with historical emissions, trends, and Paris agreement compliance status. Returns 304 Not Modified if the resource has not changed since the last request (based on ETag).
+         * @description Retrieve national (Sweden) data with territorial fossil, biogenic, consumption abroad, oil export, and e-commerce emissions. Returns 304 Not Modified if the resource has not changed since the last request (based on ETag).
          */
         get: {
             parameters: {
@@ -2835,22 +2835,26 @@ export interface paths {
                                 en: string;
                             };
                             logoUrl?: string | null;
-                            emissions: ({
+                            territorialFossilEmissions: ({
                                 year: string;
                                 value: number;
                             } | null)[];
-                            totalTrend: number;
-                            totalCarbonLaw: number;
-                            approximatedHistoricalEmission: ({
+                            biogenicEmissions: ({
                                 year: string;
                                 value: number;
                             } | null)[];
-                            trend: ({
+                            consumptionAbroadEmissions: ({
                                 year: string;
                                 value: number;
                             } | null)[];
-                            historicalEmissionChangePercent: number;
-                            meetsParis: boolean;
+                            exportOfOilProductsEmissions: ({
+                                year: string;
+                                value: number;
+                            } | null)[];
+                            eCommerceEmissions: ({
+                                year: string;
+                                value: number;
+                            } | null)[];
                         };
                     };
                 };

--- a/src/utils/data/nationTerritorialTransforms.test.ts
+++ b/src/utils/data/nationTerritorialTransforms.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeNationDerivedMetrics,
+  extractYearRecord,
+} from "@/utils/data/nationTerritorialTransforms";
+
+const territorialFixture: Record<number, number> = {
+  1990: 71260000,
+  2015: 53250000,
+  2020: 45970000,
+  2023: 44230000,
+  2024: 47490000,
+};
+
+describe("extractYearRecord", () => {
+  it("parses API array format", () => {
+    expect(
+      extractYearRecord([
+        { year: "2015", value: 100 },
+        null,
+        { year: "2020", value: 80 },
+      ]),
+    ).toEqual({ 2015: 100, 2020: 80 });
+  });
+
+  it("parses yearly record format", () => {
+    expect(extractYearRecord({ "2015": 100, "2020": 80 })).toEqual({
+      2015: 100,
+      2020: 80,
+    });
+  });
+});
+
+describe("computeNationDerivedMetrics", () => {
+  it("derives CAGR from 2015 to 2024", () => {
+    const derived = computeNationDerivedMetrics(territorialFixture, 2026);
+
+    expect(derived.historicalEmissionChangePercent).toBeCloseTo(-1.24, 1);
+  });
+
+  it("maps territorial fossil emissions to the emissions series", () => {
+    const derived = computeNationDerivedMetrics(territorialFixture, 2026);
+
+    expect(derived.emissions).toEqual([
+      { year: 1990, value: 71260000 },
+      { year: 2015, value: 53250000 },
+      { year: 2020, value: 45970000 },
+      { year: 2023, value: 44230000 },
+      { year: 2024, value: 47490000 },
+    ]);
+  });
+
+  it("produces approximated and trend series for charts", () => {
+    const derived = computeNationDerivedMetrics(territorialFixture, 2026);
+
+    expect(derived.approximatedHistoricalEmission.length).toBeGreaterThan(0);
+    expect(derived.trend.some((point) => point?.year === 2050)).toBe(true);
+    expect(typeof derived.meetsParis).toBe("boolean");
+  });
+});

--- a/src/utils/data/nationTerritorialTransforms.ts
+++ b/src/utils/data/nationTerritorialTransforms.ts
@@ -1,0 +1,237 @@
+import type { EmissionDataPoint } from "@/types/municipality";
+import {
+  calculateCarbonLawCumulativeEmissions,
+  calculateCumulativeEmissions,
+} from "@/lib/calculations/trends/meetsParis";
+
+const CUTOFF_YEAR = 2015;
+const END_YEAR = 2050;
+const LAST_YEAR_WITH_SMHI_DATA = 2024;
+
+type YearRecord = Record<number, number>;
+
+export type NationEmissionBreakdown = {
+  territorialFossil: YearRecord;
+  biogenic: YearRecord;
+  consumptionAbroad: YearRecord;
+  exportOfOilProducts: YearRecord;
+  eCommerce: YearRecord;
+};
+
+export type NationDerivedMetrics = {
+  emissions: (EmissionDataPoint | null)[];
+  approximatedHistoricalEmission: (EmissionDataPoint | null)[];
+  trend: (EmissionDataPoint | null)[];
+  meetsParis: boolean;
+  historicalEmissionChangePercent: number;
+};
+
+function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid];
+}
+
+function fitLADRegression(
+  points: { year: number; value: number }[],
+): { slope: number; shift: number } {
+  if (points.length < 2) {
+    return { slope: 0, shift: points[0]?.value ?? 0 };
+  }
+
+  const lastYear = points[points.length - 1].year;
+  const lastValue = points[points.length - 1].value;
+  const centered = points.map((p) => ({
+    x: p.year - lastYear,
+    y: p.value,
+  }));
+
+  const slopeCandidates = new Set<number>([0]);
+  for (let i = 0; i < centered.length; i++) {
+    for (let j = i + 1; j < centered.length; j++) {
+      const dx = centered[j].x - centered[i].x;
+      if (dx !== 0) {
+        slopeCandidates.add((centered[j].y - centered[i].y) / dx);
+      }
+    }
+  }
+
+  let bestSlope = 0;
+  let bestIntercept = lastValue;
+  let bestError = Number.POSITIVE_INFINITY;
+
+  for (const slope of slopeCandidates) {
+    const residuals = centered.map((p) => p.y - slope * p.x);
+    const intercept = median(residuals);
+    const error = centered.reduce(
+      (sum, p) => sum + Math.abs(p.y - (intercept + slope * p.x)),
+      0,
+    );
+
+    if (error < bestError) {
+      bestError = error;
+      bestSlope = slope;
+      bestIntercept = intercept;
+    }
+  }
+
+  const interceptAtLast = bestIntercept;
+  const shift = lastValue - interceptAtLast;
+
+  return { slope: bestSlope, shift };
+}
+
+function predictWithLAD(
+  slope: number,
+  shift: number,
+  lastYear: number,
+  year: number,
+): number {
+  return slope * (year - lastYear) + shift;
+}
+
+function recordToSortedPoints(record: YearRecord): EmissionDataPoint[] {
+  return Object.entries(record)
+    .map(([year, value]) => ({ year: Number(year), value }))
+    .filter((point) => !Number.isNaN(point.year))
+    .sort((a, b) => a.year - b.year);
+}
+
+function toEmissionArray(
+  valuesByYear: Map<number, number>,
+): (EmissionDataPoint | null)[] {
+  return [...valuesByYear.entries()]
+    .sort(([a], [b]) => a - b)
+    .map(([year, value]) => ({ year, value }));
+}
+
+function calculateHistoricalEmissionChangePercent(
+  record: YearRecord,
+): number {
+  const startValue = record[CUTOFF_YEAR];
+  const endValue = record[LAST_YEAR_WITH_SMHI_DATA];
+
+  if (startValue == null || endValue == null || startValue === 0) {
+    return 0;
+  }
+
+  const yearSpan = LAST_YEAR_WITH_SMHI_DATA - CUTOFF_YEAR;
+  const cagrFraction = (endValue / startValue) ** (1 / yearSpan) - 1;
+  return cagrFraction * 100;
+}
+
+function calculateMeetsParis(
+  slope: number,
+  emissionsAtCurrentYear: number,
+  currentYear: number,
+): boolean {
+  if (emissionsAtCurrentYear <= 0) {
+    return true;
+  }
+
+  const totalTrend = calculateCumulativeEmissions(
+    emissionsAtCurrentYear,
+    slope,
+    currentYear,
+    END_YEAR,
+  );
+
+  const totalCarbonLaw = calculateCarbonLawCumulativeEmissions(
+    emissionsAtCurrentYear,
+    currentYear,
+    END_YEAR,
+  );
+
+  return totalTrend <= totalCarbonLaw;
+}
+
+export function computeNationDerivedMetrics(
+  territorialFossil: YearRecord,
+  currentYear: number = new Date().getFullYear(),
+): NationDerivedMetrics {
+  const historicalPoints = recordToSortedPoints(territorialFossil).filter(
+    (point) => point.year >= CUTOFF_YEAR,
+  );
+
+  const emissions = recordToSortedPoints(territorialFossil).map((point) => ({
+    year: point.year,
+    value: point.value,
+  }));
+
+  if (historicalPoints.length === 0) {
+    return {
+      emissions,
+      approximatedHistoricalEmission: [],
+      trend: [],
+      meetsParis: false,
+      historicalEmissionChangePercent: 0,
+    };
+  }
+
+  const lastDataYear = historicalPoints[historicalPoints.length - 1].year;
+  const { slope, shift } = fitLADRegression(historicalPoints);
+
+  const approximatedByYear = new Map<number, number>();
+  for (let year = lastDataYear; year <= currentYear; year++) {
+    approximatedByYear.set(
+      year,
+      Math.max(0, predictWithLAD(slope, shift, lastDataYear, year)),
+    );
+  }
+
+  const trendByYear = new Map<number, number>();
+  for (let year = currentYear; year <= END_YEAR; year++) {
+    trendByYear.set(
+      year,
+      Math.max(0, predictWithLAD(slope, shift, lastDataYear, year)),
+    );
+  }
+
+  const emissionsAtCurrentYear =
+    approximatedByYear.get(currentYear) ??
+    territorialFossil[currentYear] ??
+    predictWithLAD(slope, shift, lastDataYear, currentYear);
+
+  return {
+    emissions,
+    approximatedHistoricalEmission: toEmissionArray(approximatedByYear),
+    trend: toEmissionArray(trendByYear),
+    meetsParis: calculateMeetsParis(slope, emissionsAtCurrentYear, currentYear),
+    historicalEmissionChangePercent:
+      calculateHistoricalEmissionChangePercent(territorialFossil),
+  };
+}
+
+export function extractYearRecord(
+  emissions:
+    | ({ year: string | number; value: number } | null)[]
+    | Record<string, number>
+    | undefined,
+): YearRecord {
+  const record: YearRecord = {};
+
+  if (!emissions) return record;
+
+  if (Array.isArray(emissions)) {
+    emissions.forEach((point) => {
+      if (!point) return;
+      const year = Number(point.year);
+      if (!Number.isNaN(year)) {
+        record[year] = point.value;
+      }
+    });
+    return record;
+  }
+
+  Object.entries(emissions).forEach(([year, value]) => {
+    const parsedYear = Number(year);
+    if (!Number.isNaN(parsedYear) && typeof value === "number") {
+      record[parsedYear] = value;
+    }
+  });
+
+  return record;
+}

--- a/src/utils/data/nationTerritorialTransforms.ts
+++ b/src/utils/data/nationTerritorialTransforms.ts
@@ -35,9 +35,10 @@ function median(values: number[]): number {
     : sorted[mid];
 }
 
-function fitLADRegression(
-  points: { year: number; value: number }[],
-): { slope: number; shift: number } {
+function fitLADRegression(points: { year: number; value: number }[]): {
+  slope: number;
+  shift: number;
+} {
   if (points.length < 2) {
     return { slope: 0, shift: points[0]?.value ?? 0 };
   }
@@ -108,9 +109,7 @@ function toEmissionArray(
     .map(([year, value]) => ({ year, value }));
 }
 
-function calculateHistoricalEmissionChangePercent(
-  record: YearRecord,
-): number {
+function calculateHistoricalEmissionChangePercent(record: YearRecord): number {
   const startValue = record[CUTOFF_YEAR];
   const endValue = record[LAST_YEAR_WITH_SMHI_DATA];
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### ✨ What's Changed?

Adapts the frontend to the new `/api/nation` response shape from [garbo PR #1311](https://github.com/Klimatbyran/garbo/pull/1311).

The API no longer returns legacy `emissions`, `trend`, `meetsParis`, and related KPI fields. Instead it exposes the territorial pipeline breakdown:

- `territorialFossilEmissions` (used as the primary territorial fossil layer)
- `biogenicEmissions`
- `consumptionAbroadEmissions`
- `exportOfOilProductsEmissions`
- `eCommerceEmissions`

**Data layer**
- `useNationDetails` parses the new schema (array or yearly-record formats) and maps `territorialFossilEmissions` into the `territorialFossil` series
- Added `nationStoryMetrics` utilities + tests for derived chart data
- Added a dev fixture fallback when the API has not yet been updated
- Updated OpenAPI types for `GET /nation/`

**Nation page**
- Replaced the old territory detail layout with an interactive data story that visualises all emission layers (zoom chart, stacked chart, layer comparisons, oil exports, e-commerce scale, conclusion)
- Added `emissionsToSwedishCitizenEquivalent` helper for the oil export chart citizen comparison

### 📸 Screenshots (if applicable)

N/A — story page with scroll-driven charts; best reviewed locally at `/nation`.

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [ ] I've verified the change runs locally both on mobile and desktop
- [ ] I've set the labels, issue, and milestone for the PR

### 🛠 Related Issue

Related to garbo PR #1311 and frontend #1487 / #1530 (nation data story).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d65eb87-3732-4464-a39c-5f7cd321f7e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d65eb87-3732-4464-a39c-5f7cd321f7e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

