### PR TITLE
fix: allow long company names to wrap in ranked list

### DIFF
--- a/src/components/ranked/RankedList.tsx
+++ b/src/components/ranked/RankedList.tsx
@@ -214,13 +214,13 @@ export function RankedList<T extends Record<string, unknown>>({
     <button
       key={String(index)}
       onClick={() => onItemClick?.(item)}
-      className="w-full p-4 hover:bg-black/70 transition-colors flex items-center justify-between group"
+      className="w-full p-4 hover:bg-black/70 transition-colors flex items-start justify-between gap-4 group"
     >
-      <div className="flex items-center gap-4">
-        <span className="text-white/30 text-sm w-8 shrink-0 tabular-nums text-left">
+      <div className="flex items-start gap-4 min-w-0 flex-1">
+        <span className="text-white/30 text-sm w-8 shrink-0 tabular-nums text-left pt-0.5">
           {selectedDataPoint.isBoolean ? "" : getOriginalRank(item)}
         </span>
-        <span className="text-white/90 text-sm md:text-base text-left">
+        <span className="text-white/90 text-sm md:text-base text-left break-words">
           {String(item[searchKey])}
         </span>
       </div>
@@ -229,7 +229,7 @@ export function RankedList<T extends Record<string, unknown>>({
           selectedDataPoint.isBoolean || item[selectedDataPoint.key] === null
             ? "font-medium"
             : "font-semibold",
-          "text-sm md:text-base text-right",
+          "text-sm md:text-base text-right shrink-0",
         )}
         style={{ color: color }}
       >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Long company names in the ranked list (e.g. Real Estate sector) could get clipped when the name wrapped to a second line.

## Changes

- Allow the name column to shrink and wrap with `min-w-0`, `flex-1`, and `break-words`.
- Keep the KPI value column fixed with `shrink-0`.
- Align row content to the top for multi-line names.

## Test plan

- [x] Open companies overview in list view with Real Estate sector selected.
- [x] Find companies with long names and verify full names are visible when wrapping.
- [x] Confirm KPI values remain aligned on the right.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-354611c9-dd10-4c06-9cfb-5d79296ccdf3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-354611c9-dd10-4c06-9cfb-5d79296ccdf3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

