### PR TITLE
fix: prevent empty ranked list when switching KPI on later page

### DIFF
--- a/src/components/ranked/RankedList.tsx
+++ b/src/components/ranked/RankedList.tsx
@@ -112,8 +112,9 @@ function useSortedRankedData<T extends Record<string, unknown>>({
     );
   });
 
-  const totalPages = Math.ceil(filteredData.length / itemsPerPage);
-  const startIndex = (currentPage - 1) * itemsPerPage;
+  const totalPages = Math.max(1, Math.ceil(filteredData.length / itemsPerPage));
+  const currentPageSafe = Math.min(currentPage, totalPages);
+  const startIndex = (currentPageSafe - 1) * itemsPerPage;
   const paginatedData = filteredData.slice(
     startIndex,
     startIndex + itemsPerPage,
@@ -124,6 +125,7 @@ function useSortedRankedData<T extends Record<string, unknown>>({
     originalRankMap,
     filteredData,
     totalPages,
+    currentPageSafe,
     startIndex,
     paginatedData,
     sortAscending,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When switching KPI in list view while on a later page, the list could appear empty if the new KPI had fewer entities/pages than the current page number.

## Changes

- Clamp the active page during render to the valid page range.
- Sync pagination state when the clamped page differs from stored page.
- Reset search term when KPI changes.

## Test plan

- [ ] Open municipalities list view and navigate to page 3+.
- [ ] Switch to a KPI with fewer entities.
- [ ] Verify the list shows data on page 1 instead of appearing empty.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-354611c9-dd10-4c06-9cfb-5d79296ccdf3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-354611c9-dd10-4c06-9cfb-5d79296ccdf3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

