### PR TITLE
Use current year minus 2 for sectors reporting year

### DIFF
--- a/src/utils/data/yearUtils.ts
+++ b/src/utils/data/yearUtils.ts
@@ -1,6 +1,6 @@
 // Helper function to get latest year's data
 export function getSectorsReportingYear(): number {
-  return Math.round(new Date().getFullYear() - 1.5);
+  return new Date().getFullYear() - 2;
 }
 
 export function getLatestYearData<T>(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the sectors overview page to use `current year - 2` as the reporting year for charts and insights, instead of the previous `Math.round(current year - 1.5)` formula.

For 2026, this changes the reporting year from 2025 to 2024.

## Changes

- Updated `getSectorsReportingYear()` in `src/utils/data/yearUtils.ts` to return `new Date().getFullYear() - 2`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-687cf075-80a0-4868-9e2c-2b348dced39f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-687cf075-80a0-4868-9e2c-2b348dced39f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

