### PR TITLE
Reposition map zoom controls to avoid tooltip overlap

### DIFF
--- a/src/components/maps/MapOverlays.tsx
+++ b/src/components/maps/MapOverlays.tsx
@@ -79,6 +79,7 @@ function MapOverlays({
         onReset={handleReset}
         canZoomIn={positionZoom < maxZoom}
         canZoomOut={positionZoom > minZoom}
+        legendPosition={legendPosition}
       />
     </>
   );

--- a/src/components/maps/MapZoomControls.tsx
+++ b/src/components/maps/MapZoomControls.tsx
@@ -1,4 +1,6 @@
 import { RotateCcw, ZoomIn, ZoomOut } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { MapLegendPosition } from "./MapLegend";
 
 export function MapZoomControls({
   onZoomIn,
@@ -6,15 +8,28 @@ export function MapZoomControls({
   onReset,
   canZoomIn,
   canZoomOut,
+  legendPosition = "bottom-right",
 }: {
   onZoomIn: () => void;
   onZoomOut: () => void;
   onReset: () => void;
   canZoomIn: boolean;
   canZoomOut: boolean;
+  legendPosition?: MapLegendPosition;
 }) {
   return (
-    <div className="absolute top-[56px] md:top-4 left-4 flex flex-col gap-2">
+    <div
+      className={cn(
+        "absolute flex flex-col gap-2",
+        // Mobile: keep clear of the top-left tooltip and overview view toggle.
+        "top-14 right-4",
+        // Desktop: place controls in the corner opposite the legend.
+        legendPosition === "bottom-right" &&
+          "md:top-auto md:right-auto md:bottom-4 md:left-4",
+        legendPosition === "bottom-left" &&
+          "md:top-4 md:right-auto md:bottom-auto md:left-4",
+      )}
+    >
       <button
         onClick={onZoomIn}
         disabled={!canZoomIn}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The map hover tooltip and zoom controls overlapped in the top-left corner on desktop, causing the tooltip to appear hidden behind the zoom buttons.

## Approach

Instead of relying on z-index, reposition the zoom controls based on where the legend sits so each overlay has its own corner across all map views.

## Layout by view

| View | Legend | Zoom (mobile) | Zoom (desktop) |
|------|--------|---------------|----------------|
| Municipality/region overview | bottom-right | top-right | bottom-left |
| Landing municipalities section | bottom-right | top-right | bottom-left |
| Related territories detail map | bottom-left | top-right | top-left (no tooltip) |

The tooltip stays top-left on views that show it. On mobile, zoom controls move to the top-right (`top-14 right-4`) to stay clear of the tooltip and the overview view-mode toggle.

## Changes

- Pass `legendPosition` from `MapOverlays` into `MapZoomControls`
- Replace the `md:top-4 left-4` desktop positioning that caused the overlap

Supersedes the z-index-only fix in #1552.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce926ae8-bb1e-4956-803c-ad64a348c7b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce926ae8-bb1e-4956-803c-ad64a348c7b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

