### PR TITLE
[fix] Make the title of the top and bottom lists on the overpages refer to the size of the lists

### DIFF
--- a/src/components/companies/rankedList/CompanyInsightsPanel.tsx
+++ b/src/components/companies/rankedList/CompanyInsightsPanel.tsx
@@ -137,7 +137,7 @@ function CompanyInsightsPanel({
         selectedKPI.higherIsBetter
           ? "rankedInsights.titleTop"
           : "rankedInsights.titleBest",
-        { entityPlural },
+        { nrOfEntities: topCompanies.length, entityPlural: entityPlural },
       )}
       entities={topCompanies}
       totalCount={statistics.validData.length}
@@ -155,7 +155,10 @@ function CompanyInsightsPanel({
 
   const bottomPanel = !selectedKPI.isBoolean ? (
     <InsightsList<CompanyWithKPIs>
-      title={t("rankedInsights.titleWorst", { entityPlural })}
+      title={t("rankedInsights.titleWorst", {
+        nrOfEntities: bottomCompanies.length,
+        entityPlural: entityPlural,
+      })}
       entities={bottomCompanies}
       totalCount={statistics.validData.length}
       isBottomRanking

--- a/src/components/municipalities/rankedList/MunicipalityInsightsPanel.tsx
+++ b/src/components/municipalities/rankedList/MunicipalityInsightsPanel.tsx
@@ -140,7 +140,7 @@ function InsightsPanel({
         selectedKPI.higherIsBetter
           ? "rankedInsights.titleTop"
           : "rankedInsights.titleBest",
-        { entityPlural },
+        { nrOfEntities: topMunicipalities.length, entityPlural: entityPlural },
       )}
       entities={topMunicipalities}
       totalCount={municipalityData.length}
@@ -158,7 +158,10 @@ function InsightsPanel({
 
   const bottomPanel = !selectedKPI.isBoolean ? (
     <InsightsList<Municipality>
-      title={t("rankedInsights.titleWorst", { entityPlural })}
+      title={t("rankedInsights.titleWorst", {
+        nrOfEntities: bottomMunicipalities.length,
+        entityPlural: entityPlural,
+      })}
       entities={bottomMunicipalities}
       totalCount={municipalityData.length}
       isBottomRanking

--- a/src/components/regions/RegionalInsightsPanel.tsx
+++ b/src/components/regions/RegionalInsightsPanel.tsx
@@ -135,7 +135,7 @@ function RegionalInsightsPanel({
         selectedKPI.higherIsBetter
           ? "rankedInsights.titleTop"
           : "rankedInsights.titleBest",
-        { entityPlural },
+        { nrOfEntities: topRegions.length, entityPlural: entityPlural },
       )}
       entities={topRegions}
       totalCount={regionData.length}
@@ -153,7 +153,10 @@ function RegionalInsightsPanel({
 
   const bottomPanel = !selectedKPI.isBoolean ? (
     <InsightsList<Region>
-      title={t("rankedInsights.titleWorst", { entityPlural })}
+      title={t("rankedInsights.titleWorst", {
+        nrOfEntities: bottomRegions.length,
+        entityPlural: entityPlural,
+      })}
       entities={bottomRegions}
       totalCount={regionData.length}
       isBottomRanking

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1893,9 +1893,9 @@
   "rankedInsights": {
     "belowAverage": "{{entityPlural}} below average",
     "aboveAverage": "{{entityPlural}} above average",
-    "titleBest": "Top 10 {{entityPlural}}",
-    "titleTop": "Top Performing 10 {{entityPlural}}",
-    "titleWorst": "Bottom 10 {{entityPlural}}"
+    "titleBest": "Top {{nrOfEntities}} {{entityPlural}}",
+    "titleTop": "Top Performing {{nrOfEntities}} {{entityPlural}}",
+    "titleWorst": "Bottom {{nrOfEntities}} {{entityPlural}}"
   },
   "chartLegend": {
     "clickToFilterOut": "Click to filter out",

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -1948,9 +1948,9 @@
   "rankedInsights": {
     "belowAverage": "{{entityPlural}} under genomsnittet",
     "aboveAverage": "{{entityPlural}} över genomsnittet",
-    "titleBest": "Topp 10 {{entityPlural}}",
-    "titleTop": "Bästa 10 {{entityPlural}}",
-    "titleWorst": "Sämsta 10 {{entityPlural}}"
+    "titleBest": "Topp {{nrOfEntities}} {{entityPlural}}",
+    "titleTop": "Bästa {{nrOfEntities}} {{entityPlural}}",
+    "titleWorst": "Sämsta {{nrOfEntities}} {{entityPlural}}"
   },
   "chartLegend": {
     "clickToFilterOut": "Klicka för att filtrera bort",


### PR DESCRIPTION
### ✨ What’s Changed?
The top and bottom lists on the overview pages used to always be "Top 10...", etc. This changes them to refer to the actual number of entities in the list.


### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [ ] I've set the labels, issue, and milestone for the PR