### PR TITLE
Reset list pagination when switching sectors

### DIFF
--- a/src/components/ranked/RankedList.tsx
+++ b/src/components/ranked/RankedList.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useLayoutEffect } from "react";
 import { ArrowDown, ArrowUp, Search } from "lucide-react";
 import { t } from "i18next";
 import MultiPagePagination from "@/components/ui/multi-page-pagination";
@@ -113,7 +113,8 @@ function useSortedRankedData<T extends Record<string, unknown>>({
   });
 
   const totalPages = Math.ceil(filteredData.length / itemsPerPage);
-  const startIndex = (currentPage - 1) * itemsPerPage;
+  const safePage = Math.min(currentPage, Math.max(1, totalPages || 1));
+  const startIndex = (safePage - 1) * itemsPerPage;
   const paginatedData = filteredData.slice(
     startIndex,
     startIndex + itemsPerPage,
@@ -124,6 +125,7 @@ function useSortedRankedData<T extends Record<string, unknown>>({
     originalRankMap,
     filteredData,
     totalPages,
+    safePage,
     startIndex,
     paginatedData,
     sortAscending,
@@ -185,9 +187,14 @@ export function RankedList<T extends Record<string, unknown>>({
     setCurrentPage(1);
   }, [selectedDataPoint.key]);
 
+  useLayoutEffect(() => {
+    setCurrentPage(1);
+  }, [data]);
+
   const {
     originalRankMap,
     totalPages,
+    safePage,
     startIndex,
     paginatedData,
     sortAscending,
@@ -318,7 +325,7 @@ export function RankedList<T extends Record<string, unknown>>({
       </div>
       {totalPages > 1 && (
         <MultiPagePagination
-          currentPage={currentPage}
+          currentPage={safePage}
           totalPages={totalPages}
           onPageChange={handlePageChange}
         />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a bug on the companies overview page where switching sectors in list view kept the previous page number. If the user was on page 3 and picked a sector with fewer pages, the list could appear empty while pagination still showed a later page.

## Changes

- Reset `currentPage` to 1 in `RankedList` when the underlying `data` array changes (e.g. sector filter on `/companies`)
- Clamp the paginated slice to a valid page via `safePage`, so out-of-range pages never render an empty list before the reset runs

## Test plan

- [x] Open `/en/companies?sector=30&view=list&kpi=meetsParis`
- [x] Navigate to page 2 or 3 in the list
- [x] Switch to a different sector via the industry filter
- [x] Confirm the list shows page 1 of the new sector
- [x] Repeat with a sector that has fewer total pages than the previous page number
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8182b43e-020d-49b9-9cf0-772777140685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8182b43e-020d-49b9-9cf0-772777140685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

