### PR TITLE
Prune orphaned translation keys

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -88,27 +88,14 @@
       "region": "Region",
       "nation": "Nation"
     },
-    "seeResults": "See results",
-    "bestPerformers": "Top Lists",
-    "bestMunicipalities": "Municipalities with the fastest emission reduction",
-    "municipalitiesDescription": "By average annual reduction in emissions since the Paris Agreement (2015)",
-    "largestEmittor": "Companies with the largest emissions",
-    "companiesDescription": "Emissions from the most recently reported year",
-    "aboutUsTitle": "Who are we?",
     "aboutUsContent": "Klimatkollen is a citizen platform that provides climate data and builds support for reducing emissions in line with the Paris Agreement. We believe in the power of simple, engaging data visualisation to enhance knowledge and drive participation in the climate conversation.",
-    "tabName": {
-      "companies": "the companies",
-      "municipalities": "the municipalities"
-    },
     "reportCorrection": "Report a data correction",
     "questionPlaceholder": "Please tell us what data value needs to be modified and where on site",
     "questionMissing": "Please enter a comment",
     "submitQuestion": "Submit",
     "emailTitle": "Suggestion for",
     "ctaSection": {
-      "title": "Ready to Explore the Data?",
-      "description": "Start your journey into climate data. Search for companies, municipalities, regions, and countries. Explore rankings and discover who's leading the fight against climate change.",
-      "exploreData": "Explore Data"
+      "description": "Start your journey into climate data. Search for companies, municipalities, regions, and countries. Explore rankings and discover who's leading the fight against climate change."
     },
     "companiesSection": {
       "title": "How's it going with company emissions?",
@@ -138,91 +125,6 @@
     "missionSection": {
       "title": "About Us",
       "button": "About Us"
-    },
-    "siteFeatures": {
-      "title": "Comprehensive Climate Tracking",
-      "description": "Monitor emissions data and climate commitments across Sweden.",
-      "features": {
-        "municipalityRankings": {
-          "title": "Municipalities Overview",
-          "description": "Track climate progress and emissions data from municipalities and local governments."
-        },
-        "companyRankings": {
-          "title": "Companies Overview",
-          "description": "Compare emissions performance, reduction targets, and sustainability metrics across Swedish companies."
-        },
-        "progressTracking": {
-          "title": "Progress Tracking",
-          "description": "Monitor year-over-year changes and alignment with climate targets and science based goals."
-        }
-      }
-    },
-    "scrollSteps": {
-      "mission": {
-        "badge": "Transparency for Climate Action",
-        "heading": "Our Mission",
-        "paragraph": "Klimatkollen exists to make climate data accessible to everyone. We believe that transparency drives accountability, and accountability drives real climate action. By putting emissions data in the hands of citizens, we empower communities to hold organizations accountable for their environmental commitments."
-      },
-      "transparency": {
-        "badge": "Sunlight is the Best Disinfectant",
-        "heading": "Why Data\nTransparency Matters",
-        "paragraph": "When emissions data is hidden behind corporate reports and paid databases, progress stagnates. Transparent, accessible climate data creates market pressure for better performance. Companies and municipalities that know their data is public work harder to improve their rankings and meet their climate commitments."
-      },
-      "methodology": {
-        "badge": "Science-Based Rankings",
-        "heading": "Our Methodology",
-        "paragraph": "We use emissions data from official reporting sources to create fair, comparable rankings. Our metrics focus on actual emissions reductions, not just promises or targets. Every ranking is based on real performance data, ensuring that climate leaders are recognized and climate laggards are held accountable.",
-        "linkText": "Read more about our methodology"
-      },
-      "impact": {
-        "badge": "From Data to Action",
-        "heading": "Driving Real Impact",
-        "paragraph": "Our platform has already helped identify climate leaders and those falling behind across Sweden. By ranking organizations on their actual emissions performance, we create healthy competition that accelerates climate progress. The data doesn't lie—and neither should climate commitments."
-      },
-      "engagement": {
-        "badge": "Every Voice Counts",
-        "heading": "Citizen Action &\nEngagement",
-        "paragraph": "Climate action isn't just for governments and corporations—it starts with informed citizens. When you can see how your local municipality or favorite company performs on climate metrics, you can make better choices as a consumer, voter, and community member. Your engagement drives the demand for better climate performance."
-      },
-      "pathForward": {
-        "badge": "Building a Climate-Conscious Society",
-        "heading": "The Path Forward",
-        "paragraph": "Imagine a world where every organization's climate performance is as visible as their financial results. Where citizens can easily compare the environmental impact of their choices. Where transparency drives a race to the top in climate action. That's the future we're building, one data point at a time."
-      }
-    },
-    "didYouKnow": {
-      "title": "Did You Know?",
-      "subtitle": "Interesting insights from Sweden's climate data - {{action}}!",
-      "actionMobile": "click to explore",
-      "actionDesktop": "hover to explore",
-      "cardActionMobile": "Tap to learn more →",
-      "cardActionDesktop": "Hover to learn more →",
-      "ariaLabelShow": "Show details",
-      "ariaLabelHide": "Hide details",
-      "stat1": {
-        "teaser": "Leaders of the Pack",
-        "description": "{{count}} out of {{total}} companies have reduced emissions by more than 20% since their base reporting year"
-      },
-      "stat2": {
-        "teaser": "Increased Emissions",
-        "description": "{{count}} out of {{total}} companies have increased emissions since their base reporting year"
-      },
-      "stat3": {
-        "teaser": "Paris Aligned",
-        "description": "{{companyCount}} out of {{companyTotal}} companies and {{municipalityCount}} out of {{municipalityTotal}} municipalities are on track to meet Paris Agreement goals"
-      },
-      "stat4": {
-        "teaser": "Transparent Reporting",
-        "description": "{{percentage}}% of tracked companies report Scope 3 emissions by category, providing more transparency into their value chain"
-      },
-      "stat5": {
-        "teaser": "With Plans",
-        "description": "{{percentage}}% of municipalities ({{count}} out of {{total}}) have adopted climate plans"
-      },
-      "stat6": {
-        "teaser": "Tracked Emissions",
-        "description": "{{total}} million tonnes of CO₂e tracked across {{companyCount}} companies and {{municipalityCount}} municipalities, using the latest reported value for each entity"
-      }
     }
   },
   "aboutPage": {
@@ -1072,7 +974,6 @@
         }
       }
     },
