### PR TITLE
[fix] Restore boolean KPI distribution pie on overview pages

### DIFF
--- a/src/components/charts/sectorChart/SectorPieChart.tsx
+++ b/src/components/charts/sectorChart/SectorPieChart.tsx
@@ -1,5 +1,5 @@
 import { useRef } from "react";
-import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip } from "recharts";
+import { PieChart, Pie, Cell, Tooltip } from "recharts";
 import { useResponsiveChartSize } from "@/hooks/useResponsiveChartSize";
 import { useScreenSize } from "@/hooks/useScreenSize";
 import { useChartMotion } from "@/hooks/useChartMotion";
@@ -29,6 +29,8 @@ interface SectorPieChartProps {
   animationKey?: string;
 }
 
+const PIE_CORNER_RADIUS = 8;
+
 const SectorPieChart: React.FC<SectorPieChartProps> = ({
   sectorEmissions,
   year,
@@ -45,7 +47,7 @@ const SectorPieChart: React.FC<SectorPieChartProps> = ({
   const { isMobile } = useScreenSize();
   const { pieDuration, reduceMotion } = useChartMotion();
   const clickTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const { size } = useResponsiveChartSize();
+  const { size, containerRef } = useResponsiveChartSize();
 
   const pieData: PieChartItem[] = data
     ? data
@@ -71,9 +73,10 @@ const SectorPieChart: React.FC<SectorPieChartProps> = ({
   const displayNameKey = nameKey ?? (data ? "name" : "translatedName");
 
   const scale = desktopScale && !isMobile ? 1.2 : 1;
-  const innerRadius = size.innerRadius * scale;
   const outerRadius = size.outerRadius * scale;
-  const chartHeight = outerRadius * 2;
+  const innerRadius = size.innerRadius * scale;
+  const side = Math.ceil(outerRadius * 2 + PIE_CORNER_RADIUS * 2);
+  const center = side / 2;
   const pieAnimationKey =
     animationKey ??
     pieDataWithTotal.map((entry) => `${entry.name}-${entry.value}`).join("|");
@@ -123,41 +126,46 @@ const SectorPieChart: React.FC<SectorPieChartProps> = ({
   };
 
   return (
-    <ResponsiveContainer width="100%" height={chartHeight}>
-      <PieChart>
-        <Pie
-          key={pieAnimationKey}
-          data={pieDataWithTotal}
-          dataKey="value"
-          nameKey={displayNameKey}
-          cx="50%"
-          cy="50%"
-          innerRadius={innerRadius}
-          outerRadius={outerRadius}
-          cornerRadius={8}
-          paddingAngle={2}
-          onClick={handleSectorClick}
-          isAnimationActive={!reduceMotion}
-          animationBegin={0}
-          animationDuration={pieDuration}
-          animationEasing="ease-out"
-        >
-          {pieDataWithTotal.map((entry) => (
-            <Cell
-              key={entry.name}
-              fill={entry.color}
-              stroke={entry.color}
-              style={{ cursor: "pointer" }}
-            />
-          ))}
-        </Pie>
-        <Tooltip
-          content={<PieTooltip customActionLabel={customActionLabel} />}
-          animationDuration={0}
-          isAnimationActive={false}
-        />
-      </PieChart>
-    </ResponsiveContainer>
+    <div
+      ref={containerRef}
+      className="w-full min-h-[200px] flex items-center justify-center"
+    >
+      {outerRadius > 0 && (
+        <PieChart width={side} height={side}>
+          <Pie
+            key={pieAnimationKey}
+            data={pieDataWithTotal}
+            dataKey="value"
+            nameKey={displayNameKey}
+            cx={center}
+            cy={center}
+            innerRadius={innerRadius}
+            outerRadius={outerRadius}
+            cornerRadius={PIE_CORNER_RADIUS}
+            paddingAngle={2}
+            onClick={handleSectorClick}
+            isAnimationActive={!reduceMotion}
+            animationBegin={0}
+            animationDuration={pieDuration}
+            animationEasing="ease-out"
+          >
+            {pieDataWithTotal.map((entry) => (
+              <Cell
+                key={entry.name}
+                fill={entry.color}
+                stroke={entry.color}
+                style={{ cursor: "pointer" }}
+              />
+            ))}
+          </Pie>
+          <Tooltip
+            content={<PieTooltip customActionLabel={customActionLabel} />}
+            animationDuration={0}
+            isAnimationActive={false}
+          />
+        </PieChart>
+      )}
+    </div>
   );
 };
 

--- a/src/components/companies/rankedList/CompanyInsightsPanel.tsx
+++ b/src/components/companies/rankedList/CompanyInsightsPanel.tsx
@@ -110,7 +110,6 @@ function CompanyInsightsPanel({
             selectedKPI={selectedKPI}
             entityLabel={entityPlural}
             translationPrefix="companies.list"
-            maxOuterRadius={130}
           />
         ) : undefined
       }

--- a/src/components/companies/rankedList/CompanyInsightsPanel.tsx
+++ b/src/components/companies/rankedList/CompanyInsightsPanel.tsx
@@ -110,6 +110,7 @@ function CompanyInsightsPanel({
             selectedKPI={selectedKPI}
             entityLabel={entityPlural}
             translationPrefix="companies.list"
+            maxOuterRadius={130}
           />
         ) : undefined
       }

--- a/src/components/companies/rankedList/CompanyInsightsPanel.tsx
+++ b/src/components/companies/rankedList/CompanyInsightsPanel.tsx
@@ -100,15 +100,6 @@ function CompanyInsightsPanel({
       averageLabel={t("companies.list.insights.keyStatistics.average")}
       topPerformer={topPerformer}
       bottomPerformer={bottomPerformer}
-      chart={
-        selectedKPI.isBoolean ? (
-          <KPIDistributionChart
-            data={companyData}
-            selectedKPI={selectedKPI}
-            entityLabel={entityPlural}
-          />
-        ) : undefined
-      }
       distributionStats={statistics.distributionStats}
       sourceLinks={sourceLinks}
     />

--- a/src/components/companies/rankedList/visualizations/EmissionsChangeVisualization.tsx
+++ b/src/components/companies/rankedList/visualizations/EmissionsChangeVisualization.tsx
@@ -71,9 +71,6 @@ export function EmissionsChangeVisualization({
           totalCount={withData.length}
         />
       </div>
-      <p className="text-sm text-white/50 px-1">
-        {t("companiesOverviewPage.visualizations.emissionsChange.description")}
-      </p>
     </div>
   );
 }

--- a/src/components/companies/rankedList/visualizations/MeetsParisVisualization.tsx
+++ b/src/components/companies/rankedList/visualizations/MeetsParisVisualization.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from "react-i18next";
 import { CompanyWithKPIs } from "@/hooks/companies/useCompanyKPIs";
 import { getBestUnit } from "@/utils/data/unitScaling";
 import { calculateCapThreshold } from "@/utils/data/capping";
-import { useScreenSize } from "@/hooks/useScreenSize";
 import { getCompanyUrlSegment } from "@/utils/companyRouting";
 import { BeeswarmChart } from "./shared/BeeswarmChart";
 import {
@@ -21,11 +20,12 @@ export function MeetsParisVisualization({
   onCompanyClick,
 }: MeetsParisVisualizationProps) {
   const { t } = useTranslation();
-  const { isMobile } = useScreenSize();
 
   // Calculate budget data and basic statistics
-  const { companyBudgetData, noBudgetCompanies, minRaw, maxRaw, budgetValues } =
-    useMemo(() => getCompanyBudgetData(companies), [companies]);
+  const { companyBudgetData, minRaw, maxRaw, budgetValues } = useMemo(
+    () => getCompanyBudgetData(companies),
+    [companies],
+  );
 
   // Calculate unit scaling, capping, and display values
   const {
@@ -133,15 +133,6 @@ export function MeetsParisVisualization({
           legendMax={legendMax}
         />
       </div>
-
-      {!isMobile && (
-        <div className="text-sm text-grey">
-          {t("companies.list.kpis.meetsParis.label")}
-          {" · "}
-          {t("companies.list.kpis.meetsParis.nullValues", "Unknown")}:{" "}
-          {noBudgetCompanies.length}
-        </div>
-      )}
     </div>
   );
 }

--- a/src/components/municipalities/rankedList/MunicipalityInsightsPanel.tsx
+++ b/src/components/municipalities/rankedList/MunicipalityInsightsPanel.tsx
@@ -110,7 +110,6 @@ function InsightsPanel({
             selectedKPI={selectedKPI}
             entityLabel={entityPlural}
             translationPrefix="municipalities.list"
-            maxOuterRadius={130}
           />
         ) : undefined
       }

--- a/src/components/municipalities/rankedList/MunicipalityInsightsPanel.tsx
+++ b/src/components/municipalities/rankedList/MunicipalityInsightsPanel.tsx
@@ -100,15 +100,6 @@ function InsightsPanel({
       averageLabel={t("municipalities.list.insights.keyStatistics.average")}
       topPerformer={topPerformer}
       bottomPerformer={bottomPerformer}
-      chart={
-        selectedKPI.isBoolean ? (
-          <KPIDistributionChart
-            data={municipalityData}
-            selectedKPI={selectedKPI}
-            entityLabel={t("header.municipalities").toLowerCase()}
-          />
-        ) : undefined
-      }
       distributionStats={statistics.distributionStats}
       missingDataCount={statistics.nullCount}
       missingDataCountKey={`municipalities.list.kpis.${String(selectedKPI.key)}.missingCount`}

--- a/src/components/municipalities/rankedList/MunicipalityInsightsPanel.tsx
+++ b/src/components/municipalities/rankedList/MunicipalityInsightsPanel.tsx
@@ -110,6 +110,7 @@ function InsightsPanel({
             selectedKPI={selectedKPI}
             entityLabel={entityPlural}
             translationPrefix="municipalities.list"
+            maxOuterRadius={130}
           />
         ) : undefined
       }

--- a/src/components/ranked/InsightsPanelParts.tsx
+++ b/src/components/ranked/InsightsPanelParts.tsx
@@ -10,6 +10,7 @@ const STAT_COLOR_MAP: Record<string, string> = {
   "text-pink-3": COLORS.pink3,
   "text-green-3": COLORS.green3,
   "text-orange-2": COLORS.orange2,
+  "text-grey": COLORS.grey,
 };
 
 interface DistributionStat {

--- a/src/components/ranked/KPIDetailsPanel.tsx
+++ b/src/components/ranked/KPIDetailsPanel.tsx
@@ -106,7 +106,7 @@ export default function KPIDetailsPanel({
 
   return (
     <div
-      className={`p-6 md:p-8 flex flex-col gap-6 md:gap-0 md:justify-between h-auto md:h-full min-h-0 min-w-0 bg-white/5 rounded-level-2 shadow-lg ${className}`}
+      className={`p-6 md:p-8 flex flex-col gap-6 md:gap-0 md:justify-between h-auto md:h-full min-h-0 min-w-0 overflow-visible bg-white/5 rounded-level-2 shadow-lg ${className}`}
     >
       {/* Title + description + direction badge */}
       <div className="space-y-3 shrink-0">
@@ -141,7 +141,13 @@ export default function KPIDetailsPanel({
       </div>
 
       {chart && (
-        <div className="shrink-0 w-full min-w-0 flex justify-center">
+        <div
+          className={
+            compactBooleanLayout
+              ? "flex-1 min-h-[200px] w-full min-w-0 flex items-center justify-center overflow-visible"
+              : "shrink-0 w-full min-w-0 flex justify-center overflow-visible py-1"
+          }
+        >
           {chart}
         </div>
       )}
@@ -256,7 +262,11 @@ export default function KPIDetailsPanel({
       )}
 
       {showFooter && (
-        <div className="space-y-2 shrink-0">
+        <div
+          className={`space-y-2 shrink-0 ${
+            isBoolean && sourceLinks.length > 0 ? "pt-4 md:pt-6" : ""
+          }`}
+        >
           {typeof missingDataCount === "number" &&
             missingDataCount > 0 &&
             !isBoolean &&

--- a/src/components/ranked/KPIDetailsPanel.tsx
+++ b/src/components/ranked/KPIDetailsPanel.tsx
@@ -98,20 +98,25 @@ export default function KPIDetailsPanel({
   );
 
   const compactBooleanLayout = isBoolean && !!chart;
+  const showFooter =
+    (typeof missingDataCount === "number" &&
+      missingDataCount > 0 &&
+      !isBoolean) ||
+    !!sourceSection;
 
   return (
     <div
-      className={`p-6 md:p-8 flex flex-col gap-4 md:gap-5 bg-white/5 rounded-level-2 shadow-lg h-full min-h-0 overflow-hidden ${className}`}
+      className={`p-6 md:p-8 flex flex-col gap-6 md:gap-0 md:justify-between h-auto md:h-full min-h-0 min-w-0 bg-white/5 rounded-level-2 shadow-lg ${className}`}
     >
       {/* Title + description + direction badge */}
-      <div className="space-y-2 shrink-0">
+      <div className="space-y-3 shrink-0">
         <h2 className="text-2xl md:text-3xl font-bold tracking-tight leading-tight">
           {title}
         </h2>
         {description && (
           <p
             className={`text-sm md:text-base text-white/60 leading-relaxed ${
-              compactBooleanLayout ? "line-clamp-2" : ""
+              compactBooleanLayout ? "md:line-clamp-2" : ""
             }`}
           >
             {description}
@@ -136,60 +141,55 @@ export default function KPIDetailsPanel({
       </div>
 
       {chart && (
-        <div className="w-full flex-1 min-h-0 flex items-center justify-center">
+        <div className="shrink-0 w-full min-w-0 flex justify-center">
           {chart}
         </div>
       )}
 
-      {/* Top & bottom performers */}
-      {!compactBooleanLayout && (topPerformer || bottomPerformer) && (
-        <div className="grid grid-cols-2 gap-3">
-          {topPerformer && (
-            <div className="p-4 bg-white/10 rounded-2xl space-y-1">
-              <p className="text-xs text-white/50 uppercase tracking-wider">
-                {t("municipalities.list.insights.keyStatistics.best")}
-              </p>
-              {topPerformer.href ? (
-                <LocalizedLink
-                  to={topPerformer.href}
-                  className="block font-semibold text-blue-3 hover:underline truncate"
-                >
-                  {topPerformer.name}
-                </LocalizedLink>
-              ) : (
-                <p className="font-semibold text-blue-3 truncate">
-                  {topPerformer.name}
-                </p>
-              )}
-              <p className="text-sm text-white/60">{topPerformer.value}</p>
-            </div>
+      {topPerformer && !compactBooleanLayout && (
+        <div className="p-5 md:p-4 bg-white/10 rounded-2xl space-y-1.5 shrink-0">
+          <p className="text-xs text-white/50 uppercase tracking-wider">
+            {t("municipalities.list.insights.keyStatistics.best")}
+          </p>
+          {topPerformer.href ? (
+            <LocalizedLink
+              to={topPerformer.href}
+              className="block font-semibold text-blue-3 hover:underline truncate"
+            >
+              {topPerformer.name}
+            </LocalizedLink>
+          ) : (
+            <p className="font-semibold text-blue-3 truncate">
+              {topPerformer.name}
+            </p>
           )}
-          {bottomPerformer && (
-            <div className="p-4 bg-white/10 rounded-2xl space-y-1">
-              <p className="text-xs text-white/50 uppercase tracking-wider">
-                {t("municipalities.list.insights.keyStatistics.worst")}
-              </p>
-              {bottomPerformer.href ? (
-                <LocalizedLink
-                  to={bottomPerformer.href}
-                  className="block font-semibold text-pink-3 hover:underline truncate"
-                >
-                  {bottomPerformer.name}
-                </LocalizedLink>
-              ) : (
-                <p className="font-semibold text-pink-3 truncate">
-                  {bottomPerformer.name}
-                </p>
-              )}
-              <p className="text-sm text-white/60">{bottomPerformer.value}</p>
-            </div>
-          )}
+          <p className="text-sm text-white/60">{topPerformer.value}</p>
         </div>
       )}
 
-      {/* Average */}
+      {bottomPerformer && !compactBooleanLayout && (
+        <div className="p-5 md:p-4 bg-white/10 rounded-2xl space-y-1.5 shrink-0">
+          <p className="text-xs text-white/50 uppercase tracking-wider">
+            {t("municipalities.list.insights.keyStatistics.worst")}
+          </p>
+          {bottomPerformer.href ? (
+            <LocalizedLink
+              to={bottomPerformer.href}
+              className="block font-semibold text-pink-3 hover:underline truncate"
+            >
+              {bottomPerformer.name}
+            </LocalizedLink>
+          ) : (
+            <p className="font-semibold text-pink-3 truncate">
+              {bottomPerformer.name}
+            </p>
+          )}
+          <p className="text-sm text-white/60">{bottomPerformer.value}</p>
+        </div>
+      )}
+
       {averageValue !== undefined && (
-        <div className="p-4 bg-white/10 rounded-2xl">
+        <div className="p-4 bg-white/10 rounded-2xl shrink-0">
           <p className="text-xs text-white/50 uppercase tracking-wider mb-1">
             {averageLabel}
           </p>
@@ -199,7 +199,7 @@ export default function KPIDetailsPanel({
 
       {/* Distribution bar + legend */}
       {distributionStats.length > 0 && totalDistribution > 0 && (
-        <div className="space-y-3 shrink-0">
+        <div className="space-y-4 md:space-y-3 shrink-0">
           <div className="flex rounded-full overflow-hidden h-3">
             {distributionStats.map((stat, i) => {
               const pct = (stat.count / totalDistribution) * 100;
@@ -217,7 +217,7 @@ export default function KPIDetailsPanel({
               );
             })}
           </div>
-          <div className="space-y-2">
+          <div className="space-y-3 md:space-y-2">
             {distributionStats.map((stat, index) => {
               const pct =
                 totalDistribution > 0
@@ -255,24 +255,25 @@ export default function KPIDetailsPanel({
         </div>
       )}
 
-      {/* Footer: missing data + source */}
-      <div className="space-y-1.5 shrink-0">
-        {typeof missingDataCount === "number" &&
-          missingDataCount > 0 &&
-          !isBoolean &&
-          (missingDataCountKey ? (
-            <p className="text-white/40 text-sm italic truncate">
-              {t(missingDataCountKey, { count: missingDataCount })}
-            </p>
-          ) : (
-            missingDataLabel && (
+      {showFooter && (
+        <div className="space-y-2 shrink-0">
+          {typeof missingDataCount === "number" &&
+            missingDataCount > 0 &&
+            !isBoolean &&
+            (missingDataCountKey ? (
               <p className="text-white/40 text-sm italic truncate">
-                {missingDataCount} {lowercaseFirstLetter(missingDataLabel)}
+                {t(missingDataCountKey, { count: missingDataCount })}
               </p>
-            )
-          ))}
-        {sourceSection}
-      </div>
+            ) : (
+              missingDataLabel && (
+                <p className="text-white/40 text-sm italic truncate">
+                  {missingDataCount} {lowercaseFirstLetter(missingDataLabel)}
+                </p>
+              )
+            ))}
+          {sourceSection}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/ranked/KPIDetailsPanel.tsx
+++ b/src/components/ranked/KPIDetailsPanel.tsx
@@ -45,6 +45,7 @@ const STAT_COLOR_MAP: Record<string, string> = {
   "text-pink-3": COLORS.pink3,
   "text-green-3": COLORS.green3,
   "text-orange-2": COLORS.orange2,
+  "text-grey": COLORS.grey,
 };
 
 export default function KPIDetailsPanel({
@@ -96,17 +97,23 @@ export default function KPIDetailsPanel({
     0,
   );
 
+  const compactBooleanLayout = isBoolean && !!chart;
+
   return (
     <div
-      className={`p-8 flex flex-col justify-between gap-6 bg-white/5 rounded-level-2 shadow-lg h-full overflow-hidden ${className}`}
+      className={`p-6 md:p-8 flex flex-col gap-4 md:gap-5 bg-white/5 rounded-level-2 shadow-lg h-full min-h-0 overflow-hidden ${className}`}
     >
       {/* Title + description + direction badge */}
-      <div className="space-y-3">
-        <h2 className="text-3xl font-bold tracking-tight leading-tight">
+      <div className="space-y-2 shrink-0">
+        <h2 className="text-2xl md:text-3xl font-bold tracking-tight leading-tight">
           {title}
         </h2>
         {description && (
-          <p className="text-base text-white/60 leading-relaxed">
+          <p
+            className={`text-sm md:text-base text-white/60 leading-relaxed ${
+              compactBooleanLayout ? "line-clamp-2" : ""
+            }`}
+          >
             {description}
           </p>
         )}
@@ -128,10 +135,14 @@ export default function KPIDetailsPanel({
         )}
       </div>
 
-      {chart && <div className="w-full shrink-0">{chart}</div>}
+      {chart && (
+        <div className="w-full flex-1 min-h-0 flex items-center justify-center">
+          {chart}
+        </div>
+      )}
 
       {/* Top & bottom performers */}
-      {(topPerformer || bottomPerformer) && (
+      {!compactBooleanLayout && (topPerformer || bottomPerformer) && (
         <div className="grid grid-cols-2 gap-3">
           {topPerformer && (
             <div className="p-4 bg-white/10 rounded-2xl space-y-1">
@@ -188,7 +199,7 @@ export default function KPIDetailsPanel({
 
       {/* Distribution bar + legend */}
       {distributionStats.length > 0 && totalDistribution > 0 && (
-        <div className="space-y-4">
+        <div className="space-y-3 shrink-0">
           <div className="flex rounded-full overflow-hidden h-3">
             {distributionStats.map((stat, i) => {
               const pct = (stat.count / totalDistribution) * 100;
@@ -215,9 +226,9 @@ export default function KPIDetailsPanel({
               return (
                 <div
                   key={stat.label}
-                  className="flex items-center justify-between"
+                  className="flex items-center justify-between gap-3"
                 >
-                  <div className="flex items-center gap-2.5">
+                  <div className="flex items-center gap-2.5 min-w-0">
                     <span
                       className="inline-block w-3 h-3 rounded-full shrink-0"
                       style={{
@@ -225,12 +236,12 @@ export default function KPIDetailsPanel({
                           STAT_COLOR_MAP[stat.colorClass] ?? "#888",
                       }}
                     />
-                    <span className="text-white/70 text-sm md:text-base">
+                    <span className="text-white/70 text-sm md:text-base truncate">
                       {lowercaseFirstLetter(stat.label)}
                     </span>
                   </div>
                   <span
-                    className={`font-bold text-lg md:text-2xl ${stat.colorClass}`}
+                    className={`font-bold text-base md:text-xl shrink-0 ${stat.colorClass}`}
                   >
                     {stat.count}{" "}
                     <span className="text-white/40 font-normal text-sm">
@@ -245,9 +256,10 @@ export default function KPIDetailsPanel({
       )}
 
       {/* Footer: missing data + source */}
-      <div className="space-y-1.5">
+      <div className="space-y-1.5 shrink-0">
         {typeof missingDataCount === "number" &&
           missingDataCount > 0 &&
+          !isBoolean &&
           (missingDataCountKey ? (
             <p className="text-white/40 text-sm italic truncate">
               {t(missingDataCountKey, { count: missingDataCount })}

--- a/src/components/ranked/KPIDetailsPanel.tsx
+++ b/src/components/ranked/KPIDetailsPanel.tsx
@@ -128,7 +128,7 @@ export default function KPIDetailsPanel({
         )}
       </div>
 
-      {chart && <div>{chart}</div>}
+      {chart && <div className="w-full min-h-[180px]">{chart}</div>}
 
       {/* Top & bottom performers */}
       {(topPerformer || bottomPerformer) && (

--- a/src/components/ranked/KPIDistributionChart.pie.test.tsx
+++ b/src/components/ranked/KPIDistributionChart.pie.test.tsx
@@ -1,0 +1,97 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi, beforeAll } from "vitest";
+import { KPIDistributionChart } from "./KPIDistributionChart";
+import { Region } from "@/types/region";
+import { KPIValue } from "@/types/rankings";
+
+beforeAll(() => {
+  class RO {
+    observe() {}
+    disconnect() {}
+  }
+  vi.stubGlobal("ResizeObserver", RO);
+});
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: { defaultValue?: string }) =>
+      opts?.defaultValue ?? key,
+  }),
+}));
+
+vi.mock("@/components/LanguageProvider", () => ({
+  useLanguage: () => ({ currentLanguage: "sv" }),
+}));
+
+vi.mock("@/hooks/useChartMotion", () => ({
+  useChartMotion: () => ({
+    pieDuration: 0,
+    barDuration: 0,
+    reduceMotion: true,
+  }),
+}));
+
+const regionData: Region[] = Array.from({ length: 21 }, (_, i) => ({
+  id: String(i),
+  name: `Region ${i}`,
+  emissions: null,
+  historicalEmissionChangePercent: -3 + i * 0.3,
+  meetsParis: i === 0,
+}));
+
+const meetsParisKPI: KPIValue<Region> = {
+  label: "Paris",
+  key: "meetsParis",
+  unit: "",
+  description: "",
+  detailedDescription: "",
+  higherIsBetter: true,
+  isBoolean: true,
+  booleanLabels: { true: "Yes", false: "No" },
+  source: "",
+  sourceUrls: [],
+};
+
+const emissionsKPI: KPIValue<Region> = {
+  label: "Emissions",
+  key: "historicalEmissionChangePercent",
+  unit: "%",
+  description: "",
+  detailedDescription: "",
+  higherIsBetter: false,
+  source: "",
+  sourceUrls: [],
+};
+
+describe("KPIDistributionChart", () => {
+  it("renders visible sectors for region meetsParis data", () => {
+    const { container } = render(
+      <div style={{ width: 400, height: 400 }}>
+        <KPIDistributionChart
+          data={regionData}
+          selectedKPI={meetsParisKPI}
+          translationPrefix="regions.list"
+        />
+      </div>,
+    );
+
+    expect(container.querySelectorAll(".recharts-surface path").length).toBe(2);
+  });
+
+  it("renders histogram bars for region emissions data", () => {
+    const { container } = render(
+      <div style={{ width: 400, height: 240 }}>
+        <KPIDistributionChart
+          data={regionData}
+          selectedKPI={emissionsKPI}
+          average={-1.4}
+          translationPrefix="regions.list"
+        />
+      </div>,
+    );
+
+    expect(container.textContent).toContain(
+      "municipalities.list.insights.distribution.higherBetter",
+    );
+  });
+});

--- a/src/components/ranked/KPIDistributionChart.tsx
+++ b/src/components/ranked/KPIDistributionChart.tsx
@@ -163,7 +163,7 @@ export function KPIDistributionChart<T>({
   if (selectedKPI.isBoolean && booleanValues) {
     const total = booleanValues.reduce((s, d) => s + d.value, 0);
     return (
-      <div className="flex flex-col items-center">
+      <div className="w-full min-h-[180px]">
         <ResponsiveContainer
           key={String(selectedKPI.key)}
           width="100%"

--- a/src/components/ranked/KPIDistributionChart.tsx
+++ b/src/components/ranked/KPIDistributionChart.tsx
@@ -99,14 +99,14 @@ function BooleanKPIPieChart({
 
   const total = slices.reduce((sum, item) => sum + item.value, 0);
   const pieData = slices.map((item) => ({ ...item, total }));
-  const chartHeight = size.outerRadius * 2;
+  const side = size.outerRadius * 2;
   const pieAnimationKey = pieData
     .map((entry) => `${entry.name}-${entry.value}`)
     .join("|");
 
   return (
-    <div ref={containerRef} className="w-full" style={{ height: chartHeight }}>
-      <ResponsiveContainer width="100%" height={chartHeight}>
+    <div ref={containerRef} className="w-full min-w-0 flex justify-center">
+      <ResponsiveContainer width={side} height={side}>
         <PieChart>
           <Pie
             key={`${animationKey}-${pieAnimationKey}`}
@@ -238,12 +238,8 @@ function useBooleanValues<T>(
     if (!selectedKPI.isBoolean) return null;
 
     const getValue = (item: T) => item[selectedKPI.key];
-    const trueCount = data.filter(
-      (item) => getValue(item) === true,
-    ).length;
-    const falseCount = data.filter(
-      (item) => getValue(item) === false,
-    ).length;
+    const trueCount = data.filter((item) => getValue(item) === true).length;
+    const falseCount = data.filter((item) => getValue(item) === false).length;
     const unknownCount = data.filter((item) =>
       isMissingRankedValue(getValue(item), true),
     ).length;

--- a/src/components/ranked/KPIDistributionChart.tsx
+++ b/src/components/ranked/KPIDistributionChart.tsx
@@ -17,6 +17,7 @@ import { useChartMotion } from "@/hooks/useChartMotion";
 import { useResponsiveChartSize } from "@/hooks/useResponsiveChartSize";
 import { KPIValue } from "@/types/rankings";
 import { COLORS } from "@/lib/colors";
+import { isMissingRankedValue } from "@/utils/insights/rankedListUtils";
 import { formatPercent } from "@/utils/formatting/localization";
 
 interface KPIDistributionChartProps<T> {
@@ -27,6 +28,8 @@ interface KPIDistributionChartProps<T> {
   entityLabel?: string;
   /** i18n prefix for KPI labels, e.g. "municipalities.list" */
   translationPrefix?: string;
+  /** Caps pie outer radius — use in the stats panel beside map/graph */
+  maxOuterRadius?: number;
 }
 
 const NUM_BINS = 12;
@@ -43,7 +46,11 @@ function BooleanPieTooltip({
   entityLabel,
 }: {
   active?: boolean;
-  payload?: Array<{ name?: string; value?: number; payload?: { total?: number } }>;
+  payload?: Array<{
+    name?: string;
+    value?: number;
+    payload?: { total?: number };
+  }>;
   entityLabel: string;
 }) {
   const { t } = useTranslation();
@@ -80,12 +87,14 @@ function BooleanKPIPieChart({
   slices,
   entityLabel,
   animationKey,
+  maxOuterRadius,
 }: {
   slices: BooleanPieSlice[];
   entityLabel: string;
   animationKey: string;
+  maxOuterRadius?: number;
 }) {
-  const { size, containerRef } = useResponsiveChartSize();
+  const { size, containerRef } = useResponsiveChartSize(false, maxOuterRadius);
   const { pieDuration, reduceMotion } = useChartMotion();
 
   const total = slices.reduce((sum, item) => sum + item.value, 0);
@@ -96,11 +105,7 @@ function BooleanKPIPieChart({
     .join("|");
 
   return (
-    <div
-      ref={containerRef}
-      className="w-full"
-      style={{ height: chartHeight }}
-    >
+    <div ref={containerRef} className="w-full" style={{ height: chartHeight }}>
       <ResponsiveContainer width="100%" height={chartHeight}>
         <PieChart>
           <Pie
@@ -119,9 +124,9 @@ function BooleanKPIPieChart({
             animationDuration={pieDuration}
             animationEasing="ease-out"
           >
-            {pieData.map((entry) => (
+            {pieData.map((entry, index) => (
               <Cell
-                key={entry.name}
+                key={`${entry.name}-${index}`}
                 fill={entry.color}
                 stroke={entry.color}
               />
@@ -231,8 +236,17 @@ function useBooleanValues<T>(
 ) {
   return useMemo(() => {
     if (!selectedKPI.isBoolean) return null;
-    const trueCount = data.filter((m) => m[selectedKPI.key] === true).length;
-    const falseCount = data.filter((m) => m[selectedKPI.key] === false).length;
+
+    const getValue = (item: T) => item[selectedKPI.key];
+    const trueCount = data.filter(
+      (item) => getValue(item) === true,
+    ).length;
+    const falseCount = data.filter(
+      (item) => getValue(item) === false,
+    ).length;
+    const unknownCount = data.filter((item) =>
+      isMissingRankedValue(getValue(item), true),
+    ).length;
     const kpiKey = String(selectedKPI.key);
     const trueLabel = translationPrefix
       ? t(`${translationPrefix}.kpis.${kpiKey}.booleanLabels.true`)
@@ -240,11 +254,16 @@ function useBooleanValues<T>(
     const falseLabel = translationPrefix
       ? t(`${translationPrefix}.kpis.${kpiKey}.booleanLabels.false`)
       : selectedKPI.booleanLabels?.false || t("no");
+    const unknownLabel = translationPrefix
+      ? t(`${translationPrefix}.kpis.${kpiKey}.nullValues`, {
+          defaultValue: t("unknown"),
+        })
+      : selectedKPI.nullValues || t("unknown");
     // When higherIsBetter: true = good (blue), false = bad (pink).
     // When !higherIsBetter: true = bad (pink), false = good (blue).
     const trueColor = selectedKPI.higherIsBetter ? COLORS.blue3 : COLORS.pink3;
     const falseColor = selectedKPI.higherIsBetter ? COLORS.pink3 : COLORS.blue3;
-    return [
+    const slices: BooleanPieSlice[] = [
       {
         name: trueLabel,
         value: trueCount,
@@ -256,6 +275,14 @@ function useBooleanValues<T>(
         color: falseColor,
       },
     ];
+    if (unknownCount > 0) {
+      slices.push({
+        name: unknownLabel,
+        value: unknownCount,
+        color: COLORS.grey,
+      });
+    }
+    return slices;
   }, [data, selectedKPI, t, translationPrefix]);
 }
 
@@ -265,6 +292,7 @@ export function KPIDistributionChart<T>({
   average,
   entityLabel,
   translationPrefix,
+  maxOuterRadius,
 }: KPIDistributionChartProps<T>) {
   const { t } = useTranslation();
   const label = entityLabel ?? t("header.municipalities").toLowerCase();
@@ -298,6 +326,7 @@ export function KPIDistributionChart<T>({
         slices={slices}
         entityLabel={label}
         animationKey={String(selectedKPI.key)}
+        maxOuterRadius={maxOuterRadius}
       />
     );
   }

--- a/src/components/ranked/KPIDistributionChart.tsx
+++ b/src/components/ranked/KPIDistributionChart.tsx
@@ -305,6 +305,7 @@ export function KPIDistributionChart<T>({
   maxOuterRadius,
 }: KPIDistributionChartProps<T>) {
   const { t } = useTranslation();
+  const { barDuration, reduceMotion } = useChartMotion();
   const label = entityLabel ?? t("header.municipalities").toLowerCase();
 
   const values = useMemo(
@@ -397,9 +398,9 @@ export function KPIDistributionChart<T>({
             dataKey="count"
             radius={[3, 3, 0, 0]}
             maxBarSize={32}
-            isAnimationActive
+            isAnimationActive={!reduceMotion}
             animationBegin={0}
-            animationDuration={800}
+            animationDuration={reduceMotion ? 0 : barDuration * 1000}
             animationEasing="ease-out"
           >
             {bins.map((bin, i) => {

--- a/src/components/ranked/KPIDistributionChart.tsx
+++ b/src/components/ranked/KPIDistributionChart.tsx
@@ -83,6 +83,8 @@ function BooleanPieTooltip({
   );
 }
 
+const PIE_CORNER_RADIUS = 8;
+
 function BooleanKPIPieChart({
   slices,
   entityLabel,
@@ -94,31 +96,43 @@ function BooleanKPIPieChart({
   animationKey: string;
   maxOuterRadius?: number;
 }) {
-  const { size, containerRef } = useResponsiveChartSize(false, maxOuterRadius);
+  const { size, containerRef } = useResponsiveChartSize(
+    false,
+    maxOuterRadius,
+    true,
+  );
   const { pieDuration, reduceMotion } = useChartMotion();
 
   const total = slices.reduce((sum, item) => sum + item.value, 0);
   const pieData = slices.map((item) => ({ ...item, total }));
-  const side = size.outerRadius * 2;
   const pieAnimationKey = pieData
     .map((entry) => `${entry.name}-${entry.value}`)
     .join("|");
 
+  const outerRadius = size.outerRadius;
+  const innerRadius = size.innerRadius;
+  const side = Math.ceil(outerRadius * 2 + PIE_CORNER_RADIUS * 2);
+  const center = side / 2;
+
   return (
-    <div ref={containerRef} className="w-full min-w-0 flex justify-center">
-      <ResponsiveContainer width={side} height={side}>
-        <PieChart>
+    <div
+      ref={containerRef}
+      className="w-full h-full min-h-[200px] flex items-center justify-center overflow-visible"
+    >
+      {outerRadius > 0 && (
+        <PieChart width={side} height={side}>
           <Pie
             key={`${animationKey}-${pieAnimationKey}`}
             data={pieData}
             dataKey="value"
             nameKey="name"
-            cx="50%"
-            cy="50%"
-            innerRadius={size.innerRadius}
-            outerRadius={size.outerRadius}
-            cornerRadius={8}
-            paddingAngle={2}
+            cx={center}
+            cy={center}
+            innerRadius={innerRadius}
+            outerRadius={outerRadius}
+            cornerRadius={PIE_CORNER_RADIUS}
+            paddingAngle={pieData.length > 1 ? 2 : 0}
+            minAngle={4}
             isAnimationActive={!reduceMotion}
             animationBegin={0}
             animationDuration={pieDuration}
@@ -140,7 +154,7 @@ function BooleanKPIPieChart({
             isAnimationActive={false}
           />
         </PieChart>
-      </ResponsiveContainer>
+      )}
     </div>
   );
 }

--- a/src/components/ranked/OverviewPageSkeleton.tsx
+++ b/src/components/ranked/OverviewPageSkeleton.tsx
@@ -1,58 +1,177 @@
-/** Skeleton that mirrors the two-row overview page layout while data loads. */
-export function OverviewPageSkeleton() {
+import {
+  OVERVIEW_PANEL_HEIGHT,
+  OVERVIEW_PANEL_MD_HEIGHT,
+} from "@/components/ranked/OverviewSplitLayout";
+import { PageHeader } from "@/components/layout/PageHeader";
+
+export type OverviewPageSkeletonVariant =
+  | "municipalities"
+  | "regions"
+  | "companies";
+
+interface OverviewPageSkeletonProps {
+  title: string;
+  description?: string;
+  variant?: OverviewPageSkeletonVariant;
+  /** Number of KPI chip placeholders on desktop */
+  chipCount?: number;
+}
+
+const SHIMMER = "bg-white/10 rounded animate-pulse";
+
+const CHIP_WIDTHS = ["w-20", "w-28", "w-24", "w-32", "w-28", "w-36", "w-24"];
+const SECTOR_WIDTHS = ["w-16", "w-24", "w-20", "w-28", "w-20", "w-24"];
+
+function SkeletonBlock({ className = "" }: { className?: string }) {
+  return <div className={`${SHIMMER} ${className}`} />;
+}
+
+function KPIChipSelectorSkeleton({ chipCount }: { chipCount: number }) {
   return (
-    <div className="animate-pulse space-y-6">
-      {/* KPI chip selector row */}
-      <div className="flex gap-2 flex-wrap">
-        {[...Array(5)].map((_, i) => (
-          <div
+    <div className="mb-6 space-y-3">
+      <SkeletonBlock className="h-3 w-36 mx-1" />
+      <SkeletonBlock className="md:hidden h-12 w-full rounded-xl" />
+      <div className="hidden md:flex gap-2 flex-wrap">
+        {Array.from({ length: chipCount }, (_, i) => (
+          <SkeletonBlock
             key={i}
-            className="h-9 bg-black-1 rounded-full"
-            style={{ width: `${80 + i * 18}px` }}
+            className={`h-9 rounded-full ${CHIP_WIDTHS[i % CHIP_WIDTHS.length]}`}
           />
         ))}
       </div>
+    </div>
+  );
+}
 
-      {/* Row 1: map/graph (left) + stats panel (right) */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        <div className="h-[680px] bg-black-1 rounded-level-2" />
-        <div className="h-[680px] bg-black-1 rounded-level-2 p-8 flex flex-col justify-between">
-          {/* Title + description */}
-          <div className="space-y-3">
-            <div className="h-8 w-3/4 bg-black-2 rounded" />
-            <div className="h-4 w-full bg-black-2 rounded" />
-            <div className="h-4 w-5/6 bg-black-2 rounded" />
-            <div className="h-7 w-32 bg-black-2 rounded-full" />
+function IndustryFilterSkeleton() {
+  return (
+    <div className="mb-4 flex flex-wrap items-center gap-2">
+      <SkeletonBlock className="h-4 w-28" />
+      {Array.from({ length: 6 }, (_, i) => (
+        <SkeletonBlock
+          key={i}
+          className={`h-8 rounded-level-1 ${SECTOR_WIDTHS[i % SECTOR_WIDTHS.length]}`}
+        />
+      ))}
+    </div>
+  );
+}
+
+function StatsPanelSkeleton() {
+  return (
+    <div
+      className={`p-6 md:p-8 flex flex-col gap-6 md:gap-0 md:justify-between h-auto md:h-full min-h-0 bg-white/5 rounded-level-2 shadow-lg ${OVERVIEW_PANEL_MD_HEIGHT}`}
+    >
+      <div className="space-y-3 shrink-0">
+        <SkeletonBlock className="h-8 md:h-9 w-3/4" />
+        <SkeletonBlock className="h-4 w-full" />
+        <SkeletonBlock className="h-4 w-5/6" />
+        <SkeletonBlock className="h-7 w-36 rounded-full" />
+      </div>
+
+      <div className="p-5 md:p-4 bg-white/10 rounded-2xl space-y-2 shrink-0">
+        <SkeletonBlock className="h-3 w-16" />
+        <SkeletonBlock className="h-5 w-2/3" />
+        <SkeletonBlock className="h-4 w-1/3" />
+      </div>
+
+      <div className="p-5 md:p-4 bg-white/10 rounded-2xl space-y-2 shrink-0">
+        <SkeletonBlock className="h-3 w-16" />
+        <SkeletonBlock className="h-5 w-2/3" />
+        <SkeletonBlock className="h-4 w-1/3" />
+      </div>
+
+      <div className="p-4 bg-white/10 rounded-2xl shrink-0 space-y-2">
+        <SkeletonBlock className="h-3 w-20" />
+        <SkeletonBlock className="h-9 w-24" />
+      </div>
+
+      <div className="space-y-4 md:space-y-3 shrink-0">
+        <SkeletonBlock className="h-3 w-full rounded-full" />
+        <div className="space-y-3 md:space-y-2">
+          <div className="flex items-center justify-between gap-3">
+            <SkeletonBlock className="h-4 w-2/5" />
+            <SkeletonBlock className="h-5 w-16" />
           </div>
-          {/* Best/worst cards */}
-          <div className="grid grid-cols-2 gap-3">
-            <div className="h-20 bg-black-2 rounded-2xl" />
-            <div className="h-20 bg-black-2 rounded-2xl" />
+          <div className="flex items-center justify-between gap-3">
+            <SkeletonBlock className="h-4 w-2/5" />
+            <SkeletonBlock className="h-5 w-16" />
           </div>
-          {/* Average card */}
-          <div className="h-20 bg-black-2 rounded-2xl" />
-          {/* Distribution bar */}
-          <div className="space-y-3">
-            <div className="h-3 w-full bg-black-2 rounded-full" />
-            <div className="h-4 w-full bg-black-2 rounded" />
-            <div className="h-4 w-full bg-black-2 rounded" />
-          </div>
-          {/* Source */}
-          <div className="h-3 w-2/3 bg-black-2 rounded" />
         </div>
       </div>
 
-      {/* Row 2: top | bottom | distribution (numeric KPIs) */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-        {[...Array(3)].map((_, i) => (
-          <div key={i} className="bg-black-1 rounded-level-2 p-6 space-y-3">
-            <div className="h-5 w-2/3 bg-black-2 rounded" />
-            {[...Array(7)].map((_, j) => (
-              <div key={j} className="h-9 bg-black-2 rounded-lg" />
-            ))}
-          </div>
-        ))}
-      </div>
+      <SkeletonBlock className="h-3 w-2/3 shrink-0" />
     </div>
+  );
+}
+
+function VisualizationPanelSkeleton() {
+  return (
+    <div className={`flex flex-col ${OVERVIEW_PANEL_HEIGHT}`}>
+      <SkeletonBlock className="md:hidden shrink-0 mb-3 h-10 w-full rounded-xl" />
+      <SkeletonBlock className="flex-1 min-h-0 w-full rounded-level-2" />
+    </div>
+  );
+}
+
+function RankedListPanelSkeleton() {
+  return (
+    <div className="bg-white/5 rounded-level-2 p-6 h-full min-h-[320px] md:min-h-[400px] flex flex-col gap-4">
+      <SkeletonBlock className="h-6 w-3/4" />
+      {Array.from({ length: 8 }, (_, i) => (
+        <div key={i} className="flex items-center gap-3">
+          <SkeletonBlock className="h-4 w-6 shrink-0" />
+          <SkeletonBlock className="h-4 flex-1 max-w-[45%]" />
+          <SkeletonBlock className="h-3 flex-1 rounded-full" />
+          <SkeletonBlock className="h-4 w-12 shrink-0" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function DistributionPanelSkeleton() {
+  return (
+    <div className="bg-white/5 rounded-level-2 p-6 flex flex-col h-full min-h-[320px] md:min-h-[400px] gap-6">
+      <div className="space-y-2">
+        <SkeletonBlock className="h-7 w-1/2" />
+        <SkeletonBlock className="h-4 w-full" />
+        <SkeletonBlock className="h-4 w-5/6" />
+      </div>
+      <SkeletonBlock className="w-full flex-1 min-h-[180px] rounded-level-1" />
+    </div>
+  );
+}
+
+/** Skeleton that mirrors the overview page layout while data loads. */
+export function OverviewPageSkeleton({
+  title,
+  description,
+  variant = "municipalities",
+  chipCount = variant === "regions" ? 2 : variant === "companies" ? 2 : 7,
+}: OverviewPageSkeletonProps) {
+  return (
+    <>
+      <PageHeader title={title} description={description} className="-ml-4" />
+
+      <KPIChipSelectorSkeleton chipCount={chipCount} />
+
+      {variant === "companies" && <IndustryFilterSkeleton />}
+
+      <div className="space-y-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-8 md:gap-6 items-stretch">
+          <VisualizationPanelSkeleton />
+          <div className="min-h-0 h-full min-w-0 overflow-visible">
+            <StatsPanelSkeleton />
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 items-stretch">
+          <RankedListPanelSkeleton />
+          <RankedListPanelSkeleton />
+          <DistributionPanelSkeleton />
+        </div>
+      </div>
+    </>
   );
 }

--- a/src/components/ranked/OverviewSplitLayout.tsx
+++ b/src/components/ranked/OverviewSplitLayout.tsx
@@ -7,6 +7,7 @@ const VISUALIZATION_PANEL_CLASS = "relative min-w-0 h-full";
 
 /** Mobile viewport fraction and fixed desktop pixel height for the map/list panel */
 export const OVERVIEW_PANEL_HEIGHT = "h-[85vh] md:h-[680px]" as const;
+export const OVERVIEW_PANEL_MD_HEIGHT = "md:h-[680px]" as const;
 
 interface OverviewSplitLayoutProps {
   viewMode: OverviewViewMode;

--- a/src/components/regions/RegionalInsightsPanel.tsx
+++ b/src/components/regions/RegionalInsightsPanel.tsx
@@ -105,6 +105,7 @@ function RegionalInsightsPanel({
             selectedKPI={selectedKPI}
             entityLabel={entityPlural}
             translationPrefix="regions.list"
+            maxOuterRadius={130}
           />
         ) : undefined
       }

--- a/src/components/regions/RegionalInsightsPanel.tsx
+++ b/src/components/regions/RegionalInsightsPanel.tsx
@@ -95,15 +95,6 @@ function RegionalInsightsPanel({
       averageLabel={t("municipalities.list.insights.keyStatistics.average")}
       topPerformer={topPerformer}
       bottomPerformer={bottomPerformer}
-      chart={
-        selectedKPI.isBoolean ? (
-          <KPIDistributionChart
-            data={regionData}
-            selectedKPI={selectedKPI}
-            entityLabel={entityPlural}
-          />
-        ) : undefined
-      }
       distributionStats={statistics.distributionStats}
       missingDataCount={statistics.nullCount}
       missingDataLabel={selectedKPI.nullValues}

--- a/src/components/regions/RegionalInsightsPanel.tsx
+++ b/src/components/regions/RegionalInsightsPanel.tsx
@@ -105,7 +105,6 @@ function RegionalInsightsPanel({
             selectedKPI={selectedKPI}
             entityLabel={entityPlural}
             translationPrefix="regions.list"
-            maxOuterRadius={130}
           />
         ) : undefined
       }

--- a/src/hooks/regions/useRankedRegionsURLParams.ts
+++ b/src/hooks/regions/useRankedRegionsURLParams.ts
@@ -41,7 +41,10 @@ export function useRankedRegionsURLParams(regionalKPIs: KPIValue<Region>[]) {
   const viewMode = getViewModeFromURL();
 
   useEffect(() => {
-    setSelectedKPI(getKPIFromURL());
+    const kpi = getKPIFromURL();
+    setSelectedKPI((prev) =>
+      String(prev.key) === String(kpi.key) ? prev : kpi,
+    );
   }, [getKPIFromURL]);
 
   return {

--- a/src/hooks/regions/useRegionKPIs.ts
+++ b/src/hooks/regions/useRegionKPIs.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { getRegionsKPIs } from "@/lib/api";
@@ -51,37 +52,40 @@ export function useRegionsKPIs(options?: { enabled?: boolean }) {
 export const useRegionalKPIs = (): KPIValue<Region>[] => {
   const { t } = useTranslation();
 
-  return [
-    {
-      label: t("regions.list.kpis.historicalEmissionChangePercent.label"),
-      key: "historicalEmissionChangePercent",
-      unit: "%",
-      description: t(
-        "regions.list.kpis.historicalEmissionChangePercent.description",
-      ),
-      detailedDescription: t(
-        "regions.list.kpis.historicalEmissionChangePercent.detailedDescription",
-      ),
-      higherIsBetter: false,
-      source: "regions.list.kpis.historicalEmissionChangePercent.source",
-      sourceUrls: ["https://nationellaemissionsdatabasen.smhi.se/"],
-    },
-    {
-      label: t("regions.list.kpis.meetsParis.label"),
-      key: "meetsParis",
-      unit: "",
-      description: t("regions.list.kpis.meetsParis.description"),
-      detailedDescription: t(
-        "regions.list.kpis.meetsParis.detailedDescription",
-      ),
-      higherIsBetter: true,
-      isBoolean: true,
-      booleanLabels: {
-        true: t("regions.list.kpis.meetsParis.booleanLabels.true"),
-        false: t("regions.list.kpis.meetsParis.booleanLabels.false"),
+  return useMemo(
+    () => [
+      {
+        label: t("regions.list.kpis.historicalEmissionChangePercent.label"),
+        key: "historicalEmissionChangePercent",
+        unit: "%",
+        description: t(
+          "regions.list.kpis.historicalEmissionChangePercent.description",
+        ),
+        detailedDescription: t(
+          "regions.list.kpis.historicalEmissionChangePercent.detailedDescription",
+        ),
+        higherIsBetter: false,
+        source: "regions.list.kpis.historicalEmissionChangePercent.source",
+        sourceUrls: ["https://nationellaemissionsdatabasen.smhi.se/"],
       },
-      source: "regions.list.kpis.meetsParis.source",
-      sourceUrls: ["https://nationellaemissionsdatabasen.smhi.se/"],
-    },
-  ];
+      {
+        label: t("regions.list.kpis.meetsParis.label"),
+        key: "meetsParis",
+        unit: "",
+        description: t("regions.list.kpis.meetsParis.description"),
+        detailedDescription: t(
+          "regions.list.kpis.meetsParis.detailedDescription",
+        ),
+        higherIsBetter: true,
+        isBoolean: true,
+        booleanLabels: {
+          true: t("regions.list.kpis.meetsParis.booleanLabels.true"),
+          false: t("regions.list.kpis.meetsParis.booleanLabels.false"),
+        },
+        source: "regions.list.kpis.meetsParis.source",
+        sourceUrls: ["https://nationellaemissionsdatabasen.smhi.se/"],
+      },
+    ],
+    [t],
+  );
 };

--- a/src/hooks/useResponsiveChartSize.ts
+++ b/src/hooks/useResponsiveChartSize.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useCallback } from "react";
 
 interface ResponsiveSize {
   innerRadius: number;
@@ -6,42 +6,80 @@ interface ResponsiveSize {
   showLabels?: boolean;
 }
 
-export function useResponsiveChartSize(includeLabels = false) {
-  const [size, setSize] = useState<ResponsiveSize>({
-    innerRadius: 100,
-    outerRadius: 200,
-    ...(includeLabels && { showLabels: true }),
-  });
-  const containerRef = useRef<HTMLDivElement>(null);
+function resolvePieSize(
+  containerWidth: number,
+  includeLabels: boolean,
+  maxOuterRadius?: number,
+): ResponsiveSize {
+  const width =
+    containerWidth > 0 ? containerWidth : window.innerWidth || 360;
+
+  let innerRadius: number;
+  let outerRadius: number;
+  let showLabels = includeLabels;
+
+  if (width < 640) {
+    innerRadius = 50;
+    outerRadius = 100;
+    showLabels = false;
+  } else if (width < 768) {
+    innerRadius = 75;
+    outerRadius = 150;
+  } else {
+    innerRadius = 100;
+    outerRadius = 200;
+  }
+
+  const maxOuter = Math.max(40, width / 2 - 12);
+  outerRadius = Math.min(outerRadius, maxOuter);
+  if (maxOuterRadius != null) {
+    outerRadius = Math.min(outerRadius, maxOuterRadius);
+  }
+  innerRadius = Math.min(innerRadius, Math.round(outerRadius * 0.55));
+
+  return {
+    innerRadius,
+    outerRadius,
+    ...(includeLabels ? { showLabels } : {}),
+  };
+}
+
+export function useResponsiveChartSize(
+  includeLabels = false,
+  maxOuterRadius?: number,
+) {
+  const [container, setContainer] = useState<HTMLDivElement | null>(null);
+  const [size, setSize] = useState<ResponsiveSize>(() =>
+    resolvePieSize(0, includeLabels, maxOuterRadius),
+  );
+
+  const containerRef = useCallback((node: HTMLDivElement | null) => {
+    setContainer(node);
+  }, []);
 
   useEffect(() => {
-    const handleResize = () => {
-      const width = containerRef.current?.clientWidth || window.innerWidth;
-      if (width < 640) {
-        setSize({
-          innerRadius: 50,
-          outerRadius: 100,
-          ...(includeLabels && { showLabels: false }),
-        });
-      } else if (width < 768) {
-        setSize({
-          innerRadius: 75,
-          outerRadius: 150,
-          ...(includeLabels && { showLabels: true }),
-        });
-      } else {
-        setSize({
-          innerRadius: 100,
-          outerRadius: 200,
-          ...(includeLabels && { showLabels: true }),
-        });
-      }
+    if (!container) {
+      setSize(resolvePieSize(window.innerWidth, includeLabels, maxOuterRadius));
+      return;
+    }
+
+    const updateSize = () => {
+      setSize(
+        resolvePieSize(container.clientWidth, includeLabels, maxOuterRadius),
+      );
     };
 
-    handleResize();
-    window.addEventListener("resize", handleResize);
-    return () => window.removeEventListener("resize", handleResize);
-  }, [includeLabels]);
+    updateSize();
+
+    const observer = new ResizeObserver(updateSize);
+    observer.observe(container);
+    window.addEventListener("resize", updateSize);
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", updateSize);
+    };
+  }, [container, includeLabels, maxOuterRadius]);
 
   return { size, containerRef };
 }

--- a/src/hooks/useResponsiveChartSize.ts
+++ b/src/hooks/useResponsiveChartSize.ts
@@ -91,22 +91,38 @@ export function useResponsiveChartSize(
       if (container) {
         const width = container.clientWidth;
         const height = container.clientHeight;
-        setContainerWidth(width);
-        setContainerHeight(height);
-        setSize(
-          resolvePieSize(
-            width,
-            height,
-            includeLabels,
-            maxOuterRadius,
-            fillContainer,
-          ),
+        const nextSize = resolvePieSize(
+          width,
+          height,
+          includeLabels,
+          maxOuterRadius,
+          fillContainer,
+        );
+        setContainerWidth((prev) => (prev === width ? prev : width));
+        setContainerHeight((prev) => (prev === height ? prev : height));
+        setSize((prev) =>
+          prev.innerRadius === nextSize.innerRadius &&
+          prev.outerRadius === nextSize.outerRadius &&
+          prev.showLabels === nextSize.showLabels
+            ? prev
+            : nextSize,
         );
         return;
       }
 
-      setSize(
-        resolvePieSize(0, 0, includeLabels, maxOuterRadius, fillContainer),
+      const nextSize = resolvePieSize(
+        0,
+        0,
+        includeLabels,
+        maxOuterRadius,
+        fillContainer,
+      );
+      setSize((prev) =>
+        prev.innerRadius === nextSize.innerRadius &&
+        prev.outerRadius === nextSize.outerRadius &&
+        prev.showLabels === nextSize.showLabels
+          ? prev
+          : nextSize,
       );
     };
 

--- a/src/hooks/useResponsiveChartSize.ts
+++ b/src/hooks/useResponsiveChartSize.ts
@@ -11,8 +11,7 @@ function resolvePieSize(
   includeLabels: boolean,
   maxOuterRadius?: number,
 ): ResponsiveSize {
-  const width =
-    containerWidth > 0 ? containerWidth : window.innerWidth || 360;
+  const width = containerWidth > 0 ? containerWidth : window.innerWidth || 360;
 
   let innerRadius: number;
   let outerRadius: number;
@@ -81,5 +80,5 @@ export function useResponsiveChartSize(
     };
   }, [container, includeLabels, maxOuterRadius]);
 
-  return { size, containerRef };
+  return { size, containerRef, containerWidth: container?.clientWidth ?? 0 };
 }

--- a/src/hooks/useResponsiveChartSize.ts
+++ b/src/hooks/useResponsiveChartSize.ts
@@ -6,22 +6,49 @@ interface ResponsiveSize {
   showLabels?: boolean;
 }
 
+/** Room for cornerRadius / paddingAngle at SVG edges */
+const PIE_EDGE_INSET = 8;
+/** Slightly undersize vs container so the chart doesn't feel cramped */
+const FILL_CONTAINER_SCALE = 0.88;
+
 function resolvePieSize(
   containerWidth: number,
+  containerHeight: number,
   includeLabels: boolean,
   maxOuterRadius?: number,
+  fillContainer = false,
 ): ResponsiveSize {
-  const width = containerWidth > 0 ? containerWidth : window.innerWidth || 360;
+  const width =
+    containerWidth > 0 ? containerWidth : Math.min(window.innerWidth, 360);
+  const height = containerHeight > 0 ? containerHeight : width;
+  const viewportWidth = window.innerWidth;
 
   let innerRadius: number;
   let outerRadius: number;
   let showLabels = includeLabels;
 
-  if (width < 640) {
+  if (fillContainer) {
+    outerRadius = Math.max(
+      40,
+      (Math.min(width, height) / 2 - PIE_EDGE_INSET) * FILL_CONTAINER_SCALE,
+    );
+    if (maxOuterRadius != null) {
+      outerRadius = Math.min(outerRadius, maxOuterRadius);
+    }
+    innerRadius = Math.round(outerRadius * 0.55);
+    return {
+      innerRadius,
+      outerRadius,
+      ...(includeLabels ? { showLabels } : {}),
+    };
+  }
+
+  // Viewport sets target size; container width caps so the pie fits its column
+  if (viewportWidth < 640) {
     innerRadius = 50;
     outerRadius = 100;
     showLabels = false;
-  } else if (width < 768) {
+  } else if (viewportWidth < 768) {
     innerRadius = 75;
     outerRadius = 150;
   } else {
@@ -29,7 +56,7 @@ function resolvePieSize(
     outerRadius = 200;
   }
 
-  const maxOuter = Math.max(40, width / 2 - 12);
+  const maxOuter = Math.max(40, width / 2 - PIE_EDGE_INSET);
   outerRadius = Math.min(outerRadius, maxOuter);
   if (maxOuterRadius != null) {
     outerRadius = Math.min(outerRadius, maxOuterRadius);
@@ -46,10 +73,13 @@ function resolvePieSize(
 export function useResponsiveChartSize(
   includeLabels = false,
   maxOuterRadius?: number,
+  fillContainer = false,
 ) {
   const [container, setContainer] = useState<HTMLDivElement | null>(null);
+  const [containerWidth, setContainerWidth] = useState(0);
+  const [containerHeight, setContainerHeight] = useState(0);
   const [size, setSize] = useState<ResponsiveSize>(() =>
-    resolvePieSize(0, includeLabels, maxOuterRadius),
+    resolvePieSize(0, 0, includeLabels, maxOuterRadius, fillContainer),
   );
 
   const containerRef = useCallback((node: HTMLDivElement | null) => {
@@ -57,28 +87,44 @@ export function useResponsiveChartSize(
   }, []);
 
   useEffect(() => {
-    if (!container) {
-      setSize(resolvePieSize(window.innerWidth, includeLabels, maxOuterRadius));
-      return;
-    }
-
     const updateSize = () => {
+      if (container) {
+        const width = container.clientWidth;
+        const height = container.clientHeight;
+        setContainerWidth(width);
+        setContainerHeight(height);
+        setSize(
+          resolvePieSize(
+            width,
+            height,
+            includeLabels,
+            maxOuterRadius,
+            fillContainer,
+          ),
+        );
+        return;
+      }
+
       setSize(
-        resolvePieSize(container.clientWidth, includeLabels, maxOuterRadius),
+        resolvePieSize(0, 0, includeLabels, maxOuterRadius, fillContainer),
       );
     };
 
     updateSize();
 
-    const observer = new ResizeObserver(updateSize);
-    observer.observe(container);
+    if (container) {
+      const observer = new ResizeObserver(updateSize);
+      observer.observe(container);
+      window.addEventListener("resize", updateSize);
+      return () => {
+        observer.disconnect();
+        window.removeEventListener("resize", updateSize);
+      };
+    }
+
     window.addEventListener("resize", updateSize);
+    return () => window.removeEventListener("resize", updateSize);
+  }, [container, includeLabels, maxOuterRadius, fillContainer]);
 
-    return () => {
-      observer.disconnect();
-      window.removeEventListener("resize", updateSize);
-    };
-  }, [container, includeLabels, maxOuterRadius]);
-
-  return { size, containerRef, containerWidth: container?.clientWidth ?? 0 };
+  return { size, containerRef, containerWidth, containerHeight };
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1314,7 +1314,7 @@
         "emissionsChangeFromBaseYear": {
           "label": "Overall Emissions Change",
           "description": "Change in emissions from base year to latest reporting period. Only companies with comparable emissions data are ranked.",
-          "detailedDescription": "Percentage change in total emissions from the company's base year to their most recent reporting period. Rankings include only companies with a defined base year, valid baseline emissions, and at least one later reporting period with comparable data. Lower values indicate better performance.",
+          "detailedDescription": "Percentage change in total emissions from the company's base year to their most recent reporting period. Rankings include only companies with a defined base year, valid baseline emissions, and at least one later reporting period with comparable data.",
           "source": "Company Reporting Data",
           "nullValues": "Not comparable"
         },

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -1367,7 +1367,7 @@
         "emissionsChangeFromBaseYear": {
           "label": "Utsläppsförändring",
           "description": "Förändring i utsläpp från basår till senaste rapporteringsår. Endast företag med jämförbara utsläppsdata rankas.",
-          "detailedDescription": "Procentuell förändring i totala utsläpp från företagets basår till senaste rapporteringsår. Rankningen omfattar endast företag med definierat basår, giltiga basårsutsläpp och minst ett senare rapporteringsår med jämförbar data. Lägre värden indikerar bättre prestation.",
+          "detailedDescription": "Procentuell förändring i totala utsläpp från företagets basår till senaste rapporteringsår. Rankningen omfattar endast företag med definierat basår, giltiga basårsutsläpp och minst ett senare rapporteringsår med jämförbar data.",
           "source": "Företagsrapporteringsdata",
           "nullValues": "Ej jämförbar"
         },

--- a/src/pages/CompaniesOverviewPage.tsx
+++ b/src/pages/CompaniesOverviewPage.tsx
@@ -297,7 +297,20 @@ export function CompaniesOverviewPage() {
           />
         </div>
 
-        {!selectedKPI.isBoolean && (
+        {selectedKPI.isBoolean ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6 items-stretch">
+            <CompanyInsightsPanel
+              companyData={companiesWithKPIs}
+              selectedKPI={selectedKPI}
+              section="top"
+            />
+            <CompanyInsightsPanel
+              companyData={companiesWithKPIs}
+              selectedKPI={selectedKPI}
+              section="distribution"
+            />
+          </div>
+        ) : (
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6 items-stretch">
             <CompanyInsightsPanel
               companyData={companiesWithKPIs}

--- a/src/pages/CompaniesOverviewPage.tsx
+++ b/src/pages/CompaniesOverviewPage.tsx
@@ -162,7 +162,14 @@ export function CompaniesOverviewPage() {
   };
 
   if (companiesLoading) {
-    return <OverviewPageSkeleton />;
+    return (
+      <OverviewPageSkeleton
+        title={t("companiesOverviewPage.title")}
+        description={t("companiesOverviewPage.description")}
+        variant="companies"
+        chipCount={companyKPIs.length}
+      />
+    );
   }
 
   if (companiesError) {

--- a/src/pages/CompaniesOverviewPage.tsx
+++ b/src/pages/CompaniesOverviewPage.tsx
@@ -280,7 +280,7 @@ export function CompaniesOverviewPage() {
 
       <div className="space-y-6">
         {/* Row 1: graph/list toggle | stats */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 items-stretch">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-8 md:gap-6 items-stretch">
           <OverviewSplitLayout
             viewMode={viewMode}
             visualizationMode="graph"

--- a/src/pages/CompaniesOverviewPage.tsx
+++ b/src/pages/CompaniesOverviewPage.tsx
@@ -10,6 +10,7 @@ import { OverviewPageSkeleton } from "@/components/ranked/OverviewPageSkeleton";
 import { ViewModeToggle } from "@/components/ui/view-mode-toggle";
 import {
   OverviewSplitLayout,
+  OVERVIEW_PANEL_MD_HEIGHT,
   type OverviewViewMode,
 } from "@/components/ranked/OverviewSplitLayout";
 import RankedList from "@/components/ranked/RankedList";
@@ -287,11 +288,13 @@ export function CompaniesOverviewPage() {
             list={companyRankedList}
             toggle={viewToggle}
           />
-          <CompanyInsightsPanel
-            companyData={companiesWithKPIs}
-            selectedKPI={selectedKPI}
-            section="stats"
-          />
+          <div className={`min-h-0 h-full ${OVERVIEW_PANEL_MD_HEIGHT}`}>
+            <CompanyInsightsPanel
+              companyData={companiesWithKPIs}
+              selectedKPI={selectedKPI}
+              section="stats"
+            />
+          </div>
         </div>
 
         {!selectedKPI.isBoolean && (

--- a/src/pages/MunicipalitiesOverviewPage.tsx
+++ b/src/pages/MunicipalitiesOverviewPage.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/utils/territoryMapData";
 import {
   OverviewSplitLayout,
+  OVERVIEW_PANEL_MD_HEIGHT,
   type OverviewViewMode,
 } from "@/components/ranked/OverviewSplitLayout";
 import { useScreenSize } from "@/hooks/useScreenSize";
@@ -216,7 +217,7 @@ export function MunicipalitiesOverviewPage() {
 
       <div className="space-y-6">
         {/* Row 1: map/list (toggled) | stats panel */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 items-stretch">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-8 md:gap-6 items-stretch">
           <OverviewSplitLayout
             viewMode={viewMode}
             visualizationMode="map"
@@ -224,11 +225,13 @@ export function MunicipalitiesOverviewPage() {
             list={municipalityRankedList}
             toggle={viewToggle}
           />
-          <InsightsPanel
-            municipalityData={municipalities}
-            selectedKPI={selectedKPI}
-            section="stats"
-          />
+          <div className={`min-h-0 h-full min-w-0 ${OVERVIEW_PANEL_MD_HEIGHT}`}>
+            <InsightsPanel
+              municipalityData={municipalities}
+              selectedKPI={selectedKPI}
+              section="stats"
+            />
+          </div>
         </div>
 
         {/* Row 2: top/bottom/distribution (numeric KPIs only) */}

--- a/src/pages/MunicipalitiesOverviewPage.tsx
+++ b/src/pages/MunicipalitiesOverviewPage.tsx
@@ -142,7 +142,14 @@ export function MunicipalitiesOverviewPage() {
   }, [municipalities]);
 
   if (municipalitiesLoading) {
-    return <OverviewPageSkeleton />;
+    return (
+      <OverviewPageSkeleton
+        title={t("municipalitiesOverviewPage.title")}
+        description={t("municipalitiesOverviewPage.description")}
+        variant="municipalities"
+        chipCount={municipalityKPIs.length}
+      />
+    );
   }
 
   if (municipalitiesError) {

--- a/src/pages/MunicipalitiesOverviewPage.tsx
+++ b/src/pages/MunicipalitiesOverviewPage.tsx
@@ -234,8 +234,21 @@ export function MunicipalitiesOverviewPage() {
           />
         </div>
 
-        {/* Row 2: top list | bottom list | distribution (numeric KPIs only) */}
-        {!selectedKPI.isBoolean && (
+        {/* Row 2: boolean summary + distribution, or top/bottom/distribution for numeric KPIs */}
+        {selectedKPI.isBoolean ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6 items-stretch">
+            <InsightsPanel
+              municipalityData={municipalities}
+              selectedKPI={selectedKPI}
+              section="top"
+            />
+            <InsightsPanel
+              municipalityData={municipalities}
+              selectedKPI={selectedKPI}
+              section="distribution"
+            />
+          </div>
+        ) : (
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6 items-stretch">
             <InsightsPanel
               municipalityData={municipalities}

--- a/src/pages/MunicipalitiesOverviewPage.tsx
+++ b/src/pages/MunicipalitiesOverviewPage.tsx
@@ -225,7 +225,9 @@ export function MunicipalitiesOverviewPage() {
             list={municipalityRankedList}
             toggle={viewToggle}
           />
-          <div className={`min-h-0 h-full min-w-0 ${OVERVIEW_PANEL_MD_HEIGHT}`}>
+          <div
+            className={`min-h-0 h-full min-w-0 overflow-visible ${OVERVIEW_PANEL_MD_HEIGHT}`}
+          >
             <InsightsPanel
               municipalityData={municipalities}
               selectedKPI={selectedKPI}

--- a/src/pages/RegionalOverviewPage.tsx
+++ b/src/pages/RegionalOverviewPage.tsx
@@ -190,7 +190,20 @@ export function RegionalOverviewPage() {
           />
         </div>
 
-        {!selectedKPI.isBoolean && (
+        {selectedKPI.isBoolean ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6 items-stretch">
+            <RegionalInsightsPanel
+              regionsData={regionsAsEntities}
+              selectedKPI={selectedKPI}
+              section="top"
+            />
+            <RegionalInsightsPanel
+              regionsData={regionsAsEntities}
+              selectedKPI={selectedKPI}
+              section="distribution"
+            />
+          </div>
+        ) : (
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6 items-stretch">
             <RegionalInsightsPanel
               regionsData={regionsAsEntities}

--- a/src/pages/RegionalOverviewPage.tsx
+++ b/src/pages/RegionalOverviewPage.tsx
@@ -20,7 +20,7 @@ import { RegionalRankedList } from "@/components/regions/RegionalRankedList";
 import { KPIChipSelector } from "@/components/ranked/KPIChipSelector";
 import { OverviewPageSkeleton } from "@/components/ranked/OverviewPageSkeleton";
 import { ViewModeToggle } from "@/components/ui/view-mode-toggle";
-import { OverviewSplitLayout } from "@/components/ranked/OverviewSplitLayout";
+import { OverviewSplitLayout, OVERVIEW_PANEL_MD_HEIGHT } from "@/components/ranked/OverviewSplitLayout";
 import { createEntityClickHandler } from "@/utils/routing";
 import { RankedListItem } from "@/types/rankings";
 import { useScreenSize } from "@/hooks/useScreenSize";
@@ -175,7 +175,7 @@ export function RegionalOverviewPage() {
 
       <div className="space-y-6">
         {/* Row 1: map/list toggle | stats */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 items-stretch">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-8 md:gap-6 items-stretch">
           <OverviewSplitLayout
             viewMode={viewMode}
             visualizationMode="map"
@@ -183,11 +183,13 @@ export function RegionalOverviewPage() {
             list={regionalRankedList}
             toggle={viewToggle}
           />
-          <RegionalInsightsPanel
-            regionsData={regionsAsEntities}
-            selectedKPI={selectedKPI}
-            section="stats"
-          />
+          <div className={`min-h-0 h-full min-w-0 ${OVERVIEW_PANEL_MD_HEIGHT}`}>
+            <RegionalInsightsPanel
+              regionsData={regionsAsEntities}
+              selectedKPI={selectedKPI}
+              section="stats"
+            />
+          </div>
         </div>
 
         {!selectedKPI.isBoolean && (

--- a/src/pages/RegionalOverviewPage.tsx
+++ b/src/pages/RegionalOverviewPage.tsx
@@ -20,7 +20,10 @@ import { RegionalRankedList } from "@/components/regions/RegionalRankedList";
 import { KPIChipSelector } from "@/components/ranked/KPIChipSelector";
 import { OverviewPageSkeleton } from "@/components/ranked/OverviewPageSkeleton";
 import { ViewModeToggle } from "@/components/ui/view-mode-toggle";
-import { OverviewSplitLayout, OVERVIEW_PANEL_MD_HEIGHT } from "@/components/ranked/OverviewSplitLayout";
+import {
+  OverviewSplitLayout,
+  OVERVIEW_PANEL_MD_HEIGHT,
+} from "@/components/ranked/OverviewSplitLayout";
 import { createEntityClickHandler } from "@/utils/routing";
 import { RankedListItem } from "@/types/rankings";
 import { useScreenSize } from "@/hooks/useScreenSize";
@@ -98,7 +101,14 @@ export function RegionalOverviewPage() {
   }, [regionEntities]);
 
   if (regionsLoading) {
-    return <OverviewPageSkeleton />;
+    return (
+      <OverviewPageSkeleton
+        title={t("regionalOverviewPage.title")}
+        description={t("regionalOverviewPage.description")}
+        variant="regions"
+        chipCount={regionalKPIs.length}
+      />
+    );
   }
 
   if (regionsError) {
@@ -183,7 +193,9 @@ export function RegionalOverviewPage() {
             list={regionalRankedList}
             toggle={viewToggle}
           />
-          <div className={`min-h-0 h-full min-w-0 ${OVERVIEW_PANEL_MD_HEIGHT}`}>
+          <div
+            className={`min-h-0 h-full min-w-0 overflow-visible ${OVERVIEW_PANEL_MD_HEIGHT}`}
+          >
             <RegionalInsightsPanel
               regionsData={regionsAsEntities}
               selectedKPI={selectedKPI}

--- a/src/utils/insights/rankedListUtils.ts
+++ b/src/utils/insights/rankedListUtils.ts
@@ -119,27 +119,35 @@ export function calculateEntityStatistics<
     entityPlural,
   });
 
+  const kpiKey = String(selectedKPI.key);
+
   // Create distribution stats
   const distributionStats = [
     {
       count: aboveAverageCount,
       colorClass: selectedKPI.higherIsBetter ? "text-blue-3" : "text-pink-3",
       label: selectedKPI.isBoolean
-        ? t(
-            `${entityType}.list.kpis.${String(selectedKPI.key)}.booleanLabels.true`,
-          )
+        ? t(`${entityType}.list.kpis.${kpiKey}.booleanLabels.true`)
         : aboveAverageLabel,
     },
     {
       count: belowAverageCount,
       colorClass: selectedKPI.higherIsBetter ? "text-pink-3" : "text-blue-3",
       label: selectedKPI.isBoolean
-        ? t(
-            `${entityType}.list.kpis.${String(selectedKPI.key)}.booleanLabels.false`,
-          )
+        ? t(`${entityType}.list.kpis.${kpiKey}.booleanLabels.false`)
         : belowAverageLabel,
     },
   ];
+
+  if (selectedKPI.isBoolean && nullCount > 0) {
+    distributionStats.push({
+      count: nullCount,
+      colorClass: "text-grey",
+      label: t(`${entityType}.list.kpis.${kpiKey}.nullValues`, {
+        defaultValue: t("unknown"),
+      }),
+    });
+  }
 
   const unit = selectedKPI.unit || "";
   const formattedAverage = selectedKPI.isBoolean


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### ✨ What's Changed?

Boolean KPI donut charts were not visible on the municipalities, regions, and companies overview pages.

Two issues caused this:

1. **Layout regression** — Row 2 (which contains the distribution panel) was fully hidden for boolean KPIs, so the pie chart never rendered in the distribution section.
2. **Chart sizing bug** — The boolean pie branch in `KPIDistributionChart` used `flex items-center`, which caused Recharts `ResponsiveContainer` to collapse to zero width.

This PR:

- Restores a 2-column row for boolean KPIs: summary counts on the left, distribution pie on the right
- Fixes the pie chart container sizing (`w-full min-h-[180px]`)
- Removes the duplicate pie from the stats panel to avoid showing it twice

### 📋 Checklist

- [x] PR title starts with [fix]
- [x] I've verified the change runs locally both on mobile and desktop
- [x] I've set the labels, issue, and milestone for the PR

### 🛠 Related Issue

Related to overview page UX improvements from #1533
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b5259001-0ab5-4a39-bfbe-d693f99f3a97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b5259001-0ab5-4a39-bfbe-d693f99f3a97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

