### PR TITLE
Make sector insight company lists clickable

### DIFF
--- a/src/components/companies/sectors/charts/InsightVisualization.tsx
+++ b/src/components/companies/sectors/charts/InsightVisualization.tsx
@@ -1,10 +1,12 @@
 import React from "react";
 import { motion } from "framer-motion";
+import { LocalizedLink } from "@/components/LocalizedLink";
 import {
   InsightBar,
   InsightSegment,
 } from "@/hooks/companies/useSectorChartInsights";
 import { useChartMotion } from "@/hooks/useChartMotion";
+import { getCompanyDetailPath } from "@/utils/companyRouting";
 
 interface InsightBarChartProps {
   bars: InsightBar[];
@@ -24,41 +26,60 @@ export const InsightBarChart: React.FC<InsightBarChartProps> = ({
 
   return (
     <div className="space-y-2.5">
-      {bars.map((bar, index) => (
-        <motion.div
-          key={bar.label}
-          className="space-y-1"
-          initial={reduceMotion ? false : { opacity: 0, x: -8 }}
-          animate={{ opacity: 1, x: 0 }}
-          transition={{
-            duration: fadeDuration,
-            delay: stagger(index, 0.06),
-            ease,
-          }}
-        >
-          <div className="flex items-center justify-between gap-2 text-xs">
-            <span className="text-white truncate">{bar.label}</span>
-            {showValues && (
-              <span className="text-grey shrink-0">{bar.valueLabel}</span>
-            )}
+      {bars.map((bar, index) => {
+        const content = (
+          <motion.div
+            className="space-y-1"
+            initial={reduceMotion ? false : { opacity: 0, x: -8 }}
+            animate={{ opacity: 1, x: 0 }}
+            transition={{
+              duration: fadeDuration,
+              delay: stagger(index, 0.06),
+              ease,
+            }}
+          >
+            <div className="flex items-center justify-between gap-2 text-xs">
+              <span className="text-white truncate">{bar.label}</span>
+              {showValues && (
+                <span className="text-grey shrink-0">{bar.valueLabel}</span>
+              )}
+            </div>
+            <div className="h-2 rounded-full bg-black-1 overflow-hidden">
+              <motion.div
+                className="h-full rounded-full"
+                initial={reduceMotion ? false : { width: 0 }}
+                animate={{
+                  width: `${Math.max(bar.share * 100, 2)}%`,
+                }}
+                transition={{
+                  duration: barDuration,
+                  delay: stagger(index, 0.08),
+                  ease,
+                }}
+                style={{ backgroundColor: bar.color }}
+              />
+            </div>
+          </motion.div>
+        );
+
+        if (bar.company?.id) {
+          return (
+            <LocalizedLink
+              key={bar.label}
+              to={getCompanyDetailPath(bar.company)}
+              className="block rounded-lg px-1 -mx-1 transition-colors hover:bg-white/5"
+            >
+              {content}
+            </LocalizedLink>
+          );
+        }
+
+        return (
+          <div key={bar.label} className="space-y-1">
+            {content}
           </div>
-          <div className="h-2 rounded-full bg-black-1 overflow-hidden">
-            <motion.div
-              className="h-full rounded-full"
-              initial={reduceMotion ? false : { width: 0 }}
-              animate={{
-                width: `${Math.max(bar.share * 100, 2)}%`,
-              }}
-              transition={{
-                duration: barDuration,
-                delay: stagger(index, 0.08),
-                ease,
-              }}
-              style={{ backgroundColor: bar.color }}
-            />
-          </div>
-        </motion.div>
-      ))}
+        );
+      })}
     </div>
   );
 };

--- a/src/hooks/companies/useChartData.ts
+++ b/src/hooks/companies/useChartData.ts
@@ -54,6 +54,7 @@ const createCompanyDataItem = (
   value: number;
   sectorCode: string | undefined;
   wikidataId: string | undefined;
+  companyId: string;
   total: number;
 } | null => {
   const periodForYear = company.reportingPeriods.find((period) =>
@@ -76,6 +77,7 @@ const createCompanyDataItem = (
     value: totalEmissions,
     sectorCode: company.industry?.industryGics?.sectorCode,
     wikidataId: getCompanyUrlSegment(company),
+    companyId: company.id,
     total: totalEmissions,
   };
 };

--- a/src/hooks/companies/useSectorChartInsights.ts
+++ b/src/hooks/companies/useSectorChartInsights.ts
@@ -28,6 +28,7 @@ export type InsightBar = {
   valueLabel: string;
   share: number;
   color: string;
+  company?: { id: string; wikidataId?: string | null };
 };
 
 export type InsightSegment = {
@@ -55,6 +56,7 @@ type PieChartEntry = {
   total: number;
   sectorCode?: string;
   wikidataId?: string;
+  companyId?: string;
   scope1?: number;
   scope2?: number;
   scope3?: number;
@@ -110,6 +112,7 @@ const formatEmissionsLabel = (
 type CompanyTrend = {
   name: string;
   changePercent: number;
+  company: { id: string; wikidataId?: string | null };
 };
 
 const getComparableCompanyTrends = (
@@ -124,7 +127,13 @@ const getComparableCompanyTrends = (
       return [];
     }
 
-    return [{ name: company.name, changePercent }];
+    return [
+      {
+        name: company.name,
+        changePercent,
+        company: { id: company.id, wikidataId: company.wikidataId },
+      },
+    ];
   });
 };
 
@@ -179,6 +188,7 @@ const buildTrendChangeBars = (
     valueLabel: formatPercentChange(trend.changePercent, currentLanguage),
     share: Math.abs(trend.changePercent) / maxAbsChange,
     color: palette[index % palette.length],
+    company: trend.company,
   }));
 };
 
@@ -224,6 +234,9 @@ export const useSectorChartInsights = (
           ),
           share: entry.value / entry.total,
           color: getCompanyColors(index).base,
+          company: entry.companyId
+            ? { id: entry.companyId, wikidataId: entry.wikidataId }
+            : undefined,
         }));
 
       const reducingBars = buildTrendChangeBars(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On the sectors page (`/en/sectors`), company names shown in the insight panels below the chart were plain text. Users can now click them to navigate to the corresponding company detail page.

This applies when a sector is selected (drilled into from the pie chart):
- **Top emitters** in the sector
- **Top reducers** (emissions decreasing since base year)
- **Top increasers** (emissions increasing since base year)

Sector-level insight bars (top 3 sectors on the overview) remain non-clickable, since those are sectors rather than companies.

## Changes

- Extended `InsightBar` with an optional `company` reference (`id` + `wikidataId`)
- Propagated company IDs from pie chart data and trend calculations into insight bars
- Wrapped clickable insight rows in `LocalizedLink` with hover styling, matching the pattern used in `InsightsList` on the companies overview page

## Test plan

- [x] Visit `/en/sectors` and click a sector in the pie chart
- [x] Verify company names in the three insight panels link to `/en/companies/{wikidataId}`
- [x] Confirm hover state appears on clickable rows
- [x] Confirm sector-level bars (before selecting a sector) are not clickable
- [x] Test on `/sv/sectors` to verify localized links work
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c4bdbcf-f48c-46a2-8163-b38248ed05f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c4bdbcf-f48c-46a2-8163-b38248ed05f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

