### PR TITLE
[fix] Correct base year emissions change percentages in insights list

### DIFF
--- a/src/components/companies/rankedList/CompanyInsightsPanel.tsx
+++ b/src/components/companies/rankedList/CompanyInsightsPanel.tsx
@@ -140,7 +140,7 @@ function CompanyInsightsPanel({
         { entityPlural },
       )}
       entities={topCompanies}
-      totalCount={companyData.length}
+      totalCount={statistics.validData.length}
       dataPointKey={selectedKPI.key}
       unit={selectedKPI.unit}
       nullValues={selectedKPI.nullValues}
@@ -157,7 +157,7 @@ function CompanyInsightsPanel({
     <InsightsList<CompanyWithKPIs>
       title={t("rankedInsights.titleWorst", { entityPlural })}
       entities={bottomCompanies}
-      totalCount={companyData.length}
+      totalCount={statistics.validData.length}
       isBottomRanking
       dataPointKey={selectedKPI.key}
       unit={selectedKPI.unit}

--- a/src/components/companies/rankedList/CompanyInsightsPanel.tsx
+++ b/src/components/companies/rankedList/CompanyInsightsPanel.tsx
@@ -93,7 +93,7 @@ function CompanyInsightsPanel({
   const statsPanel = (
     <KPIDetailsPanel
       title={selectedKPI.label}
-      description={selectedKPI.description}
+      description={selectedKPI.detailedDescription || selectedKPI.description}
       isBoolean={selectedKPI.isBoolean}
       higherIsBetter={selectedKPI.higherIsBetter}
       averageValue={statistics.formattedAverage}

--- a/src/components/companies/rankedList/visualizations/EmissionsChangeVisualization.tsx
+++ b/src/components/companies/rankedList/visualizations/EmissionsChangeVisualization.tsx
@@ -45,8 +45,10 @@ export function EmissionsChangeVisualization({
   if (withData.length === 0) {
     return (
       <div className="bg-black-2 rounded-level-2 p-8 h-full flex items-center justify-center">
-        <p className="text-grey text-lg">
-          {t("companiesOverviewPage.visualizations.noDataAvailable")}
+        <p className="text-grey text-lg text-center px-4">
+          {t(
+            "companiesOverviewPage.visualizations.emissionsChange.noComparableData",
+          )}
         </p>
       </div>
     );
@@ -69,6 +71,9 @@ export function EmissionsChangeVisualization({
           totalCount={withData.length}
         />
       </div>
+      <p className="text-sm text-white/50 px-1">
+        {t("companiesOverviewPage.visualizations.emissionsChange.description")}
+      </p>
     </div>
   );
 }

--- a/src/hooks/companies/useCompanyKPIs.ts
+++ b/src/hooks/companies/useCompanyKPIs.ts
@@ -45,6 +45,9 @@ export const useCompanyKPIs = (): CompanyKPIValue[] => {
         detailedDescription: t(
           "companies.list.kpis.emissionsChangeFromBaseYear.detailedDescription",
         ),
+        nullValues: t(
+          "companies.list.kpis.emissionsChangeFromBaseYear.nullValues",
+        ),
         higherIsBetter: false,
         createKPIColorGetter: (companies: CompanyWithKPIs[]) =>
           createSymmetricKPIColorGetter(

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -421,6 +421,8 @@
       "noDataAvailable": "No data available",
       "emissionsChange": {
         "title": "Emissions Change from Base Year",
+        "description": "Only companies with a defined base year and comparable follow-up emissions data are ranked.",
+        "noComparableData": "No companies in this sector with comparable emissions change data.",
         "unknown": "Unknown"
       },
       "meetsParis": {
@@ -1408,9 +1410,10 @@
         },
         "emissionsChangeFromBaseYear": {
           "label": "Overall Emissions Change",
-          "description": "Change in emissions from base year to latest reporting period",
-          "detailedDescription": "Percentage change in total emissions from the company's base year to their most recent reporting period. Lower values indicate better performance.",
-          "source": "Company Reporting Data"
+          "description": "Change in emissions from base year to latest reporting period. Only companies with comparable emissions data are ranked.",
+          "detailedDescription": "Percentage change in total emissions from the company's base year to their most recent reporting period. Rankings include only companies with a defined base year, valid baseline emissions, and at least one later reporting period with comparable data. Lower values indicate better performance.",
+          "source": "Company Reporting Data",
+          "nullValues": "Not comparable"
         },
         "trendSlope": {
           "label": "Emissions Trend",

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -426,6 +426,8 @@
       "noDataAvailable": "Ingen data tillgänglig",
       "emissionsChange": {
         "title": "Utsläppsförändring från basår",
+        "description": "Endast företag med ett definierat basår och jämförbara uppföljningsdata rankas.",
+        "noComparableData": "Inga företag i denna sektor med jämförbar utsläppsförändringsdata.",
         "unknown": "Okänt"
       },
       "meetsParis": {
@@ -1465,9 +1467,10 @@
         },
         "emissionsChangeFromBaseYear": {
           "label": "Utsläppsförändring",
-          "description": "Förändring i utsläpp från basår till senaste rapporteringsår",
-          "detailedDescription": "Procentuell förändring i totala utsläpp från företagets basår till senaste rapporteringsår. Lägre värden indikerar bättre prestation.",
-          "source": "Företagsrapporteringsdata"
+          "description": "Förändring i utsläpp från basår till senaste rapporteringsår. Endast företag med jämförbara utsläppsdata rankas.",
+          "detailedDescription": "Procentuell förändring i totala utsläpp från företagets basår till senaste rapporteringsår. Rankningen omfattar endast företag med definierat basår, giltiga basårsutsläpp och minst ett senare rapporteringsår med jämförbar data. Lägre värden indikerar bättre prestation.",
+          "source": "Företagsrapporteringsdata",
+          "nullValues": "Ej jämförbar"
         },
         "trendSlope": {
           "label": "Utsläppstrend",

--- a/src/pages/CompaniesOverviewPage.tsx
+++ b/src/pages/CompaniesOverviewPage.tsx
@@ -137,11 +137,22 @@ export function CompaniesOverviewPage() {
 
     const filtered = companies.filter((company) => {
       const sectorCode = company.industry?.industryGics?.sectorCode;
-      return sectorCode === selectedSector;
+      if (sectorCode !== selectedSector) {
+        return false;
+      }
+
+      if (
+        selectedKPI.key === "emissionsChangeFromBaseYear" &&
+        !company.baseYear?.year
+      ) {
+        return false;
+      }
+
+      return true;
     });
 
     return filtered.map((company) => enrichCompanyWithKPIs(company));
-  }, [companies, selectedSector]);
+  }, [companies, selectedSector, selectedKPI.key]);
 
   const handleSectorChange = (sector: string) => {
     setSelectedSector(sector);

--- a/src/utils/__tests__/emissionsUtils.test.ts
+++ b/src/utils/__tests__/emissionsUtils.test.ts
@@ -5,6 +5,7 @@ import {
   getValidData,
   getMinYear,
   calculateParisValue,
+  calculateEmissionsChangeFromBaseYear,
 } from "../calculations/emissionsCalculations";
 
 describe("generateYearRange", () => {
@@ -175,5 +176,127 @@ describe("calculateParisValue", () => {
     expect(() => calculateParisValue(2024, 2023, NaN)).toThrow(
       "calculateParisValue: Current year value must be a valid number",
     );
+  });
+});
+
+describe("calculateEmissionsChangeFromBaseYear", () => {
+  const createCompany = (
+    baseYear: number,
+    periods: Array<{
+      startDate: string;
+      endDate: string;
+      emissions?: number | null;
+    }>,
+  ) => ({
+    baseYear: { year: baseYear },
+    reportingPeriods: periods.map((period) => ({
+      startDate: period.startDate,
+      endDate: period.endDate,
+      emissions:
+        period.emissions === undefined
+          ? undefined
+          : {
+              calculatedTotalEmissions: period.emissions,
+            },
+    })),
+  });
+
+  it("returns null when company has no base year", () => {
+    expect(
+      calculateEmissionsChangeFromBaseYear({
+        reportingPeriods: [
+          {
+            startDate: "2020-01-01",
+            endDate: "2020-12-31",
+            emissions: { calculatedTotalEmissions: 100 },
+          },
+        ],
+      }),
+    ).toBeNull();
+  });
+
+  it("calculates percentage change from base year to latest period after base year", () => {
+    const company = createCompany(2020, [
+      {
+        startDate: "2020-01-01",
+        endDate: "2020-12-31",
+        emissions: 100,
+      },
+      {
+        startDate: "2023-01-01",
+        endDate: "2023-12-31",
+        emissions: 80,
+      },
+    ]);
+
+    expect(calculateEmissionsChangeFromBaseYear(company)).toBe(-20);
+  });
+
+  it("matches base year using ISO date string, not local timezone", () => {
+    const company = createCompany(2020, [
+      {
+        startDate: "2020-01-01",
+        endDate: "2020-12-31T23:59:59.999Z",
+        emissions: 100,
+      },
+      {
+        startDate: "2023-01-01",
+        endDate: "2023-12-31T23:59:59.999Z",
+        emissions: 125,
+      },
+    ]);
+
+    expect(calculateEmissionsChangeFromBaseYear(company)).toBe(25);
+  });
+
+  it("ignores periods before the base year when finding the latest period", () => {
+    const company = createCompany(2020, [
+      {
+        startDate: "2018-01-01",
+        endDate: "2018-12-31",
+        emissions: 200,
+      },
+      {
+        startDate: "2020-01-01",
+        endDate: "2020-12-31",
+        emissions: 100,
+      },
+      {
+        startDate: "2023-01-01",
+        endDate: "2023-12-31",
+        emissions: 90,
+      },
+    ]);
+
+    expect(calculateEmissionsChangeFromBaseYear(company)).toBe(-10);
+  });
+
+  it("returns null when there is no reporting period after the base year", () => {
+    const company = createCompany(2020, [
+      {
+        startDate: "2020-01-01",
+        endDate: "2020-12-31",
+        emissions: 100,
+      },
+    ]);
+
+    expect(calculateEmissionsChangeFromBaseYear(company)).toBeNull();
+  });
+
+  it("filters out extreme outliers above 200%", () => {
+    const company = createCompany(2020, [
+      {
+        startDate: "2020-01-01",
+        endDate: "2020-12-31",
+        emissions: 100,
+      },
+      {
+        startDate: "2023-01-01",
+        endDate: "2023-12-31",
+        emissions: 350,
+      },
+    ]);
+
+    expect(calculateEmissionsChangeFromBaseYear(company)).toBeNull();
   });
 });

--- a/src/utils/calculations/emissionsCalculations.ts
+++ b/src/utils/calculations/emissionsCalculations.ts
@@ -2,6 +2,8 @@
  * Common utility functions for emissions calculations
  */
 
+import { yearFromIsoDate } from "@/utils/date";
+
 /**
  * Get year-over-year emissions change percentage from API
  * Uses API-provided absolute value (all data) if available,
@@ -278,7 +280,8 @@ export function calculateEmissionsChangeFromBaseYear(
     return null;
   }
 
-  const baseYear = company.baseYear.year.toString();
+  const baseYear = company.baseYear.year;
+  const baseYearStr = baseYear.toString();
 
   // Sort periods by start date (oldest first)
   const periods = [...company.reportingPeriods].sort((a, b) =>
@@ -290,10 +293,9 @@ export function calculateEmissionsChangeFromBaseYear(
   }
 
   // Find baseline period matching the base year (using endDate year)
-  const baselinePeriod = periods.find((p) => {
-    const periodYear = new Date(p.endDate).getFullYear().toString();
-    return periodYear === baseYear;
-  });
+  const baselinePeriod = periods.find(
+    (p) => yearFromIsoDate(p.endDate) === baseYearStr,
+  );
 
   if (!baselinePeriod) {
     return null;
@@ -320,8 +322,13 @@ export function calculateEmissionsChangeFromBaseYear(
     // Use the last period in the array (even if 0)
     latestPeriod = periods[periods.length - 1];
   } else {
-    // Find latest period with >0 emissions (working backwards from latest)
+    // Find latest period with >0 emissions after the base year
     for (let i = periods.length - 1; i >= 0; i--) {
+      const periodYear = Number(yearFromIsoDate(periods[i].endDate));
+      if (periodYear <= baseYear) {
+        continue;
+      }
+
       const emissions = periods[i].emissions?.calculatedTotalEmissions ?? null;
       if (emissions !== null && emissions > 0) {
         latestPeriod = periods[i];
@@ -334,10 +341,10 @@ export function calculateEmissionsChangeFromBaseYear(
     return null;
   }
 
-  // Check if latest period is the same year as base year (using endDate year)
-  const latestYear = new Date(latestPeriod.endDate).getFullYear().toString();
-  if (latestYear === baseYear) {
-    return null; // No change possible - same year
+  // Latest period must be after the base year
+  const latestYear = Number(yearFromIsoDate(latestPeriod.endDate));
+  if (latestYear <= baseYear) {
+    return null;
   }
 
   const latestEmissions = latestPeriod.emissions?.calculatedTotalEmissions ?? 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### ✨ What's Changed?

Fixes incorrect percentage calculations for "Overall Emissions Change" on the companies overview insights list.

**Root cause:** `calculateEmissionsChangeFromBaseYear` used `new Date(endDate).getFullYear()` to match reporting periods to the base year. For end-of-year UTC timestamps (e.g. `2020-12-31T23:59:59.999Z`), this can resolve to the next calendar year in local timezones like Europe/Stockholm, causing wrong baseline matching and incorrect increase/decrease percentages.

**Fixes:**
- Use `yearFromIsoDate` (already used elsewhere in the app) when matching periods to the base year
- Only compare against reporting periods **after** the base year when finding the latest value
- Filter the companies overview to companies with a defined base year when viewing the emissions change KPI
- Use the valid-data count for top/bottom insight rank positions instead of the full sector count

Added unit tests covering timezone-safe matching, post-base-year period selection, and outlier filtering.

### 📋 Checklist

- [x] PR title starts with [fix]
- [x] Unit tests added and passing
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b137eb3b-88ec-4cef-94e8-12505724facc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b137eb3b-88ec-4cef-94e8-12505724facc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