-
     "contact": {
       "title": "Contact Us",
       "description": "Have questions about supporting Klimatkollen, or want to find other ways to volunteer? We'd love to hear from you.",
@@ -2004,7 +1905,6 @@
     "next": "Next",
     "previous": "Previous"
   },
-
   "explorePage": {
     "title": "Explore the data",
     "description": "Explore and compare emissions data and climate targets for companies and municipalities.",

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -88,32 +88,14 @@
       "region": "Län",
       "nation": "Land"
     },
-    "seeResults": "Se resultat",
-    "bestPerformers": "Topplistor",
-    "bestMunicipalities": "Kommuner med snabbast utsläppsminskning",
-    "municipalitiesDescription": "Årlig utsläppsminskning sedan Parisavtalet 2015",
-    "largestEmittor": "Företag med störst utsläpp",
-    "companiesDescription": "Utsläpp från senaste rapporterade året",
-    "aboutUsTitle": "Vilka är vi?",
     "aboutUsContent": "Klimatkollen är en medborgarplattform som tillgängliggör klimatdata och bygger stöd för minskade utsläpp enligt Parisavtalet. Vi tror på kraften i enkel och tilltalande datavisualisering för att öka kunskapen och engagemanget kring klimatdebatten.",
-    "tabName": {
-      "companies": "företagen",
-      "municipalities": "kommunerna"
-    },
     "reportCorrection": "Anmäl en korrigering",
     "questionPlaceholder": "Berätta vad och var ärendet gäller",
     "questionMissing": "Ange en kommentar",
     "submitQuestion": "Skicka",
     "emailTitle": "Förslag till",
     "ctaSection": {
-      "title": "Redo att utforska datan?",
-      "description": "Börja din resa in i klimatdata. Sök efter företag, kommuner, regioner och länder. Utforska rankningar och upptäck vem som leder kampen mot klimatförändringarna.",
-      "exploreData": "Utforska Data",
-      "stats": {
-        "companiesAvailable": "Tillgängliga företag",
-        "municipalitiesAdded": "Kommuner tillagda",
-        "esgAndAnnualReports": "ESG- och årsrapporter"
-      }
+      "description": "Börja din resa in i klimatdata. Sök efter företag, kommuner, regioner och länder. Utforska rankningar och upptäck vem som leder kampen mot klimatförändringarna."
     },
     "companiesSection": {
       "title": "Hur går det med företagens utsläpp?",
@@ -143,91 +125,6 @@
     "missionSection": {
       "title": "Vårt uppdrag",
       "button": "Vårt uppdrag"
-    },
-    "siteFeatures": {
-      "title": "Omfattande klimatspårning",
-      "description": "Övervaka utsläppsdata och klimatåtaganden i hela Sverige.",
-      "features": {
-        "municipalityRankings": {
-          "title": "Kommunöversikt",
-          "description": "Spåra klimatframsteg och utsläppsdata från kommuner och lokala myndigheter."
-        },
-        "companyRankings": {
-          "title": "Företagsöversikt",
-          "description": "Jämför utsläppsprestationer, minskningsmål och hållbarhetsmått för svenska företag."
-        },
-        "progressTracking": {
-          "title": "Framstegsspårning",
-          "description": "Övervaka år-till-år-förändringar och överensstämmelse med klimatmål och vetenskapsbaserade mål."
-        }
-      }
-    },
-    "scrollSteps": {
-      "mission": {
-        "badge": "Transparens för klimatåtgärder",
-        "heading": "Vårt uppdrag",
-        "paragraph": "Klimatkollen finns för att göra klimatdata tillgänglig för alla. Vi tror att transparens driver ansvar, och ansvar driver verklig klimatåtgärd. Genom att sätta utsläppsdata i medborgarnas händer ger vi samhällen möjlighet att hålla organisationer ansvariga för sina miljöåtaganden."
-      },
-      "transparency": {
-        "badge": "Ljuset är det bästa desinfektionsmedlet",
-        "heading": "Varför datatransparens\när viktigt",
-        "paragraph": "När utsläppsdata döljs bakom företagsrapporter och betalda databaser stagnerar framstegen. Transparent, tillgänglig klimatdata skapar marknadstryck för bättre prestanda. Företag och kommuner som vet att deras data är offentlig arbetar hårdare för att förbättra sina rankingar och uppfylla sina klimatåtaganden."
-      },
-      "methodology": {
-        "badge": "Vetenskapsbaserade rankingar",
-        "heading": "Vår metodik",
-        "paragraph": "Vi använder utsläppsdata från officiella rapporteringskällor för att skapa rättvisa, jämförbara rankingar. Våra mätvärden fokuserar på faktiska utsläppsminskningar, inte bara löften eller mål. Varje ranking baseras på verkliga prestationsdata, vilket säkerställer att klimatledare erkänns och klimatfördröjare hålls ansvariga.",
-        "linkText": "Läs mer om vår metodik"
-      },
-      "impact": {
-        "badge": "Från data till handling",
-        "heading": "Driva verklig påverkan",
-        "paragraph": "Vår plattform har redan hjälpt till att identifiera klimatledare och de som halkar efter i hela Sverige. Genom att ranka organisationer på deras faktiska utsläppsprestationer skapar vi hälsosam konkurrens som påskyndar klimatframsteg. Datan ljuger inte—och det borde inte klimatåtaganden heller."
-      },
-      "engagement": {
-        "badge": "Varje röst räknas",
-        "heading": "Medborgaråtgärder &\nengagemang",
-        "paragraph": "Klimatåtgärder är inte bara för regeringar och företag—det börjar med informerade medborgare. När du kan se hur din lokala kommun eller favoritföretag presterar på klimatmätvärden kan du fatta bättre beslut som konsument, väljare och samhällsmedlem. Ditt engagemang driver efterfrågan på bättre klimatprestanda."
-      },
-      "pathForward": {
-        "badge": "Bygga ett klimatmedvetet samhälle",
-        "heading": "Vägen framåt",
-        "paragraph": "Föreställ dig en värld där varje organisations klimatprestanda är lika synlig som deras finansiella resultat. Där medborgare enkelt kan jämföra miljöpåverkan av sina val. Där transparens driver en tävling mot toppen i klimatåtgärder. Det är framtiden vi bygger, en datapunkt i taget."
-      }
-    },
-    "didYouKnow": {
-      "title": "Visste du att?",
-      "subtitle": "Intressanta insikter från Sveriges klimatdata - {{action}}!",
-      "actionMobile": "klicka för att utforska",
-      "actionDesktop": "håll muspekaren för att utforska",
-      "cardActionMobile": "Tryck för att läsa mer →",
-      "cardActionDesktop": "Håll muspekaren för att läsa mer →",
-      "ariaLabelShow": "Visa detaljer",
-      "ariaLabelHide": "Dölj detaljer",
-      "stat1": {
-        "teaser": "Ledarna i klassen",
-        "description": "{{count}} av {{total}} företag har minskat sina utsläpp med mer än 20% sedan sitt basår"
-      },
-      "stat2": {
-        "teaser": "Ökade utsläpp",
-        "description": "{{count}} av {{total}} företag har ökat sina utsläpp sedan sitt basår"
-      },
-      "stat3": {
-        "teaser": "Paris-anpassade",
-        "description": "{{companyCount}} av {{companyTotal}} företag och {{municipalityCount}} av {{municipalityTotal}} kommuner är på väg att nå Parisavtalets mål"
-      },
-      "stat4": {
-        "teaser": "Transparent rapportering",
-        "description": "{{percentage}}% av de spårade företagen rapporterar Scope 3-utsläpp per kategori, vilket ger mer transparens i deras värdekedja"
-      },
-      "stat5": {
-        "teaser": "Med planer",
-        "description": "{{percentage}}% av kommunerna ({{count}} av {{total}}) har antagit klimatplaner"
-      },
-      "stat6": {
-        "teaser": "Spårade utsläpp",
-        "description": "{{total}} miljoner ton CO₂e spåras över {{companyCount}} företag och {{municipalityCount}} kommuner, med användning av det senaste rapporterade värdet för varje enhet"
-      }
     }
   },
   "aboutPage": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes ~200 lines of orphaned translation keys from `sv/translation.json` and `en/translation.json`:

**Landing page (unused components):**
- `landingPage.siteFeatures` — SiteFeatures component
- `landingPage.scrollSteps` — LandingPageScrollSteps component
- `landingPage.didYouKnow` — DidYouKnow / FlipCard components
- Legacy TopList-era keys: `seeResults`, `bestPerformers`, `tabName`, etc.

**Other:**
- Unused `landingPage.ctaSection` sub-keys (only `description` is still used)

Best merged after PR #1555 (dead code removal) lands.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e43c5bef-4dad-41a4-93d8-ee79c56f64a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e43c5bef-4dad-41a4-93d8-ee79c56f64a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

