### PR TITLE
Unify PageSEO as a wrapper around Seo

### DIFF
--- a/src/components/SEO/PageSEO.tsx
+++ b/src/components/SEO/PageSEO.tsx
@@ -1,6 +1,7 @@
-import { Helmet } from "react-helmet-async";
 import { ReactNode } from "react";
+import { SeoMeta } from "@/types/seo";
 import { DEFAULT_OG_IMAGE } from "@/utils/seo";
+import { Seo } from "./Seo";
 
 interface PageSEOProps {
   title: string;
@@ -12,9 +13,16 @@ interface PageSEOProps {
   children?: ReactNode;
 }
 
+function toCanonicalPath(url: string): string {
+  if (url.startsWith("http://") || url.startsWith("https://")) {
+    return new URL(url).pathname;
+  }
+  return url.startsWith("/") ? url : `/${url}`;
+}
+
 /**
- * Reusable SEO component for pages
- * Handles meta tags, structured data, and hidden SEO content
+ * Convenience wrapper for static pages — builds a SeoMeta and delegates to Seo.
+ * Supports structured data (JSON-LD) and sr-only hidden content for crawlers.
  */
 export function PageSEO({
   title,
@@ -25,25 +33,28 @@ export function PageSEO({
   structuredData,
   children,
 }: PageSEOProps) {
+  const meta: SeoMeta = {
+    title,
+    description,
+    canonical: toCanonicalPath(canonicalUrl),
+    og: {
+      title,
+      description,
+      image: ogImage,
+      type: ogType,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      image: ogImage,
+    },
+    structuredData,
+  };
+
   return (
     <>
-      <Helmet>
-        <title>{title}</title>
-        <meta name="description" content={description} />
-        <meta property="og:title" content={title} />
-        <meta property="og:description" content={description} />
-        <meta property="og:type" content={ogType} />
-        <meta property="og:url" content={canonicalUrl} />
-        {ogImage && <meta property="og:image" content={ogImage} />}
-        <link rel="canonical" href={canonicalUrl} />
-        {structuredData && (
-          <script type="application/ld+json">
-            {JSON.stringify(structuredData)}
-          </script>
-        )}
-      </Helmet>
-
-      {/* Hidden SEO content for search engines */}
+      <Seo meta={meta} />
       {children && <div className="sr-only">{children}</div>}
     </>
   );

--- a/src/components/SEO/Seo.tsx
+++ b/src/components/SEO/Seo.tsx
@@ -11,7 +11,8 @@ interface SeoProps {
  * Handles title, description, canonical, robots, OpenGraph, and Twitter tags
  */
 export function Seo({ meta }: SeoProps) {
-  const { title, description, canonical, noindex, og, twitter } = meta;
+  const { title, description, canonical, noindex, og, twitter, structuredData } =
+    meta;
 
   // Build absolute URLs
   const canonicalUrl = canonical ? buildAbsoluteUrl(canonical) : undefined;
@@ -53,6 +54,12 @@ export function Seo({ meta }: SeoProps) {
           )}
           {twitterImage && <meta name="twitter:image" content={twitterImage} />}
         </>
+      )}
+
+      {structuredData && (
+        <script type="application/ld+json">
+          {JSON.stringify(structuredData)}
+        </script>
       )}
     </Helmet>
   );

--- a/src/components/SEO/Seo.tsx
+++ b/src/components/SEO/Seo.tsx
@@ -11,8 +11,15 @@ interface SeoProps {
  * Handles title, description, canonical, robots, OpenGraph, and Twitter tags
  */
 export function Seo({ meta }: SeoProps) {
-  const { title, description, canonical, noindex, og, twitter, structuredData } =
-    meta;
+  const {
+    title,
+    description,
+    canonical,
+    noindex,
+    og,
+    twitter,
+    structuredData,
+  } = meta;
 
   // Build absolute URLs
   const canonicalUrl = canonical ? buildAbsoluteUrl(canonical) : undefined;

--- a/src/types/seo.ts
+++ b/src/types/seo.ts
@@ -18,4 +18,5 @@ export interface SeoMeta {
     description?: string;
     image?: string;
   };
+  structuredData?: Record<string, unknown>;
 }

--- a/src/utils/insights/kpiColorUtils.ts
+++ b/src/utils/insights/kpiColorUtils.ts
@@ -86,7 +86,7 @@ export function createBudgetKPIColorGetter(companies: CompanyWithKPIs[]) {
   const colorForTonnes = createBudgetColorFunction(minRaw, maxRaw);
   const budgetTonnesByCompanyId = new Map<string, number>();
 
-  for (let data of companyBudgetData) {
+  for (const data of companyBudgetData) {
     budgetTonnesByCompanyId.set(data.company.wikidataId, data.budgetTonnes);
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Consolidates the two SEO components into a single implementation:

- `PageSEO` now builds a `SeoMeta` object and delegates to `Seo`
- Removes duplicate Helmet/meta tag logic from `PageSEO`
- Adds Twitter card tags to static pages (previously only had Open Graph)
- Extends `SeoMeta` with optional `structuredData` for JSON-LD

All existing `PageSEO` call sites remain unchanged — same props, same behavior, plus Twitter tags.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e43c5bef-4dad-41a4-93d8-ee79c56f64a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e43c5bef-4dad-41a4-93d8-ee79c56f64a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

