### PR TITLE
fix: refresh insight panel text when language changes

### DIFF
--- a/src/components/companies/rankedList/CompanyInsightsPanel.tsx
+++ b/src/components/companies/rankedList/CompanyInsightsPanel.tsx
@@ -36,6 +36,7 @@ function CompanyInsightsPanel({
   section,
 }: InsightsPanelProps) {
   const { t } = useTranslation();
+  const kpiKey = String(selectedKPI.key);
 
   if (!companyData?.length) {
     return (
@@ -59,7 +60,7 @@ function CompanyInsightsPanel({
       <div className="bg-white/5 backdrop-blur-sm rounded-level-2 p-8 h-full flex items-center justify-center">
         <p className="text-white text-lg">
           {t("companies.list.insights.noData.metric", {
-            metric: selectedKPI.label,
+            metric: t(`companies.list.kpis.${kpiKey}.label`),
           })}
         </p>
       </div>
@@ -92,8 +93,10 @@ function CompanyInsightsPanel({
 
   const statsPanel = (
     <KPIDetailsPanel
-      title={selectedKPI.label}
-      description={selectedKPI.detailedDescription || selectedKPI.description}
+      title={t(`companies.list.kpis.${kpiKey}.label`)}
+      description={t(`companies.list.kpis.${kpiKey}.detailedDescription`, {
+        defaultValue: t(`companies.list.kpis.${kpiKey}.description`),
+      })}
       isBoolean={selectedKPI.isBoolean}
       higherIsBetter={selectedKPI.higherIsBetter}
       averageValue={statistics.formattedAverage}
@@ -106,6 +109,7 @@ function CompanyInsightsPanel({
             data={companyData}
             selectedKPI={selectedKPI}
             entityLabel={entityPlural}
+            translationPrefix="companies.list"
           />
         ) : undefined
       }
@@ -122,6 +126,7 @@ function CompanyInsightsPanel({
           selectedKPI={selectedKPI}
           average={!selectedKPI.isBoolean ? statistics.average : undefined}
           entityLabel={entityPlural}
+          translationPrefix="companies.list"
         />
       }
     />
@@ -143,7 +148,9 @@ function CompanyInsightsPanel({
       totalCount={statistics.validData.length}
       dataPointKey={selectedKPI.key}
       unit={selectedKPI.unit}
-      nullValues={selectedKPI.nullValues}
+      nullValues={t(`companies.list.kpis.${kpiKey}.nullValues`, {
+        defaultValue: "",
+      })}
       entityType="companies"
       nameKey="name"
       showBars
@@ -161,7 +168,9 @@ function CompanyInsightsPanel({
       isBottomRanking
       dataPointKey={selectedKPI.key}
       unit={selectedKPI.unit}
-      nullValues={selectedKPI.nullValues}
+      nullValues={t(`companies.list.kpis.${kpiKey}.nullValues`, {
+        defaultValue: "",
+      })}
       entityType="companies"
       nameKey="name"
       showBars

--- a/src/components/municipalities/rankedList/MunicipalityInsightsPanel.tsx
+++ b/src/components/municipalities/rankedList/MunicipalityInsightsPanel.tsx
@@ -56,7 +56,9 @@ function InsightsPanel({
       <div className="bg-white/5 backdrop-blur-sm rounded-level-2 p-8 h-full flex items-center justify-center">
         <p className="text-white text-lg">
           {t("municipalities.list.insights.noData.metric", {
-            metric: t(`municipalities.list.kpis.${String(selectedKPI.key)}.label`),
+            metric: t(
+              `municipalities.list.kpis.${String(selectedKPI.key)}.label`,
+            ),
           })}
         </p>
       </div>

--- a/src/components/municipalities/rankedList/MunicipalityInsightsPanel.tsx
+++ b/src/components/municipalities/rankedList/MunicipalityInsightsPanel.tsx
@@ -33,6 +33,7 @@ function InsightsPanel({
   section,
 }: InsightsPanelProps) {
   const { t } = useTranslation();
+  const kpiKey = String(selectedKPI.key);
 
   if (!municipalityData?.length) {
     return (
@@ -55,7 +56,7 @@ function InsightsPanel({
       <div className="bg-white/5 backdrop-blur-sm rounded-level-2 p-8 h-full flex items-center justify-center">
         <p className="text-white text-lg">
           {t("municipalities.list.insights.noData.metric", {
-            metric: selectedKPI.label,
+            metric: t(`municipalities.list.kpis.${String(selectedKPI.key)}.label`),
           })}
         </p>
       </div>
@@ -93,8 +94,8 @@ function InsightsPanel({
 
   const statsPanel = (
     <KPIDetailsPanel
-      title={selectedKPI.label}
-      description={selectedKPI.description}
+      title={t(`municipalities.list.kpis.${kpiKey}.label`)}
+      description={t(`municipalities.list.kpis.${kpiKey}.description`)}
       isBoolean={selectedKPI.isBoolean}
       higherIsBetter={selectedKPI.higherIsBetter}
       averageValue={statistics.formattedAverage}
@@ -107,12 +108,15 @@ function InsightsPanel({
             data={municipalityData}
             selectedKPI={selectedKPI}
             entityLabel={t("header.municipalities").toLowerCase()}
+            translationPrefix="municipalities.list"
           />
         ) : undefined
       }
       distributionStats={statistics.distributionStats}
       missingDataCount={statistics.nullCount}
-      missingDataLabel={selectedKPI.nullValues}
+      missingDataLabel={t(`municipalities.list.kpis.${kpiKey}.nullValues`, {
+        defaultValue: "",
+      })}
       sourceLinks={sourceLinks}
     />
   );
@@ -125,6 +129,7 @@ function InsightsPanel({
           selectedKPI={selectedKPI}
           average={!selectedKPI.isBoolean ? statistics.average : undefined}
           entityLabel={entityPlural}
+          translationPrefix="municipalities.list"
         />
       }
     />
@@ -146,7 +151,9 @@ function InsightsPanel({
       totalCount={municipalityData.length}
       dataPointKey={selectedKPI.key as keyof Municipality}
       unit={selectedKPI.unit}
-      nullValues={selectedKPI.nullValues}
+      nullValues={t(`municipalities.list.kpis.${kpiKey}.nullValues`, {
+        defaultValue: "",
+      })}
       entityType="municipalities"
       nameKey="name"
       showBars
@@ -164,7 +171,9 @@ function InsightsPanel({
       isBottomRanking
       dataPointKey={selectedKPI.key as keyof Municipality}
       unit={selectedKPI.unit}
-      nullValues={selectedKPI.nullValues}
+      nullValues={t(`municipalities.list.kpis.${kpiKey}.nullValues`, {
+        defaultValue: "",
+      })}
       entityType="municipalities"
       nameKey="name"
       showBars

--- a/src/components/ranked/KPIDistributionChart.tsx
+++ b/src/components/ranked/KPIDistributionChart.tsx
@@ -21,6 +21,8 @@ interface KPIDistributionChartProps<T> {
   average?: number;
   /** Plural label used in tooltips, e.g. "kommuner" */
   entityLabel?: string;
+  /** i18n prefix for KPI labels, e.g. "municipalities.list" */
+  translationPrefix?: string;
 }
 
 const NUM_BINS = 12;
@@ -103,28 +105,36 @@ function useBooleanValues<T>(
   data: T[],
   selectedKPI: KPIValue<T>,
   t: ReturnType<typeof useTranslation>["t"],
+  translationPrefix?: string,
 ) {
   return useMemo(() => {
     if (!selectedKPI.isBoolean) return null;
     const trueCount = data.filter((m) => m[selectedKPI.key] === true).length;
     const falseCount = data.filter((m) => m[selectedKPI.key] === false).length;
+    const kpiKey = String(selectedKPI.key);
+    const trueLabel = translationPrefix
+      ? t(`${translationPrefix}.kpis.${kpiKey}.booleanLabels.true`)
+      : selectedKPI.booleanLabels?.true || t("yes");
+    const falseLabel = translationPrefix
+      ? t(`${translationPrefix}.kpis.${kpiKey}.booleanLabels.false`)
+      : selectedKPI.booleanLabels?.false || t("no");
     // When higherIsBetter: true = good (blue), false = bad (pink).
     // When !higherIsBetter: true = bad (pink), false = good (blue).
     const trueColor = selectedKPI.higherIsBetter ? COLORS.blue3 : COLORS.pink3;
     const falseColor = selectedKPI.higherIsBetter ? COLORS.pink3 : COLORS.blue3;
     return [
       {
-        name: selectedKPI.booleanLabels?.true || t("yes"),
+        name: trueLabel,
         value: trueCount,
         fill: trueColor,
       },
       {
-        name: selectedKPI.booleanLabels?.false || t("no"),
+        name: falseLabel,
         value: falseCount,
         fill: falseColor,
       },
     ];
-  }, [data, selectedKPI, t]);
+  }, [data, selectedKPI, t, translationPrefix]);
 }
 
 export function KPIDistributionChart<T>({
@@ -132,6 +142,7 @@ export function KPIDistributionChart<T>({
   selectedKPI,
   average,
   entityLabel,
+  translationPrefix,
 }: KPIDistributionChartProps<T>) {
   const { t } = useTranslation();
   const label = entityLabel ?? t("header.municipalities").toLowerCase();
@@ -144,7 +155,12 @@ export function KPIDistributionChart<T>({
     [data, selectedKPI.key],
   );
 
-  const booleanValues = useBooleanValues(data, selectedKPI, t);
+  const booleanValues = useBooleanValues(
+    data,
+    selectedKPI,
+    t,
+    translationPrefix,
+  );
 
   const bins = useMemo(
     () => (!selectedKPI.isBoolean ? buildHistogramBins(values, NUM_BINS) : []),

--- a/src/components/regions/RegionalInsightsPanel.tsx
+++ b/src/components/regions/RegionalInsightsPanel.tsx
@@ -32,6 +32,7 @@ function RegionalInsightsPanel({
   section,
 }: InsightsPanelProps) {
   const { t } = useTranslation();
+  const kpiKey = String(selectedKPI.key);
 
   if (!regionData?.length) {
     return (
@@ -52,7 +53,9 @@ function RegionalInsightsPanel({
     return (
       <div className="bg-white/5 backdrop-blur-sm rounded-level-2 p-8 h-full flex items-center justify-center">
         <p className="text-white text-lg">
-          {t("noData", { metric: selectedKPI.label })}
+          {t("noData", {
+            metric: t(`regions.list.kpis.${kpiKey}.label`),
+          })}
         </p>
       </div>
     );
@@ -88,8 +91,8 @@ function RegionalInsightsPanel({
 
   const statsPanel = (
     <KPIDetailsPanel
-      title={selectedKPI.label}
-      description={selectedKPI.description}
+      title={t(`regions.list.kpis.${kpiKey}.label`)}
+      description={t(`regions.list.kpis.${kpiKey}.description`)}
       isBoolean={selectedKPI.isBoolean}
       higherIsBetter={selectedKPI.higherIsBetter}
       averageValue={statistics.formattedAverage}
@@ -102,12 +105,15 @@ function RegionalInsightsPanel({
             data={regionData}
             selectedKPI={selectedKPI}
             entityLabel={entityPlural}
+            translationPrefix="regions.list"
           />
         ) : undefined
       }
       distributionStats={statistics.distributionStats}
       missingDataCount={statistics.nullCount}
-      missingDataLabel={selectedKPI.nullValues}
+      missingDataLabel={t(`regions.list.kpis.${kpiKey}.nullValues`, {
+        defaultValue: "",
+      })}
       sourceLinks={sourceLinks}
     />
   );
@@ -120,6 +126,7 @@ function RegionalInsightsPanel({
           selectedKPI={selectedKPI}
           average={!selectedKPI.isBoolean ? statistics.average : undefined}
           entityLabel={entityPlural}
+          translationPrefix="regions.list"
         />
       }
     />
@@ -141,7 +148,9 @@ function RegionalInsightsPanel({
       totalCount={regionData.length}
       dataPointKey={selectedKPI.key as keyof Region}
       unit={selectedKPI.unit}
-      nullValues={selectedKPI.nullValues}
+      nullValues={t(`regions.list.kpis.${kpiKey}.nullValues`, {
+        defaultValue: "",
+      })}
       entityType="regions"
       nameKey="name"
       showBars
@@ -159,7 +168,9 @@ function RegionalInsightsPanel({
       isBottomRanking
       dataPointKey={selectedKPI.key as keyof Region}
       unit={selectedKPI.unit}
-      nullValues={selectedKPI.nullValues}
+      nullValues={t(`regions.list.kpis.${kpiKey}.nullValues`, {
+        defaultValue: "",
+      })}
       entityType="regions"
       nameKey="name"
       showBars

--- a/src/hooks/municipalities/useMunicipalityKPIs.ts
+++ b/src/hooks/municipalities/useMunicipalityKPIs.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { KPIValue } from "@/types/rankings";
 import type { Municipality } from "@/types/municipality";
@@ -32,5 +33,5 @@ export function useMunicipalityKPIs(options?: { enabled?: boolean }) {
 
 export const useMunicipalityKPIDefinitions = (): KPIValue<Municipality>[] => {
   const { t } = useTranslation();
-  return buildMunicipalityKpiDefinitions(t);
+  return useMemo(() => buildMunicipalityKpiDefinitions(t), [t]);
 };

--- a/src/hooks/regions/useRankedRegionsURLParams.ts
+++ b/src/hooks/regions/useRankedRegionsURLParams.ts
@@ -41,11 +41,8 @@ export function useRankedRegionsURLParams(regionalKPIs: KPIValue<Region>[]) {
   const viewMode = getViewModeFromURL();
 
   useEffect(() => {
-    const kpiFromUrl = getKPIFromURL();
-    if (kpiFromUrl && kpiFromUrl.key !== selectedKPI.key) {
-      setSelectedKPI(kpiFromUrl);
-    }
-  }, [getKPIFromURL, selectedKPI.key]);
+    setSelectedKPI(getKPIFromURL());
+  }, [getKPIFromURL]);
 
   return {
     selectedKPI,

--- a/src/pages/CompaniesOverviewPage.tsx
+++ b/src/pages/CompaniesOverviewPage.tsx
@@ -118,11 +118,8 @@ export function CompaniesOverviewPage() {
   }, [availableSectors, selectedSector, setSectorInURL]);
 
   useEffect(() => {
-    const kpiFromUrl = getKPIFromURL();
-    if (kpiFromUrl.key !== selectedKPI.key) {
-      setSelectedKPI(kpiFromUrl);
-    }
-  }, [getKPIFromURL, selectedKPI.key]);
+    setSelectedKPI(getKPIFromURL());
+  }, [getKPIFromURL]);
 
   useEffect(() => {
     const sectorFromUrl = getSectorFromURL();

--- a/src/pages/MunicipalitiesOverviewPage.test.tsx
+++ b/src/pages/MunicipalitiesOverviewPage.test.tsx
@@ -3,14 +3,8 @@ import { describe, expect, it, vi } from "vitest";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { MunicipalitiesOverviewPage } from "./MunicipalitiesOverviewPage";
 
-vi.mock("@/hooks/municipalities/useMunicipalityKPIs", () => ({
-  useMunicipalityKPIs: () => ({
-    municipalitiesData: [],
-    municipalities: [],
-    loading: false,
-    error: null,
-  }),
-  useMunicipalityKPIDefinitions: () => [
+const { mockKpiDefinitions } = vi.hoisted(() => ({
+  mockKpiDefinitions: [
     {
       key: "bicycleMetrePerCapita",
       label: "bicycleMetrePerCapita",
@@ -22,6 +16,16 @@ vi.mock("@/hooks/municipalities/useMunicipalityKPIs", () => ({
       higherIsBetter: false,
     },
   ],
+}));
+
+vi.mock("@/hooks/municipalities/useMunicipalityKPIs", () => ({
+  useMunicipalityKPIs: () => ({
+    municipalitiesData: [],
+    municipalities: [],
+    loading: false,
+    error: null,
+  }),
+  useMunicipalityKPIDefinitions: () => mockKpiDefinitions,
 }));
 
 vi.mock("@/components/layout/PageHeader", () => ({

--- a/src/pages/MunicipalitiesOverviewPage.tsx
+++ b/src/pages/MunicipalitiesOverviewPage.tsx
@@ -104,11 +104,8 @@ export function MunicipalitiesOverviewPage() {
   const viewMode = getViewModeFromURL();
 
   useEffect(() => {
-    const kpiFromUrl = getKPIFromURL();
-    if (String(kpiFromUrl.key) !== String(selectedKPI.key)) {
-      setSelectedKPI(kpiFromUrl);
-    }
-  }, [getKPIFromURL, selectedKPI.label]);
+    setSelectedKPI(getKPIFromURL());
+  }, [getKPIFromURL]);
 
   const handleMunicipalityClick = createEntityClickHandler(
     navigate,

--- a/src/utils/insights/rankedListUtils.ts
+++ b/src/utils/insights/rankedListUtils.ts
@@ -125,14 +125,18 @@ export function calculateEntityStatistics<
       count: aboveAverageCount,
       colorClass: selectedKPI.higherIsBetter ? "text-blue-3" : "text-pink-3",
       label: selectedKPI.isBoolean
-        ? selectedKPI.booleanLabels?.true || t("yes")
+        ? t(
+            `${entityType}.list.kpis.${String(selectedKPI.key)}.booleanLabels.true`,
+          )
         : aboveAverageLabel,
     },
     {
       count: belowAverageCount,
       colorClass: selectedKPI.higherIsBetter ? "text-pink-3" : "text-blue-3",
       label: selectedKPI.isBoolean
-        ? selectedKPI.booleanLabels?.false || t("no")
+        ? t(
+            `${entityType}.list.kpis.${String(selectedKPI.key)}.booleanLabels.false`,
+          )
         : belowAverageLabel,
     },
   ];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Some InsightPanel text (KPI title, description, boolean labels, distribution stats) stayed in the previous language after switching locale. It only updated if the user also changed KPI.

## Changes

- Re-sync `selectedKPI` from fresh KPI definitions whenever translations change (municipalities, companies, regions overview pages).
- Resolve KPI labels, descriptions, boolean labels, and null values from i18n keys at render time in all three insights panels.
- Translate boolean distribution stat labels via i18n keys in `calculateEntityStatistics`.
- Add `translationPrefix` to `KPIDistributionChart` for live boolean label translation.

## Test plan

- [x] Open municipality overview insights panel in Swedish, switch to English, verify title/description/stats update immediately.
- [x] Repeat for company and region overview pages.
- [x] Switch language on a boolean KPI (e.g. climate plan) and verify yes/no labels update.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-354611c9-dd10-4c06-9cfb-5d79296ccdf3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-354611c9-dd10-4c06-9cfb-5d79296ccdf3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

