### PR TITLE
[fix] Fix untranslated strings on overview pages

### DIFF
--- a/src/components/companies/rankedList/IndustryFilter.tsx
+++ b/src/components/companies/rankedList/IndustryFilter.tsx
@@ -45,7 +45,7 @@ export function IndustryFilter({
     return (
       <div className="space-y-2">
         <label className="text-sm text-grey">
-          {t("companiesOverviewPage.selectIndustry", "Select industry")}:
+          {t("companiesOverviewPage.selectIndustry")}:
         </label>
         <Select
           value={selectedSector || undefined}
@@ -53,10 +53,7 @@ export function IndustryFilter({
         >
           <SelectTrigger className="w-full bg-black-2 border-black-3 text-white">
             <SelectValue
-              placeholder={t(
-                "companiesOverviewPage.selectIndustry",
-                "Select industry",
-              )}
+              placeholder={t("companiesOverviewPage.selectIndustry")}
             >
               {selectedSectorName}
             </SelectValue>
@@ -86,7 +83,7 @@ export function IndustryFilter({
   return (
     <div className="flex flex-wrap items-center gap-2">
       <span className="text-sm text-grey mr-1">
-        {t("companiesOverviewPage.selectIndustry", "Select industry")}:
+        {t("companiesOverviewPage.selectIndustry")}:
       </span>
       {availableSectors.map((sectorCode) => {
         const isSelected = selectedSector === sectorCode;

--- a/src/components/maps/MapOverlays.tsx
+++ b/src/components/maps/MapOverlays.tsx
@@ -58,7 +58,7 @@ function MapOverlays({
           nullValue={
             selectedKPI.key
               ? t(`${entityType}.list.kpis.${selectedKPI.key}.nullValues`)
-              : "No data"
+              : t("noData")
           }
           selectedKPI={selectedKPI as KPIValue}
           onClick={onAreaClick ? () => onAreaClick(hoveredArea) : undefined}

--- a/src/components/maps/MapZoomControls.tsx
+++ b/src/components/maps/MapZoomControls.tsx
@@ -1,4 +1,5 @@
 import { RotateCcw, ZoomIn, ZoomOut } from "lucide-react";
+import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import type { MapLegendPosition } from "./MapLegend";
 
@@ -17,6 +18,8 @@ export function MapZoomControls({
   canZoomOut: boolean;
   legendPosition?: MapLegendPosition;
 }) {
+  const { t } = useTranslation();
+
   return (
     <div
       className={cn(
@@ -33,7 +36,7 @@ export function MapZoomControls({
       <button
         onClick={onZoomIn}
         disabled={!canZoomIn}
-        aria-label="Zoom in"
+        aria-label={t("mapControls.zoomIn")}
         className="p-2 bg-black/40 backdrop-blur-sm rounded-xl hover:bg-black/60 transition-colors disabled:opacity-50"
       >
         <ZoomIn className="w-5 h-5 text-white/70" />
@@ -41,14 +44,14 @@ export function MapZoomControls({
       <button
         onClick={onZoomOut}
         disabled={!canZoomOut}
-        aria-label="Zoom out"
+        aria-label={t("mapControls.zoomOut")}
         className="p-2 bg-black/40 backdrop-blur-sm rounded-xl hover:bg-black/60 transition-colors disabled:opacity-50"
       >
         <ZoomOut className="w-5 h-5 text-white/70" />
       </button>
       <button
         onClick={onReset}
-        aria-label="Reset"
+        aria-label={t("mapControls.reset")}
         className="p-2 bg-black/40 backdrop-blur-sm rounded-xl hover:bg-black/60 transition-colors"
       >
         <RotateCcw className="w-5 h-5 text-white/70" />

--- a/src/components/ui/multi-page-pagination.tsx
+++ b/src/components/ui/multi-page-pagination.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 
 interface PaginationProps {
@@ -12,6 +13,7 @@ const MultiPagePagination: React.FC<PaginationProps> = ({
   totalPages,
   onPageChange,
 }) => {
+  const { t } = useTranslation();
   const [isMobile, setIsMobile] = useState(false);
 
   useEffect(() => {
@@ -62,7 +64,7 @@ const MultiPagePagination: React.FC<PaginationProps> = ({
       <button
         onClick={() => onPageChange(currentPage - 1)}
         disabled={currentPage === 1}
-        aria-label="Previous page"
+        aria-label={t("rankedList.pagination.previousPage")}
         className="p-2 text-white/70 disabled:text-white/20 disabled:cursor-not-allowed hover:bg-black/40 rounded-xl transition-colors"
       >
         <ChevronLeft className="w-5 h-5" />
@@ -71,7 +73,7 @@ const MultiPagePagination: React.FC<PaginationProps> = ({
       <button
         onClick={() => onPageChange(currentPage + 1)}
         disabled={currentPage === totalPages}
-        aria-label="Next page"
+        aria-label={t("rankedList.pagination.nextPage")}
         className="p-2 text-white/70 disabled:text-white/20 disabled:cursor-not-allowed hover:bg-black/40 rounded-xl transition-colors"
       >
         <ChevronRight className="w-5 h-5" />

--- a/src/hooks/companies/useCompanyKPIs.ts
+++ b/src/hooks/companies/useCompanyKPIs.ts
@@ -31,10 +31,7 @@ export const useCompanyKPIs = (): CompanyKPIValue[] => {
   return useMemo<CompanyKPIValue[]>(() => {
     return [
       {
-        label: t(
-          "companies.list.kpis.emissionsChangeFromBaseYear.label",
-          "Overall Emissions Change",
-        ),
+        label: t("companies.list.kpis.emissionsChangeFromBaseYear.label"),
         key: "emissionsChangeFromBaseYear",
         unit: "%",
         source: "companies.list.kpis.emissionsChangeFromBaseYear.source",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -381,7 +381,10 @@
       "back": "Back",
       "sectorTotal": "Sector Total Emissions",
       "total": "Total Emissions",
-      "emissionsUnit": "ton CO₂e"
+      "emissionsUnit": "ton CO₂e",
+      "noDataAvailablePieChart": "No data available for this year",
+      "pieLegendCompany": "View company details",
+      "pieLegendSector": "View sector details"
     }
   },
   "sectorsOverviewPage": {
@@ -1429,9 +1432,19 @@
       "regions": "Regions"
     }
   },
+  "mapControls": {
+    "zoomIn": "Zoom in",
+    "zoomOut": "Zoom out",
+    "reset": "Reset"
+  },
   "regions": {
     "detailPage": {
       "municipalities": "Municipalities"
+    },
+    "map": {
+      "legend": {
+        "null": "No data"
+      }
     },
     "kpis": {
       "emissions": {
@@ -1454,7 +1467,8 @@
           "label": "Emissions",
           "description": "Historical change in emissions",
           "detailedDescription": "Average annual percentage change in greenhouse gas emissions since the Paris Agreement in 2015.",
-          "source": "National Emissions Database"
+          "source": "National Emissions Database",
+          "nullValues": "No data"
         },
         "meetsParis": {
           "label": "Paris Agreement",
@@ -1464,7 +1478,10 @@
           "booleanLabels": {
             "true": "Meets Paris Agreement",
             "false": "Fails Paris Agreement"
-          }
+          },
+          "nullValues": "Unknown",
+          "aboveString": "are on track to meet the Paris Agreement",
+          "belowString": "are on track to miss the Paris Agreement"
         }
       },
       "insights": {
@@ -1900,6 +1917,10 @@
     "sort": {
       "asc": "Sort from low to high",
       "desc": "Sort from high to low"
+    },
+    "pagination": {
+      "previousPage": "Previous page",
+      "nextPage": "Next page"
     }
   },
   "rankedInsights": {

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -1482,9 +1482,19 @@
       "regions": "Län"
     }
   },
+  "mapControls": {
+    "zoomIn": "Zooma in",
+    "zoomOut": "Zooma ut",
+    "reset": "Återställ"
+  },
   "regions": {
     "detailPage": {
       "municipalities": "Kommuner"
+    },
+    "map": {
+      "legend": {
+        "null": "Saknar data"
+      }
     },
     "kpis": {
       "emissions": {
@@ -1507,7 +1517,8 @@
           "label": "Utsläppen",
           "description": "Historisk förändring av utsläpp",
           "detailedDescription": "Genomsnittlig årlig procentuell förändring av växthusgasutsläppen i Sveriges län sedan Parisavtalet år 2015.",
-          "source": "Nationella emissionsdatabasen"
+          "source": "Nationella emissionsdatabasen",
+          "nullValues": "Saknar data"
         },
         "meetsParis": {
           "label": "Parisavtalet",
@@ -1518,6 +1529,7 @@
             "true": "Klarar Parisavtalet",
             "false": "Missar Parisavtalet"
           },
+          "nullValues": "Okänt",
           "aboveString": "är på väg att klara Parisavtalet",
           "belowString": "är på väg att missa Parisavtalet"
         }
@@ -1955,6 +1967,10 @@
     "sort": {
       "asc": "Sortera från lågt till högt",
       "desc": "Sortera från högt till lågt"
+    },
+    "pagination": {
+      "previousPage": "Föregående sida",
+      "nextPage": "Nästa sida"
     }
   },
   "rankedInsights": {

--- a/src/pages/CompaniesOverviewPage.tsx
+++ b/src/pages/CompaniesOverviewPage.tsx
@@ -214,8 +214,8 @@ export function CompaniesOverviewPage() {
       modes={["graph", "list"]}
       onChange={setViewModeInURL}
       titles={{
-        graph: t("companiesOverviewPage.viewToggle.showGraph", "Graf"),
-        list: t("companiesOverviewPage.viewToggle.showList", "Lista"),
+        graph: t("companiesOverviewPage.viewToggle.showGraph"),
+        list: t("companiesOverviewPage.viewToggle.showList"),
       }}
       showTitles
       icons={{
@@ -269,7 +269,7 @@ export function CompaniesOverviewPage() {
         }}
         iconMap={COMPANY_KPI_ICONS}
         translationPrefix="companies.list"
-        label={t("municipalities.list.dataSelector.label")}
+        label={t("companies.list.dataSelector.label")}
       />
 
       <div className="mb-4">

--- a/src/pages/RegionalOverviewPage.tsx
+++ b/src/pages/RegionalOverviewPage.tsx
@@ -180,7 +180,7 @@ export function RegionalOverviewPage() {
         }}
         iconMap={REGION_KPI_ICONS}
         translationPrefix="regions.list"
-        label={t("municipalities.list.dataSelector.label")}
+        label={t("regions.list.dataSelector.label")}
       />
 
       <div className="space-y-6">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### ✨ What's Changed?

Fixes i18n gaps on the regions, municipalities, companies, and sectors overview pages so text follows the language toggle correctly.

**Translation keys added**
- `regions.map.legend.null` and `regions.list.kpis.*.nullValues` in both SV and EN
- Missing English `companyDetailPage.sectorGraphs` keys used on `/sectors` (`noDataAvailablePieChart`, `pieLegendCompany`, `pieLegendSector`)
- `mapControls.*` and `rankedList.pagination.*` for map zoom buttons and list pagination aria-labels

**Components updated**
- `MapZoomControls`, `MapOverlays`, and `MultiPagePagination` now use `t()` instead of hardcoded English
- Regions and companies overview pages use their own `dataSelector` translation keys
- Removed wrong-language `t()` fallbacks in companies overview, industry filter, and company KPI hook

### 📋 Checklist

- [x] I've verified the change runs locally both on mobile and desktop
- [ ] I've set the labels, issue, and milestone for the PR

### 🛠 Related Issue

Audit of overview page translations (regions, municipalities, companies, sectors).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0637aa97-66a1-477d-8402-0a4f9dc9126b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0637aa97-66a1-477d-8402-0a4f9dc9126b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

