### PR TITLE
[#1542] fix: prevent stale companies in overview top lists when switching sectors

### DIFF
--- a/src/components/companies/rankedList/CompanyInsightsPanel.tsx
+++ b/src/components/companies/rankedList/CompanyInsightsPanel.tsx
@@ -26,6 +26,8 @@ interface InsightsPanelProps {
   companyData: CompanyWithKPIs[];
   selectedKPI: CompanyKPIValue;
   section?: InsightsPanelSection;
+  /** Forces insight lists to remount when the active filter changes */
+  listKey?: string;
 }
 
 const MIN_COMPANIES = 2;
@@ -34,6 +36,7 @@ function CompanyInsightsPanel({
   companyData,
   selectedKPI,
   section,
+  listKey,
 }: InsightsPanelProps) {
   const { t } = useTranslation();
   const kpiKey = String(selectedKPI.key);
@@ -139,6 +142,7 @@ function CompanyInsightsPanel({
 
   const topPanel = !selectedKPI.isBoolean ? (
     <InsightsList<CompanyWithKPIs>
+      key={listKey ? `top-${listKey}` : undefined}
       title={t(
         selectedKPI.higherIsBetter
           ? "rankedInsights.titleTop"
@@ -163,6 +167,7 @@ function CompanyInsightsPanel({
 
   const bottomPanel = !selectedKPI.isBoolean ? (
     <InsightsList<CompanyWithKPIs>
+      key={listKey ? `bottom-${listKey}` : undefined}
       title={t("rankedInsights.titleWorst", {
         nrOfEntities: bottomCompanies.length,
         entityPlural: entityPlural,

--- a/src/components/ranked/InsightsList.test.tsx
+++ b/src/components/ranked/InsightsList.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import InsightsList from "./InsightsList";
+
+vi.mock("@/components/LocalizedLink", () => ({
+  LocalizedLink: ({
+    children,
+    to,
+  }: {
+    children: React.ReactNode;
+    to: string;
+  }) => <a href={to}>{children}</a>,
+}));
+
+describe("InsightsList", () => {
+  it("renders companies that share a name as separate rows", () => {
+    render(
+      <InsightsList
+        title="Top companies"
+        entities={[
+          { id: "company-a", name: "Duni AB", value: 10 },
+          { id: "company-b", name: "Duni AB", value: 20 },
+        ]}
+        dataPointKey="value"
+        unit="%"
+        totalCount={2}
+        entityType="companies"
+        nameKey="name"
+        colorItem={() => "#ffffff"}
+      />,
+    );
+
+    expect(screen.getAllByText("Duni AB")).toHaveLength(2);
+  });
+});

--- a/src/components/ranked/InsightsList.tsx
+++ b/src/components/ranked/InsightsList.tsx
@@ -10,6 +10,21 @@ function calcBarWidth(
   return Math.min(100, (Math.abs(numVal) / absMax) * 100);
 }
 
+function getEntityKey<T>(
+  entity: T,
+  entityType: string,
+  nameKey: keyof T,
+): string {
+  const name = String(entity[nameKey]);
+
+  if (entityType === "companies") {
+    const company = entity as { id?: string; wikidataId?: string | null };
+    return company.id ?? company.wikidataId ?? name;
+  }
+
+  return name;
+}
+
 interface InsightsListProps<T> {
   title: string;
   entities: T[];
@@ -53,6 +68,7 @@ function InsightsList<T>({
         {entities.map((entity, index) => {
           const position = isBottomRanking ? totalCount - index : index + 1;
           const name = String(entity[nameKey]);
+          const entityKey = getEntityKey(entity, entityType, nameKey);
           const rawValue = entity[dataPointKey];
           const numVal =
             typeof rawValue === "number" && !isNaN(rawValue) ? rawValue : null;
@@ -101,7 +117,7 @@ function InsightsList<T>({
           if (entityType === "municipalities" || entityType === "regions") {
             return (
               <LocalizedLink
-                key={name}
+                key={entityKey}
                 to={`/${entityType}/${name.toLowerCase()}`}
                 className="block transition-colors hover:bg-white/5 rounded-lg"
               >
@@ -118,7 +134,7 @@ function InsightsList<T>({
             if (company.id) {
               return (
                 <LocalizedLink
-                  key={name}
+                  key={entityKey}
                   to={getCompanyDetailPath(company)}
                   className="block transition-colors hover:bg-white/5 rounded-lg"
                 >
@@ -130,7 +146,7 @@ function InsightsList<T>({
 
           return (
             <div
-              key={name}
+              key={entityKey}
               className="block transition-colors hover:bg-white/5 rounded-lg"
             >
               {content}

--- a/src/pages/CompaniesOverviewPage.test.tsx
+++ b/src/pages/CompaniesOverviewPage.test.tsx
@@ -94,13 +94,20 @@ vi.mock("@/components/ranked/KPIChipSelector", () => ({
   KPIChipSelector: () => <div data-testid="kpi-selector" />,
 }));
 
-vi.mock("@/components/ranked/OverviewSplitLayout", () => ({
-  OverviewSplitLayout: ({
-    visualization,
-  }: {
-    visualization: React.ReactNode;
-  }) => <div data-testid="visualization">{visualization}</div>,
-}));
+vi.mock("@/components/ranked/OverviewSplitLayout", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("@/components/ranked/OverviewSplitLayout")
+  >();
+
+  return {
+    ...actual,
+    OverviewSplitLayout: ({
+      visualization,
+    }: {
+      visualization: React.ReactNode;
+    }) => <div data-testid="visualization">{visualization}</div>,
+  };
+});
 
 vi.mock("@/components/ranked/RankedList", () => ({
   default: () => <div data-testid="ranked-list" />,

--- a/src/pages/CompaniesOverviewPage.test.tsx
+++ b/src/pages/CompaniesOverviewPage.test.tsx
@@ -95,9 +95,11 @@ vi.mock("@/components/ranked/KPIChipSelector", () => ({
 }));
 
 vi.mock("@/components/ranked/OverviewSplitLayout", () => ({
-  OverviewSplitLayout: ({ visualization }: { visualization: React.ReactNode }) => (
-    <div data-testid="visualization">{visualization}</div>
-  ),
+  OverviewSplitLayout: ({
+    visualization,
+  }: {
+    visualization: React.ReactNode;
+  }) => <div data-testid="visualization">{visualization}</div>,
 }));
 
 vi.mock("@/components/ranked/RankedList", () => ({
@@ -138,7 +140,10 @@ vi.mock("@/components/companies/rankedList/CompanyInsightsPanel", () => ({
     companyData,
     section,
   }: {
-    companyData: Array<{ name: string; industry?: { industryGics?: { sectorCode?: string } } }>;
+    companyData: Array<{
+      name: string;
+      industry?: { industryGics?: { sectorCode?: string } };
+    }>;
     section?: string;
   }) => {
     if (section === "top") {

--- a/src/pages/CompaniesOverviewPage.test.tsx
+++ b/src/pages/CompaniesOverviewPage.test.tsx
@@ -1,0 +1,239 @@
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import type { RankedCompany } from "@/types/company";
+import { CompaniesOverviewPage } from "./CompaniesOverviewPage";
+
+const MATERIALS_SECTOR = "15";
+const HEALTHCARE_SECTOR = "35";
+
+function createCompany(
+  id: string,
+  name: string,
+  sectorCode: string,
+): RankedCompany {
+  return {
+    id,
+    name,
+    wikidataId: `Q${id}`,
+    baseYear: { year: 2019 },
+    industry: {
+      industryGics: {
+        sectorCode,
+      },
+    },
+    reportingPeriods: [
+      {
+        endDate: "2024-12-31",
+        emissions: { calculatedTotalEmissions: 1000 },
+      },
+      {
+        endDate: "2019-12-31",
+        emissions: { calculatedTotalEmissions: 2000 },
+      },
+    ],
+    metrics: {
+      emissionsReduction: 50,
+      displayReduction: "50.0",
+    },
+  } as RankedCompany;
+}
+
+const mockCompanies = [
+  createCompany("1", "Duni AB", MATERIALS_SECTOR),
+  createCompany("2", "Materials Two", MATERIALS_SECTOR),
+  createCompany("3", "Materials Three", MATERIALS_SECTOR),
+  createCompany("4", "Health One", HEALTHCARE_SECTOR),
+  createCompany("5", "Health Two", HEALTHCARE_SECTOR),
+  createCompany("6", "Health Three", HEALTHCARE_SECTOR),
+];
+
+const { mockKpiDefinitions, capturedTopLists } = vi.hoisted(() => ({
+  mockKpiDefinitions: [
+    {
+      key: "emissionsChangeFromBaseYear",
+      label: "emissionsChangeFromBaseYear",
+      unit: "%",
+      source: "",
+      sourceUrls: [],
+      description: "",
+      detailedDescription: "",
+      higherIsBetter: false,
+      nullValues: "No data",
+    },
+  ],
+  capturedTopLists: [] as string[][],
+}));
+
+vi.mock("@/hooks/companies/useCompanies", () => ({
+  useCompanies: () => ({
+    companies: mockCompanies,
+    companiesLoading: false,
+    companiesError: null,
+  }),
+}));
+
+vi.mock("@/hooks/companies/useCompanyKPIs", () => ({
+  useCompanyKPIs: () => mockKpiDefinitions,
+  enrichCompanyWithKPIs: (company: RankedCompany) => ({
+    ...company,
+    emissionsChangeFromBaseYear: -50,
+    meetsParis: true,
+  }),
+}));
+
+vi.mock("@/hooks/useScreenSize", () => ({
+  useScreenSize: () => ({ isMobile: false }),
+}));
+
+vi.mock("@/components/layout/PageHeader", () => ({
+  PageHeader: () => <div />,
+}));
+
+vi.mock("@/components/ranked/KPIChipSelector", () => ({
+  KPIChipSelector: () => <div data-testid="kpi-selector" />,
+}));
+
+vi.mock("@/components/ranked/OverviewSplitLayout", () => ({
+  OverviewSplitLayout: ({ visualization }: { visualization: React.ReactNode }) => (
+    <div data-testid="visualization">{visualization}</div>
+  ),
+}));
+
+vi.mock("@/components/ranked/RankedList", () => ({
+  default: () => <div data-testid="ranked-list" />,
+}));
+
+vi.mock("@/components/companies/rankedList/CompanyKPIVisualization", () => ({
+  CompanyKPIVisualization: () => <div data-testid="kpi-visualization" />,
+}));
+
+vi.mock("@/components/companies/rankedList/IndustryFilter", () => ({
+  IndustryFilter: ({
+    availableSectors,
+    selectedSector,
+    onSectorChange,
+  }: {
+    availableSectors: string[];
+    selectedSector: string | null;
+    onSectorChange: (sector: string) => void;
+  }) => (
+    <div>
+      {availableSectors.map((sector) => (
+        <button
+          key={sector}
+          type="button"
+          aria-pressed={selectedSector === sector}
+          onClick={() => onSectorChange(sector)}
+        >
+          {sector}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock("@/components/companies/rankedList/CompanyInsightsPanel", () => ({
+  default: ({
+    companyData,
+    section,
+  }: {
+    companyData: Array<{ name: string; industry?: { industryGics?: { sectorCode?: string } } }>;
+    section?: string;
+  }) => {
+    if (section === "top") {
+      capturedTopLists.push(companyData.map((company) => company.name));
+    }
+
+    return <div data-testid={`insights-${section}`} />;
+  },
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+function LocationDisplay() {
+  const location = useLocation();
+  return <div data-testid="location-search">{location.search}</div>;
+}
+
+describe("CompaniesOverviewPage", () => {
+  beforeEach(() => {
+    capturedTopLists.length = 0;
+  });
+
+  it("keeps the top insights list scoped to the selected sector when switching", async () => {
+    render(
+      <MemoryRouter initialEntries={["/en/companies?sector=15"]}>
+        <Routes>
+          <Route
+            path="/en/companies"
+            element={
+              <>
+                <CompaniesOverviewPage />
+                <LocationDisplay />
+              </>
+            }
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(capturedTopLists.at(-1)).toEqual([
+        "Duni AB",
+        "Materials Two",
+        "Materials Three",
+      ]);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: HEALTHCARE_SECTOR }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("location-search")).toHaveTextContent(
+        `sector=${HEALTHCARE_SECTOR}`,
+      );
+    });
+
+    await waitFor(() => {
+      expect(capturedTopLists.at(-1)).toEqual([
+        "Health One",
+        "Health Two",
+        "Health Three",
+      ]);
+    });
+
+    expect(capturedTopLists.at(-1)).not.toContain("Duni AB");
+  });
+
+  it("preserves the sector from the URL after company data loads", async () => {
+    render(
+      <MemoryRouter initialEntries={["/en/companies?sector=35"]}>
+        <Routes>
+          <Route
+            path="/en/companies"
+            element={
+              <>
+                <CompaniesOverviewPage />
+                <LocationDisplay />
+              </>
+            }
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("location-search")).toHaveTextContent(
+        "sector=35",
+      );
+    });
+
+    expect(
+      screen.getByRole("button", { name: HEALTHCARE_SECTOR }),
+    ).toHaveAttribute("aria-pressed", "true");
+  });
+});

--- a/src/pages/CompaniesOverviewPage.test.tsx
+++ b/src/pages/CompaniesOverviewPage.test.tsx
@@ -95,9 +95,10 @@ vi.mock("@/components/ranked/KPIChipSelector", () => ({
 }));
 
 vi.mock("@/components/ranked/OverviewSplitLayout", async (importOriginal) => {
-  const actual = await importOriginal<
-    typeof import("@/components/ranked/OverviewSplitLayout")
-  >();
+  const actual =
+    await importOriginal<
+      typeof import("@/components/ranked/OverviewSplitLayout")
+    >();
 
   return {
     ...actual,

--- a/src/pages/CompaniesOverviewPage.tsx
+++ b/src/pages/CompaniesOverviewPage.tsx
@@ -103,10 +103,7 @@ export function CompaniesOverviewPage() {
   };
 
   const [selectedKPI, setSelectedKPI] = useState(getKPIFromURL());
-  const selectedSector = useMemo(
-    () => getSectorFromURL(),
-    [getSectorFromURL],
-  );
+  const selectedSector = useMemo(() => getSectorFromURL(), [getSectorFromURL]);
   const viewMode = getViewModeFromURL();
 
   // Ensure a sector is written to the URL once sectors are known

--- a/src/pages/CompaniesOverviewPage.tsx
+++ b/src/pages/CompaniesOverviewPage.tsx
@@ -103,30 +103,29 @@ export function CompaniesOverviewPage() {
   };
 
   const [selectedKPI, setSelectedKPI] = useState(getKPIFromURL());
-  const [selectedSector, setSelectedSector] = useState<string | null>(
-    getSectorFromURL(),
+  const selectedSector = useMemo(
+    () => getSectorFromURL(),
+    [getSectorFromURL],
   );
   const viewMode = getViewModeFromURL();
 
-  // Ensure a sector is selected on initial load
+  // Ensure a sector is written to the URL once sectors are known
   useEffect(() => {
-    if (!selectedSector && availableSectors.length > 0) {
-      const firstSector = availableSectors[0];
-      setSelectedSector(firstSector);
-      setSectorInURL(firstSector);
+    if (availableSectors.length === 0) return;
+
+    const params = new URLSearchParams(location.search);
+    const sectorParam = params.get("sector");
+
+    if (sectorParam && availableSectors.includes(sectorParam)) {
+      return;
     }
-  }, [availableSectors, selectedSector, setSectorInURL]);
+
+    setSectorInURL(availableSectors[0]);
+  }, [availableSectors, location.search, setSectorInURL]);
 
   useEffect(() => {
     setSelectedKPI(getKPIFromURL());
   }, [getKPIFromURL]);
-
-  useEffect(() => {
-    const sectorFromUrl = getSectorFromURL();
-    if (sectorFromUrl !== selectedSector) {
-      setSelectedSector(sectorFromUrl);
-    }
-  }, [getSectorFromURL, selectedSector]);
 
   // Filter and enrich companies with KPI values
   const companiesWithKPIs: CompanyWithKPIs[] = useMemo(() => {
@@ -152,7 +151,6 @@ export function CompaniesOverviewPage() {
   }, [companies, selectedSector, selectedKPI.key]);
 
   const handleSectorChange = (sector: string) => {
-    setSelectedSector(sector);
     setSectorInURL(sector);
   };
 
@@ -300,11 +298,13 @@ export function CompaniesOverviewPage() {
               companyData={companiesWithKPIs}
               selectedKPI={selectedKPI}
               section="top"
+              listKey={selectedSector ?? undefined}
             />
             <CompanyInsightsPanel
               companyData={companiesWithKPIs}
               selectedKPI={selectedKPI}
               section="bottom"
+              listKey={selectedSector ?? undefined}
             />
             <CompanyInsightsPanel
               companyData={companiesWithKPIs}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### ✨ What's Changed?

The companies overview page kept sector selection in both React state and the URL. When browsing sectors, those two sources could briefly disagree while `navigate()` updated the query string. That caused the top/bottom insight lists to filter against the wrong sector, leaving companies like Duni AB visible after switching away from Materials.

This PR makes the URL the single source of truth for the selected sector (matching how view mode already works), only writes a default sector once sector data is available, and hardens the insight lists by:

- remounting top/bottom lists when the sector changes
- using stable company ids as React keys instead of company names

Also fixes the related reload issue where a valid `?sector=` query param could be overwritten before company data finished loading (#1541).

### 📋 Checklist

- [x] PR title starts with [#issue-number]
- [x] Tests added for sector switching and InsightsList keys
- [ ] I've verified the change runs locally both on mobile and desktop
- [ ] I've set the labels, issue, and milestone for the PR

### 🛠 Related Issue

Closes #1542
Related to #1541
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4924b76a-4cd7-43f2-b7d7-72fab57eb4c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4924b76a-4cd7-43f2-b7d7-72fab57eb4c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

