### PR TITLE
fix: use entity-specific distribution graph descriptions

### DIFF
--- a/src/components/companies/rankedList/CompanyInsightsPanel.tsx
+++ b/src/components/companies/rankedList/CompanyInsightsPanel.tsx
@@ -116,6 +116,7 @@ function CompanyInsightsPanel({
 
   const distributionPanel = (
     <DistributionBox
+      entityType="companies"
       chart={
         <KPIDistributionChart<CompanyWithKPIs>
           data={companyData}

--- a/src/components/municipalities/rankedList/MunicipalityInsightsPanel.tsx
+++ b/src/components/municipalities/rankedList/MunicipalityInsightsPanel.tsx
@@ -119,6 +119,7 @@ function InsightsPanel({
 
   const distributionPanel = (
     <DistributionBox
+      entityType="municipalities"
       chart={
         <KPIDistributionChart
           data={municipalityData}

--- a/src/components/ranked/InsightsPanelParts.tsx
+++ b/src/components/ranked/InsightsPanelParts.tsx
@@ -18,30 +18,36 @@ interface DistributionStat {
   label: string;
 }
 
+type DistributionEntityType = "municipalities" | "companies" | "regions";
+
 interface DistributionBoxProps {
   /** The chart or visualisation to display at the bottom */
   chart: React.ReactNode;
+  /** Entity type used to resolve distribution description copy */
+  entityType: DistributionEntityType;
   /** Override the default title (falls back to distribution.title key) */
   title?: string;
-  /** Override the default subtitle (falls back to distribution.subtitle key) */
+  /** Override the default subtitle (falls back to entity-specific distribution.subtitle key) */
   subtitle?: string;
 }
 
 /** Titled box that places a description at the top and a chart at the bottom. */
 export function DistributionBox({
   chart,
+  entityType,
   title,
   subtitle,
 }: DistributionBoxProps) {
   const { t } = useTranslation();
+  const distributionKey = `${entityType}.list.insights.distribution`;
   return (
     <div className="bg-white/5 rounded-level-2 p-6 flex flex-col justify-between h-full gap-6">
       <div>
         <h3 className="text-2xl font-bold text-white">
-          {title ?? t("municipalities.list.insights.distribution.title")}
+          {title ?? t(`${distributionKey}.title`)}
         </h3>
         <p className="text-sm text-white/60 leading-relaxed mt-2">
-          {subtitle ?? t("municipalities.list.insights.distribution.subtitle")}
+          {subtitle ?? t(`${distributionKey}.subtitle`)}
         </p>
       </div>
       {chart}

--- a/src/components/regions/RegionalInsightsPanel.tsx
+++ b/src/components/regions/RegionalInsightsPanel.tsx
@@ -114,6 +114,7 @@ function RegionalInsightsPanel({
 
   const distributionPanel = (
     <DistributionBox
+      entityType="regions"
       chart={
         <KPIDistributionChart<Region>
           data={regionData}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1333,6 +1333,10 @@
         },
         "keyStatistics": {
           "average": "Average:"
+        },
+        "distribution": {
+          "title": "Distribution",
+          "subtitle": "Shows how companies are spread across the scale for the selected indicator. Blue bars mean better results, pink worse, and the dashed line marks the average."
         }
       },
       "sort": {
@@ -1461,6 +1465,12 @@
             "true": "Meets Paris Agreement",
             "false": "Fails Paris Agreement"
           }
+        }
+      },
+      "insights": {
+        "distribution": {
+          "title": "Distribution",
+          "subtitle": "Shows how regions are spread across the scale for the selected indicator. Blue bars mean better results, pink worse, and the dashed line marks the average."
         }
       }
     }

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -1386,6 +1386,10 @@
         },
         "keyStatistics": {
           "average": "Genomsnitt:"
+        },
+        "distribution": {
+          "title": "Fördelning",
+          "subtitle": "Visar hur företagen sprider sig längs skalan för vald indikator. Blå staplar betyder bättre resultat, rosa sämre, och den streckade linjen markerar genomsnittet."
         }
       },
       "sort": {
@@ -1516,6 +1520,12 @@
           },
           "aboveString": "är på väg att klara Parisavtalet",
           "belowString": "är på väg att missa Parisavtalet"
+        }
+      },
+      "insights": {
+        "distribution": {
+          "title": "Fördelning",
+          "subtitle": "Visar hur länen sprider sig längs skalan för vald indikator. Blå staplar betyder bättre resultat, rosa sämre, och den streckade linjen markerar genomsnittet."
         }
       }
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The distribution graph (fördelningsgraf) description always referred to municipalities, even on company and region overview pages.

## Changes

- Added an `entityType` prop to `DistributionBox` so title and subtitle resolve from the correct translation namespace.
- Passed `entityType` from municipality, company, and region insights panels.
- Added distribution title/subtitle translations for companies and regions in English and Swedish.

## Test plan

- [x] Open company overview and verify distribution description mentions companies, not municipalities.
- [x] Open region overview and verify distribution description mentions regions/län.
- [x] Open municipality overview and confirm existing municipality copy is unchanged.
- [x] Switch language and verify descriptions update correctly on all three pages.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-354611c9-dd10-4c06-9cfb-5d79296ccdf3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-354611c9-dd10-4c06-9cfb-5d79296ccdf3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

