### PR TITLE
[fix] Keep compare picker above mobile keyboard on detail pages

### DIFF
--- a/src/components/compare/ComparisonPickerDialog.tsx
+++ b/src/components/compare/ComparisonPickerDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
@@ -17,6 +17,8 @@ import { useComparisonPickerDialogState } from "@/hooks/compare/useComparisonPic
 import { useComparisonPickerPrefill } from "@/hooks/compare/useComparisonPickerPrefill";
 import { useComparisonPickerSearch } from "@/hooks/compare/useComparisonPickerSearch";
 import { useComparisonPickerToggle } from "@/hooks/compare/useComparisonPickerToggle";
+import { useScreenSize } from "@/hooks/useScreenSize";
+import { useVisualViewportBottomInset } from "@/hooks/useVisualViewportBottomInset";
 import { combinedDataToComparison } from "@/utils/compare/comparisonUtils";
 import { getComparisonCopyKey } from "@/utils/compare/comparisonCopy";
 import { PICKER_RESULT_LIST_HEIGHT } from "@/components/compare/comparisonPicker.constants";
@@ -38,8 +40,23 @@ export function ComparisonPickerDialog({
 }: ComparisonPickerDialogProps) {
   const { t } = useTranslation();
   const navigateToComparisonPage = useNavigateToComparison();
+  const { isMobile } = useScreenSize();
   const [inputValue, setInputValue] = useState("");
   const commandListRef = useRef<HTMLDivElement | null>(null);
+  const useMobileSheetLayout = sheetOnMobile && isMobile;
+  const { bottomInset, viewportHeight } = useVisualViewportBottomInset(
+    open && useMobileSheetLayout,
+  );
+  const mobileSheetStyle = useMemo(
+    () =>
+      useMobileSheetLayout
+        ? {
+            bottom: bottomInset,
+            maxHeight: viewportHeight * 0.92,
+          }
+        : undefined,
+    [bottomInset, useMobileSheetLayout, viewportHeight],
+  );
 
   const { selectedCount, canViewComparison, clearSelection, variant } =
     useComparison();
@@ -105,9 +122,10 @@ export function ComparisonPickerDialog({
           className={cn(
             "fixed z-50 w-full focus:outline-none",
             sheetOnMobile
-              ? "inset-x-0 bottom-0 top-auto max-h-[92vh] md:top-[7vh] md:bottom-auto md:left-1/2 md:max-w-lg md:-translate-x-1/2"
+              ? "inset-x-0 bottom-0 top-auto max-h-[92dvh] md:top-[7vh] md:bottom-auto md:left-1/2 md:max-w-lg md:-translate-x-1/2 md:max-h-none"
               : "top-[7vh] left-1/2 max-w-lg -translate-x-1/2 transform",
           )}
+          style={mobileSheetStyle}
         >
           <div
             className={cn(

--- a/src/hooks/useVisualViewportBottomInset.ts
+++ b/src/hooks/useVisualViewportBottomInset.ts
@@ -1,0 +1,58 @@
+import { useLayoutEffect, useState } from "react";
+import {
+  getVisualViewportBottomInset,
+  getVisualViewportHeight,
+} from "@/utils/ui/visualViewport";
+
+interface VisualViewportState {
+  bottomInset: number;
+  viewportHeight: number;
+}
+
+function readVisualViewportState(): VisualViewportState {
+  if (typeof window === "undefined") {
+    return { bottomInset: 0, viewportHeight: 0 };
+  }
+
+  return {
+    bottomInset: getVisualViewportBottomInset(
+      window.innerHeight,
+      window.visualViewport,
+    ),
+    viewportHeight: getVisualViewportHeight(
+      window.innerHeight,
+      window.visualViewport,
+    ),
+  };
+}
+
+export function useVisualViewportBottomInset(enabled: boolean) {
+  const [state, setState] = useState<VisualViewportState>(() =>
+    enabled ? readVisualViewportState() : { bottomInset: 0, viewportHeight: 0 },
+  );
+
+  useLayoutEffect(() => {
+    if (!enabled || typeof window === "undefined") {
+      return;
+    }
+
+    const update = () => {
+      setState(readVisualViewportState());
+    };
+
+    update();
+
+    const viewport = window.visualViewport;
+    viewport?.addEventListener("resize", update);
+    viewport?.addEventListener("scroll", update);
+    window.addEventListener("resize", update);
+
+    return () => {
+      viewport?.removeEventListener("resize", update);
+      viewport?.removeEventListener("scroll", update);
+      window.removeEventListener("resize", update);
+    };
+  }, [enabled]);
+
+  return state;
+}

--- a/src/utils/ui/__tests__/visualViewport.test.ts
+++ b/src/utils/ui/__tests__/visualViewport.test.ts
@@ -1,0 +1,39 @@
+import {
+  getVisualViewportBottomInset,
+  getVisualViewportHeight,
+} from "../visualViewport";
+
+describe("getVisualViewportBottomInset", () => {
+  it("returns 0 when viewport is unavailable", () => {
+    expect(getVisualViewportBottomInset(800, null)).toBe(0);
+    expect(getVisualViewportBottomInset(800, undefined)).toBe(0);
+  });
+
+  it("returns 0 when the keyboard is closed", () => {
+    expect(
+      getVisualViewportBottomInset(800, { height: 800, offsetTop: 0 }),
+    ).toBe(0);
+  });
+
+  it("returns the keyboard height when the visual viewport shrinks", () => {
+    expect(
+      getVisualViewportBottomInset(800, { height: 500, offsetTop: 0 }),
+    ).toBe(300);
+  });
+
+  it("accounts for visual viewport offset on iOS", () => {
+    expect(
+      getVisualViewportBottomInset(800, { height: 500, offsetTop: 50 }),
+    ).toBe(250);
+  });
+});
+
+describe("getVisualViewportHeight", () => {
+  it("falls back to window inner height when viewport is unavailable", () => {
+    expect(getVisualViewportHeight(800, null)).toBe(800);
+  });
+
+  it("returns the visual viewport height when available", () => {
+    expect(getVisualViewportHeight(800, { height: 500 })).toBe(500);
+  });
+});

--- a/src/utils/ui/visualViewport.ts
+++ b/src/utils/ui/visualViewport.ts
@@ -1,0 +1,19 @@
+type VisualViewportLike = Pick<VisualViewport, "height" | "offsetTop">;
+
+export function getVisualViewportBottomInset(
+  windowInnerHeight: number,
+  viewport: VisualViewportLike | null | undefined,
+): number {
+  if (!viewport) {
+    return 0;
+  }
+
+  return Math.max(0, windowInnerHeight - viewport.height - viewport.offsetTop);
+}
+
+export function getVisualViewportHeight(
+  windowInnerHeight: number,
+  viewport: Pick<VisualViewport, "height"> | null | undefined,
+): number {
+  return viewport?.height ?? windowInnerHeight;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### ✨ What’s Changed?

When compare is opened from detail pages on mobile, the picker renders as a bottom sheet (`sheetOnMobile`). Focusing the search input opens the virtual keyboard, but the sheet stayed anchored to `bottom: 0` on the layout viewport — so it ended up hidden behind the keyboard.

This PR tracks the visual viewport and shifts the sheet up by the keyboard inset while constraining its height to the visible area.

**Changes:**
- Added `useVisualViewportBottomInset` hook and pure viewport helpers
- Applied dynamic `bottom` and `maxHeight` to `ComparisonPickerDialog` on mobile sheet layout
- Switched fallback max height from `92vh` to `92dvh` for better mobile viewport behavior

### 📸 Screenshots (if applicable)

Manual verification recommended on a real device: open compare from a company/region/municipality detail page, tap the search field, and confirm the sheet and footer actions remain visible above the keyboard.

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [ ] I've verified the change runs locally both on mobile and desktop
- [ ] I've set the labels, issue, and milestone for the PR

### 🛠 Related Issue

Related to mobile compare UX on detail pages
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb85c734-97dc-4707-bcbb-f14b896fd14b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb85c734-97dc-4707-bcbb-f14b896fd14b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

