### PR TITLE
Fix map tooltip appearing behind zoom controls

### DIFF
--- a/src/components/maps/MapTooltip.tsx
+++ b/src/components/maps/MapTooltip.tsx
@@ -34,7 +34,7 @@ export function MapTooltip({
 
   return (
     <div
-      className="absolute top-4 left-4 bg-black/40 backdrop-blur-sm p-4 rounded-2xl"
+      className="absolute top-4 left-4 z-20 bg-black/40 backdrop-blur-sm p-4 rounded-2xl"
       onClick={onClick}
     >
       <p className="text-white font-medium text-xl">{name}</p>

--- a/src/components/maps/MapZoomControls.tsx
+++ b/src/components/maps/MapZoomControls.tsx
@@ -14,7 +14,7 @@ export function MapZoomControls({
   canZoomOut: boolean;
 }) {
   return (
-    <div className="absolute top-[56px] md:top-4 left-4 flex flex-col gap-2">
+    <div className="absolute top-[56px] left-4 z-10 flex flex-col gap-2">
       <button
         onClick={onZoomIn}
         disabled={!canZoomIn}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When hovering a region on the map, the tooltip could render behind the zoom controls on `md+` breakpoints.

## Root cause

Two issues combined:

1. **Overlapping positions** — `MapZoomControls` used `top-[56px] md:top-4`, which moved the controls to the same top-left corner as `MapTooltip` on desktop.
2. **Stacking order** — Zoom controls are rendered after the tooltip in the DOM with no explicit z-index, so they painted on top.

## Fix

- Keep zoom controls at `top-[56px]` on all breakpoints so they sit below the tooltip.
- Add `z-20` to the tooltip and `z-10` to the zoom controls so tooltip content always stacks above controls if they overlap.

## Testing

- Hover a municipality/region on overview map pages and confirm the tooltip is fully visible above the zoom buttons on desktop and mobile.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce926ae8-bb1e-4956-803c-ad64a348c7b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce926ae8-bb1e-4956-803c-ad64a348c7b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

