### PR TITLE
Group header nav into Territorial emissions and Companies

### DIFF
--- a/src/components/layout/header/navConfig.tsx
+++ b/src/components/layout/header/navConfig.tsx
@@ -18,23 +18,29 @@ export const NAV_LINKS: NavLink[] = [
         path: `/explore/municipalities`,
       },
       {
-        label: "header.nation",
-        path: `/nation`,
+        label: "header.territorialEmissions",
         items: [
           {
-            label: "header.municipalities",
-            path: `/municipalities`,
+            label: "header.nation",
+            path: `/nation`,
           },
           {
             label: "header.regions",
             path: `/regions`,
           },
+          {
+            label: "header.municipalities",
+            path: `/municipalities`,
+          },
         ],
       },
       {
         label: "header.companies",
-        path: `/companies`,
         items: [
+          {
+            label: "header.allCompanies",
+            path: `/companies`,
+          },
           {
             label: "header.sectors",
             path: `/sectors`,

--- a/src/components/layout/header/navConfig.tsx
+++ b/src/components/layout/header/navConfig.tsx
@@ -18,7 +18,7 @@ export const NAV_LINKS: NavLink[] = [
         path: `/explore/municipalities`,
       },
       {
-        label: "header.localEmissions",
+        label: "header.territories",
         items: [
           {
             label: "header.nation",

--- a/src/components/layout/header/navConfig.tsx
+++ b/src/components/layout/header/navConfig.tsx
@@ -18,7 +18,7 @@ export const NAV_LINKS: NavLink[] = [
         path: `/explore/municipalities`,
       },
       {
-        label: "header.territorialEmissions",
+        label: "header.localEmissions",
         items: [
           {
             label: "header.nation",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -9,8 +9,10 @@
   "header": {
     "data": "Data",
     "companies": "Companies",
+    "allCompanies": "All companies",
     "sectors": "Sectors",
     "explore": "Explore",
+    "territorialEmissions": "Territorial emissions",
     "municipalities": "Municipalities",
     "nation": "Sweden",
     "regions": "Regions",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -12,7 +12,7 @@
     "allCompanies": "All companies",
     "sectors": "Sectors",
     "explore": "Explore",
-    "territorialEmissions": "Territorial emissions",
+    "localEmissions": "Local emissions",
     "municipalities": "Municipalities",
     "nation": "Sweden",
     "regions": "Regions",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -12,7 +12,7 @@
     "allCompanies": "All companies",
     "sectors": "Sectors",
     "explore": "Explore",
-    "localEmissions": "Local emissions",
+    "territories": "Territories",
     "municipalities": "Municipalities",
     "nation": "Sweden",
     "regions": "Regions",

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -12,7 +12,7 @@
     "allCompanies": "Alla företag",
     "sectors": "Branscher",
     "explore": "Utforska",
-    "territorialEmissions": "Territoriella utsläpp",
+    "localEmissions": "Lokala utsläpp",
     "municipalities": "Kommuner",
     "nation": "Sverige",
     "regions": "Län",

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -12,7 +12,7 @@
     "allCompanies": "Alla företag",
     "sectors": "Branscher",
     "explore": "Utforska",
-    "localEmissions": "Lokala utsläpp",
+    "territories": "Territorier",
     "municipalities": "Kommuner",
     "nation": "Sverige",
     "regions": "Län",

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -9,8 +9,10 @@
   "header": {
     "data": "Data",
     "companies": "Företag",
+    "allCompanies": "Alla företag",
     "sectors": "Branscher",
     "explore": "Utforska",
+    "territorialEmissions": "Territoriella utsläpp",
     "municipalities": "Kommuner",
     "nation": "Sverige",
     "regions": "Län",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What's Changed?

Restructures the header "Data" dropdown into two clear, symmetric groups so territorial emissions and company data read as distinct categories.

**Before:** territorial pages were nested under a "Sverige" header (confusing — Sverige is itself just one of the pages), and `/companies` doubled as the companies group header, with a floating "Utforska" link on top.

**After:**
- **Territoriella utsläpp / Territorial emissions** — Sverige (`/nation`), Län (`/regions`), Kommuner (`/municipalities`)
- **Företag / Companies** — Alla företag (`/companies`), Branscher (`/sectors`)
- **Utforska / Explore** quick-link kept at the top.

Adds `header.territorialEmissions` and `header.allCompanies` strings (sv + en).

### Notes

Split out of the nation story branch (`1487-ii`) so the nav grouping can be reviewed and shipped independently.

### Testing

- `npx tsc --noEmit`
- Translation JSON validated
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86f75533-bf2f-4794-aebc-70141dcd6a24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86f75533-bf2f-4794-aebc-70141dcd6a24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

