### PR TITLE
[fix] Correct three data calculation bugs (nation trend anchor, 100x % change, tooltip threshold)

### DIFF
--- a/src/components/companies/detail/overview/CompanyOverviewTooltip.tsx
+++ b/src/components/companies/detail/overview/CompanyOverviewTooltip.tsx
@@ -13,7 +13,7 @@ export function CompanyOverviewTooltip({
   return (
     <InfoTooltip ariaLabel="Information about emissions change rate">
       {yearOverYearChange != null ? (
-        yearOverYearChange <= -0.8 || yearOverYearChange >= 0.8 ? (
+        yearOverYearChange <= -80 || yearOverYearChange >= 80 ? (
           <>
             <p>{t("companies.card.emissionsChangeRateInfo")}</p>
             <p className="my-2">

--- a/src/pages/internal-pages/InternalDashboard.tsx
+++ b/src/pages/internal-pages/InternalDashboard.tsx
@@ -112,7 +112,7 @@ export const InternalDashboard = () => {
     const changeRate = calculateEmissionsChange(company.reportingPeriods[0]);
 
     return changeRate
-      ? formatPercentChange(changeRate, currentLanguage, true)
+      ? formatPercentChange(changeRate, currentLanguage)
       : "N/A";
   };
 

--- a/src/utils/data/nationTerritorialTransforms.test.ts
+++ b/src/utils/data/nationTerritorialTransforms.test.ts
@@ -57,4 +57,16 @@ describe("computeNationDerivedMetrics", () => {
     expect(derived.trend.some((point) => point?.year === 2050)).toBe(true);
     expect(typeof derived.meetsParis).toBe("boolean");
   });
+
+  it("anchors the approximated series at the last observed data point", () => {
+    const derived = computeNationDerivedMetrics(territorialFixture, 2026);
+
+    const lastDataYear = 2024;
+    const lastDataValue = territorialFixture[lastDataYear];
+    const anchorPoint = derived.approximatedHistoricalEmission.find(
+      (point) => point?.year === lastDataYear,
+    );
+
+    expect(anchorPoint?.value).toBeCloseTo(lastDataValue, 0);
+  });
 });

--- a/src/utils/data/nationTerritorialTransforms.ts
+++ b/src/utils/data/nationTerritorialTransforms.ts
@@ -61,7 +61,6 @@ function fitLADRegression(points: { year: number; value: number }[]): {
   }
 
   let bestSlope = 0;
-  let bestIntercept = lastValue;
   let bestError = Number.POSITIVE_INFINITY;
 
   for (const slope of slopeCandidates) {
@@ -75,12 +74,13 @@ function fitLADRegression(points: { year: number; value: number }[]): {
     if (error < bestError) {
       bestError = error;
       bestSlope = slope;
-      bestIntercept = intercept;
     }
   }
 
-  const interceptAtLast = bestIntercept;
-  const shift = lastValue - interceptAtLast;
+  // Anchor the trend line at the last observed data point so the projected
+  // series is continuous with the historical emissions series. `shift` is the
+  // value at the last data year (x = 0 in centered coordinates).
+  const shift = lastValue;
 
   return { slope: bestSlope, shift };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### ✨ What's Changed?

While auditing the repo for incorrect data calculations, I found and fixed three verified bugs that produce numerically wrong, user-facing values. Each fix is a separate commit.

**1. National emissions trend line was anchored at the wrong value** (`src/utils/data/nationTerritorialTransforms.ts`)

`fitLADRegression` returned `shift = lastValue - intercept` and then projected with `slope * (year - lastYear) + shift`. This anchored the projected/approximated series at `lastValue - intercept` instead of at the last observed data point. For the SMHI test fixture (last value ≈ 47.5 Mt in 2024) the projection started at ≈ 4.4 Mt and went negative within a few years, so the national trend line, approximated-history line, and the derived `meetsParis` result were all wrong.

Fixed by anchoring the trend line at the last observed value (`shift = lastValue`), which also makes the projection continuous with the historical series and matches the company projection logic in `approximatedData.ts`. Added a regression test asserting the approximated series starts at the last data point.

**2. Internal dashboard showed emissions change ~100x too large** (`src/pages/internal-pages/InternalDashboard.tsx`)

`calculateEmissionsChange` returns percentage points (e.g. `-15` for −15%), but the dashboard called `formatPercentChange(changeRate, currentLanguage, true)`. With `isAlreadyPercentage=true`, that function treats the input as a fraction and the percent formatter multiplies by 100 again, so −15% rendered as −1 500%. Removed the `true` argument so the default percentage-point handling applies (this was the only `formatPercentChange(..., true)` call site).

**3. "Large change" tooltip appeared for almost every company** (`src/components/companies/detail/overview/CompanyOverviewTooltip.tsx`)

`yearOverYearChange` is in percentage points, but the threshold for showing the extended large-change explanation was `±0.8`, so it triggered for essentially any non-zero change. Changed it to `±80` to match the company list card (`useTransformCompanyListCard.ts`).

### 📋 Checklist

- [x] PR title starts with [fix]
- [ ] I've verified the change runs locally both on mobile and desktop
- [x] I've set the labels, issue, and milestone for the PR

### 🛠 Related Issue

Related to an audit request for incorrect data calculations.

---

**Testing:** All 196 existing unit tests pass, plus the new nation-transform regression test. Lint on the changed files reports no new errors (only pre-existing complexity/length warnings in `InternalDashboard.tsx`).

**Other observations not fixed here** (lower confidence / need product input, mentioned for maintainers):
- `formatPercent` and `formatPercentChange` in `localization.ts` use opposite meanings for the `isAlreadyPercentage` flag — a footgun that caused bug #2.
- `calculateRateOfChange` (`utils/calculations/general.ts`) uses `previous && selected`, so a valid `0` current value returns `null`.
- Sector pie chart totals in `useChartData.ts` use the sum of scopes rather than `calculatedTotalEmissions`.
- `TrendAnalysisDashboard.tsx` uses a `-11` Carbon Law threshold vs the `-11.72` constant.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9fdd8bfa-615e-4cc0-aeaf-c45c3e089c98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9fdd8bfa-615e-4cc0-aeaf-c45c3e089c98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

