### PR TITLE
fix: correct English phrasing for missing charging points

### DIFF
--- a/src/components/municipalities/MunicipalityRankedList.tsx
+++ b/src/components/municipalities/MunicipalityRankedList.tsx
@@ -25,9 +25,12 @@ export function MunicipalityRankedList({
 
   const formatValue = (value: unknown) => {
     if (value === null || value === undefined) {
-      return t(`municipalities.list.kpis.${String(selectedKPI.key)}.nullValues`, {
-        defaultValue: t("noData"),
-      });
+      return t(
+        `municipalities.list.kpis.${String(selectedKPI.key)}.nullValues`,
+        {
+          defaultValue: t("noData"),
+        },
+      );
     }
 
     if (typeof value === "boolean") {

--- a/src/components/municipalities/MunicipalityRankedList.tsx
+++ b/src/components/municipalities/MunicipalityRankedList.tsx
@@ -25,7 +25,9 @@ export function MunicipalityRankedList({
 
   const formatValue = (value: unknown) => {
     if (value === null || value === undefined) {
-      return selectedKPI.nullValues ? t(selectedKPI.nullValues) : t("noData");
+      return t(`municipalities.list.kpis.${String(selectedKPI.key)}.nullValues`, {
+        defaultValue: t("noData"),
+      });
     }
 
     if (typeof value === "boolean") {

--- a/src/components/municipalities/rankedList/MunicipalityInsightsPanel.tsx
+++ b/src/components/municipalities/rankedList/MunicipalityInsightsPanel.tsx
@@ -112,6 +112,7 @@ function InsightsPanel({
       }
       distributionStats={statistics.distributionStats}
       missingDataCount={statistics.nullCount}
+      missingDataCountKey={`municipalities.list.kpis.${String(selectedKPI.key)}.missingCount`}
       missingDataLabel={selectedKPI.nullValues}
       sourceLinks={sourceLinks}
     />

--- a/src/components/ranked/KPIDetailsPanel.tsx
+++ b/src/components/ranked/KPIDetailsPanel.tsx
@@ -32,6 +32,8 @@ interface KPIDetailsPanelProps {
   distributionStats: DistributionStat[];
   missingDataCount?: number;
   missingDataLabel?: string;
+  /** i18n key for missing-data count, receives {{count}} */
+  missingDataCountKey?: string;
   sourceLinks?: SourceLink[];
   className?: string;
   /** Optional chart rendered between the header and distribution bar */
@@ -57,6 +59,7 @@ export default function KPIDetailsPanel({
   distributionStats,
   missingDataCount,
   missingDataLabel,
+  missingDataCountKey,
   sourceLinks = [],
   className = "",
   chart,
@@ -245,11 +248,17 @@ export default function KPIDetailsPanel({
       <div className="space-y-1.5">
         {typeof missingDataCount === "number" &&
           missingDataCount > 0 &&
-          missingDataLabel && (
+          (missingDataCountKey ? (
             <p className="text-white/40 text-sm italic truncate">
-              {missingDataCount} {lowercaseFirstLetter(missingDataLabel)}
+              {t(missingDataCountKey, { count: missingDataCount })}
             </p>
-          )}
+          ) : (
+            missingDataLabel && (
+              <p className="text-white/40 text-sm italic truncate">
+                {missingDataCount} {lowercaseFirstLetter(missingDataLabel)}
+              </p>
+            )
+          ))}
         {sourceSection}
       </div>
     </div>

--- a/src/components/regions/RegionalRankedList.tsx
+++ b/src/components/regions/RegionalRankedList.tsx
@@ -34,7 +34,9 @@ export function RegionalRankedList({
     booleanLabels: selectedKPI.booleanLabels,
     formatter: (value: unknown) => {
       if (value === null || value === undefined) {
-        return selectedKPI.nullValues ? t(selectedKPI.nullValues) : t("noData");
+        return t(`regions.list.kpis.${String(selectedKPI.key)}.nullValues`, {
+          defaultValue: t("noData"),
+        });
       }
 
       if (typeof value === "boolean") {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1545,7 +1545,9 @@
           "description": "Number of electric vehicles per charging point",
           "detailedDescription": "Number of electric vehicles per public charging point, per municipality in 2025. Lower numbers are better, as good infrastructure promotes increased electric vehicle adoption.",
           "source": "Power Circle",
-          "nullValues": "No charging points"
+          "nullValues": "No charging points",
+          "missingCount_one": "{{count}} municipality without charging points",
+          "missingCount_other": "{{count}} municipalities without charging points"
         },
         "bicycleMetrePerCapita": {
           "label": "Bicycles",

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -1600,7 +1600,9 @@
           "description": "Antal elbilar per laddningspunkt",
           "detailedDescription": "Antal elbilar per publik laddningspunkt per kommun år 2025. Ju färre bilar per laddningspunkt desto bättre, god infrastruktur gynnar ökad elbilskonsumtion",
           "source": "Power Circle",
-          "nullValues": "Saknar laddpunkter"
+          "nullValues": "Saknar laddpunkter",
+          "missingCount_one": "{{count}} kommun saknar laddpunkter",
+          "missingCount_other": "{{count}} kommuner saknar laddpunkter"
         },
         "bicycleMetrePerCapita": {
           "label": "Cyklarna",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The insights panel showed ungrammatical English like "1 no charging points" for municipalities missing charging point data.

## Changes

- Added pluralized `missingCount` translation keys for the electric vehicle per charge points KPI.
- Updated `KPIDetailsPanel` to support an i18n count key instead of concatenating count + label.
- Fixed ranked list null-value formatters to resolve translations by KPI key path.

## Test plan

- [ ] Open municipalities overview with `electricVehiclePerChargePoints` KPI.
- [ ] Verify missing-data footer reads e.g. "1 municipality without charging points" in English.
- [ ] Verify list cells show "No charging points" for null values.
- [ ] Switch to Swedish and confirm correct phrasing.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-354611c9-dd10-4c06-9cfb-5d79296ccdf3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-354611c9-dd10-4c06-9cfb-5d79296ccdf3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

