### PR TITLE
[1538] Don't include invalid data when doing rankings on the overview pages

### DIFF
--- a/src/components/municipalities/rankedList/MunicipalityInsightsPanel.tsx
+++ b/src/components/municipalities/rankedList/MunicipalityInsightsPanel.tsx
@@ -1,4 +1,3 @@
-import { COLORS } from "@/lib/colors";
 import { useTranslation } from "react-i18next";
 import { Municipality } from "@/types/municipality";
 import { KPIValue } from "@/types/rankings";
@@ -143,7 +142,7 @@ function InsightsPanel({
         { entityPlural },
       )}
       entities={topMunicipalities}
-      totalCount={municipalityData.length}
+      totalCount={statistics.validData.length}
       dataPointKey={selectedKPI.key as keyof Municipality}
       unit={selectedKPI.unit}
       nullValues={selectedKPI.nullValues}
@@ -160,7 +159,7 @@ function InsightsPanel({
     <InsightsList<Municipality>
       title={t("rankedInsights.titleWorst", { entityPlural })}
       entities={bottomMunicipalities}
-      totalCount={municipalityData.length}
+      totalCount={statistics.validData.length}
       isBottomRanking
       dataPointKey={selectedKPI.key as keyof Municipality}
       unit={selectedKPI.unit}

--- a/src/components/ranked/RankedList.tsx
+++ b/src/components/ranked/RankedList.tsx
@@ -218,7 +218,14 @@ export function RankedList<T extends Record<string, unknown>>({
     >
       <div className="flex items-center gap-4">
         <span className="text-white/30 text-sm w-8 shrink-0 tabular-nums text-left">
-          {selectedDataPoint.isBoolean ? "" : getOriginalRank(item)}
+          {selectedDataPoint.isBoolean
+            ? ""
+            : isMissingRankedValue(
+                  item[selectedDataPoint.key],
+                  selectedDataPoint.isBoolean,
+                )
+              ? "—"
+              : getOriginalRank(item)}
         </span>
         <span className="text-white/90 text-sm md:text-base text-left">
           {String(item[searchKey])}

--- a/src/components/regions/RegionalInsightsPanel.tsx
+++ b/src/components/regions/RegionalInsightsPanel.tsx
@@ -1,4 +1,3 @@
-import { COLORS } from "@/lib/colors";
 import { useTranslation } from "react-i18next";
 import { getSortedEntityKPIValues } from "@/utils/data/sorting";
 import { Region } from "@/types/region";
@@ -138,7 +137,7 @@ function RegionalInsightsPanel({
         { entityPlural },
       )}
       entities={topRegions}
-      totalCount={regionData.length}
+      totalCount={statistics.validData.length}
       dataPointKey={selectedKPI.key as keyof Region}
       unit={selectedKPI.unit}
       nullValues={selectedKPI.nullValues}
@@ -155,7 +154,7 @@ function RegionalInsightsPanel({
     <InsightsList<Region>
       title={t("rankedInsights.titleWorst", { entityPlural })}
       entities={bottomRegions}
-      totalCount={regionData.length}
+      totalCount={statistics.validData.length}
       isBottomRanking
       dataPointKey={selectedKPI.key as keyof Region}
       unit={selectedKPI.unit}


### PR DESCRIPTION
### ✨ What’s Changed?

The count of the total number of entities sent to the bottom list now only includes valid data which ensure that the ranking remain correct even when there's entities with missing data. Entities with missing data in the main list also doesn't display a ranking.

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [ ] I've set the labels, issue, and milestone for the PR

### 🛠 Related Issue

Closes #1538