### PR TITLE
Add company country filter

### DIFF
--- a/src/components/companies/rankedList/CountryFilter.tsx
+++ b/src/components/companies/rankedList/CountryFilter.tsx
@@ -1,0 +1,91 @@
+import { useTranslation } from "react-i18next";
+import { cn } from "@/lib/utils";
+import { useCompanyCountryNames } from "@/hooks/companies/companyCountryFilterUtils";
+import { useScreenSize } from "@/hooks/useScreenSize";
+import type { CompanyCountryTagSlug } from "@/lib/constants/companyCountryTags";
+import { Checkbox } from "@/components/ui/checkbox";
+
+interface CountryFilterProps {
+  availableCountries: CompanyCountryTagSlug[];
+  selectedCountries: CompanyCountryTagSlug[];
+  onCountriesChange: (countries: CompanyCountryTagSlug[]) => void;
+}
+
+export function CountryFilter({
+  availableCountries,
+  selectedCountries,
+  onCountriesChange,
+}: CountryFilterProps) {
+  const { t } = useTranslation();
+  const countryNames = useCompanyCountryNames();
+  const { isMobile } = useScreenSize();
+
+  const handleCountryToggle = (country: CompanyCountryTagSlug) => {
+    if (selectedCountries.includes(country)) {
+      onCountriesChange(selectedCountries.filter((value) => value !== country));
+      return;
+    }
+
+    onCountriesChange([...selectedCountries, country]);
+  };
+
+  if (availableCountries.length === 0) {
+    return null;
+  }
+
+  if (isMobile) {
+    return (
+      <div className="space-y-2">
+        <label className="text-sm text-grey">
+          {t("companiesOverviewPage.selectCountry", "Select country")}:
+        </label>
+        <div className="space-y-2 rounded-level-1 border border-black-3 bg-black-2 p-3">
+          {availableCountries.map((country) => {
+            const isSelected = selectedCountries.includes(country);
+
+            return (
+              <label
+                key={country}
+                className="flex items-center gap-2 text-sm text-white"
+              >
+                <Checkbox
+                  checked={isSelected}
+                  onCheckedChange={() => handleCountryToggle(country)}
+                />
+                {countryNames[country]}
+              </label>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <span className="text-sm text-grey mr-1">
+        {t("companiesOverviewPage.selectCountry", "Select country")}:
+      </span>
+      {availableCountries.map((country) => {
+        const isSelected = selectedCountries.includes(country);
+
+        return (
+          <button
+            key={country}
+            type="button"
+            onClick={() => handleCountryToggle(country)}
+            className={cn(
+              "px-3 py-1.5 rounded-level-1 text-xs font-medium transition-all",
+              "border",
+              isSelected
+                ? "bg-blue-5/30 border-blue-4 text-blue-2 hover:bg-blue-5/40"
+                : "bg-black-2 border-black-3 text-grey hover:bg-black-3 hover:border-black-4",
+            )}
+          >
+            {countryNames[country]}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/hooks/companies/companyCountryFilterUtils.ts
+++ b/src/hooks/companies/companyCountryFilterUtils.ts
@@ -1,0 +1,130 @@
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import type { TFunction } from "i18next";
+import type { FilterGroup } from "@/components/explore/FilterPopover";
+import {
+  COMPANY_COUNTRY_TAG_SLUGS,
+  isCompanyCountryTagSlug,
+  type CompanyCountryTagSlug,
+} from "@/lib/constants/companyCountryTags";
+
+type CompanyWithTags = {
+  tags?: string[] | null;
+};
+
+export function useCompanyCountryNames() {
+  const { t } = useTranslation();
+
+  return useMemo(
+    () =>
+      Object.fromEntries(
+        COMPANY_COUNTRY_TAG_SLUGS.map((slug) => [
+          slug,
+          t(`companyCountries.${slug}`, slug),
+        ]),
+      ) as Record<CompanyCountryTagSlug, string>,
+    [t],
+  );
+}
+
+export function parseCountriesFromURL(
+  searchParams: URLSearchParams,
+): CompanyCountryTagSlug[] {
+  const raw = searchParams.get("countries");
+  if (!raw) return [];
+
+  return raw
+    .split(",")
+    .map((value) => value.trim())
+    .filter(isCompanyCountryTagSlug);
+}
+
+export function getAvailableCountryOptions(
+  companies: CompanyWithTags[],
+): CompanyCountryTagSlug[] {
+  const present = new Set<string>();
+  for (const company of companies) {
+    for (const tag of company.tags ?? []) {
+      if (isCompanyCountryTagSlug(tag)) {
+        present.add(tag);
+      }
+    }
+  }
+
+  return COMPANY_COUNTRY_TAG_SLUGS.filter((slug) => present.has(slug));
+}
+
+export function companyMatchesCountries(
+  company: CompanyWithTags,
+  selectedCountries: CompanyCountryTagSlug[],
+): boolean {
+  if (selectedCountries.length === 0) return true;
+
+  const tags = company.tags ?? [];
+  return selectedCountries.some((country) => tags.includes(country));
+}
+
+export function toggleCountrySelection(
+  selectedCountries: CompanyCountryTagSlug[],
+  value: string,
+): CompanyCountryTagSlug[] {
+  if (value === "all") return [];
+
+  if (!isCompanyCountryTagSlug(value)) return selectedCountries;
+
+  if (selectedCountries.includes(value)) {
+    return selectedCountries.filter((country) => country !== value);
+  }
+
+  return [...selectedCountries, value];
+}
+
+export function buildCountryFilterGroup({
+  t,
+  countryNames,
+  availableCountries,
+  selectedCountries,
+  onSelect,
+}: {
+  t: TFunction;
+  countryNames: Record<CompanyCountryTagSlug, string>;
+  availableCountries: CompanyCountryTagSlug[];
+  selectedCountries: CompanyCountryTagSlug[];
+  onSelect: (value: string) => void;
+}): FilterGroup | null {
+  if (availableCountries.length === 0) return null;
+
+  return {
+    heading: t("explorePage.companies.filteringOptions.country"),
+    options: [
+      {
+        value: "all",
+        label: t("explorePage.companies.filteringOptions.allCountries"),
+      },
+      ...availableCountries.map((slug) => ({
+        value: slug,
+        label: countryNames[slug],
+      })),
+    ],
+    selectedValues:
+      selectedCountries.length === 0 ? ["all"] : selectedCountries,
+    onSelect,
+    selectMultiple: true,
+  };
+}
+
+export function buildCountryActiveFilters({
+  countryNames,
+  selectedCountries,
+  onRemove,
+}: {
+  countryNames: Record<CompanyCountryTagSlug, string>;
+  selectedCountries: CompanyCountryTagSlug[];
+  onRemove: (country: CompanyCountryTagSlug) => void;
+}) {
+  return selectedCountries.map((country) => ({
+    type: "filter" as const,
+    label: countryNames[country] ?? country,
+    onRemove: () => onRemove(country),
+  }));
+}

--- a/src/hooks/companies/useCompanyFilters.ts
+++ b/src/hooks/companies/useCompanyFilters.ts
@@ -20,6 +20,16 @@ import {
 } from "./useCompanySorting";
 import { useExploreFilters } from "@/hooks/explore/useExploreFilters";
 import { getSearchTerms } from "@/hooks/explore/exploreFilterUtils";
+import type { CompanyCountryTagSlug } from "@/lib/constants/companyCountryTags";
+import {
+  buildCountryActiveFilters,
+  buildCountryFilterGroup,
+  companyMatchesCountries,
+  getAvailableCountryOptions,
+  parseCountriesFromURL,
+  toggleCountrySelection,
+  useCompanyCountryNames,
+} from "@/hooks/companies/companyCountryFilterUtils";
 
 const MEETS_PARIS_OPTIONS = ["all", "yes", "no", "unknown"] as const;
 type MeetsParisFilter = (typeof MEETS_PARIS_OPTIONS)[number];
@@ -82,11 +92,27 @@ export const useCompanyFilters = (
         sectors.length > 0 ? sectors.join(",") : null,
         "sectors",
       ),
-    [],
+    [setSearchParams],
+  );
+
+  const selectedCountries = parseCountriesFromURL(searchParams);
+  const setSelectedCountries = useCallback(
+    (countries: CompanyCountryTagSlug[]) =>
+      setOrDeleteSearchParam(
+        setSearchParams,
+        countries.length > 0 ? countries.join(",") : null,
+        "countries",
+      ),
+    [setSearchParams],
   );
 
   const sectorNames = useSectorNames();
   const sectorOptions = useSectors();
+  const countryNames = useCompanyCountryNames();
+  const availableCountries = useMemo(
+    () => getAvailableCountryOptions(companies),
+    [companies],
+  );
   const { t } = useTranslation();
 
   const filteredCompanies = useMemo(() => {
@@ -134,7 +160,14 @@ export const useCompanyFilters = (
           return true;
         })();
 
-        return matchesSector && matchesSearch && matchesMeetsParis;
+        const matchesCountry = companyMatchesCountries(
+          company,
+          selectedCountries,
+        );
+
+        return (
+          matchesSector && matchesSearch && matchesMeetsParis && matchesCountry
+        );
       })
       .sort((a, b) => {
         // Sort companies
@@ -202,12 +235,22 @@ export const useCompanyFilters = (
   }, [
     companies,
     sectors,
+    selectedCountries,
     searchQuery,
     meetsParisFilter,
     sortBy,
     sortDirection,
     sectorNames,
   ]);
+
+  const countryFilterGroup = buildCountryFilterGroup({
+    t,
+    countryNames,
+    availableCountries,
+    selectedCountries,
+    onSelect: (value) =>
+      setSelectedCountries(toggleCountrySelection(selectedCountries, value)),
+  });
 
   const filterGroups: FilterGroup[] = [
     ...(includeSectorFilter
@@ -234,6 +277,7 @@ export const useCompanyFilters = (
           } satisfies FilterGroup,
         ]
       : []),
+    ...(countryFilterGroup ? [countryFilterGroup] : []),
     {
       heading: t("explorePage.companies.filteringOptions.meetsParis"),
       options: [
@@ -267,6 +311,14 @@ export const useCompanyFilters = (
             onRemove: () => setSectors(sectors.filter((s) => s !== sector)),
           }))
         : []),
+      ...buildCountryActiveFilters({
+        countryNames,
+        selectedCountries,
+        onRemove: (country) =>
+          setSelectedCountries(
+            selectedCountries.filter((value) => value !== country),
+          ),
+      }),
       ...(meetsParisFilter !== "all"
         ? [
             {
@@ -288,10 +340,13 @@ export const useCompanyFilters = (
   }, [
     includeSectorFilter,
     sectors,
+    selectedCountries,
     meetsParisFilter,
     sectorNames,
+    countryNames,
     t,
     setSectors,
+    setSelectedCountries,
     setMeetsParisFilter,
   ]);
 
@@ -300,6 +355,8 @@ export const useCompanyFilters = (
     setSearchQuery,
     sectors,
     setSectors,
+    selectedCountries,
+    setSelectedCountries,
     meetsParisFilter,
     setMeetsParisFilter,
     sortBy,

--- a/src/lib/constants/companyCountryTags.ts
+++ b/src/lib/constants/companyCountryTags.ts
@@ -1,0 +1,14 @@
+export const COMPANY_COUNTRY_TAG_SLUGS = [
+  "sweden",
+  "norway",
+  "finland",
+  "denmark",
+  "iceland",
+] as const;
+
+export type CompanyCountryTagSlug = (typeof COMPANY_COUNTRY_TAG_SLUGS)[number];
+
+export const isCompanyCountryTagSlug = (
+  value: string,
+): value is CompanyCountryTagSlug =>
+  COMPANY_COUNTRY_TAG_SLUGS.includes(value as CompanyCountryTagSlug);

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -316,6 +316,7 @@
     "filterByIndustry": "Filter by industry",
     "clearFilters": "Clear all",
     "selectIndustry": "Select industry",
+    "selectCountry": "Select country",
     "viewToggle": {
       "showGraph": "Graph",
       "showList": "List"
@@ -2053,6 +2054,8 @@
       "errorTitle": "Failed to retrieve company information",
       "errorDescription": "Please try again later",
       "filteringOptions": {
+        "country": "Country",
+        "allCountries": "All countries",
         "meetsParis": "Meets the Paris Agreement",
         "meetsParisYes": "Yes",
         "meetsParisNo": "No",
@@ -2075,6 +2078,13 @@
       "sectionTitle": "Companies",
       "noCompaniesInSection": "No companies in this section"
     }
+  },
+  "companyCountries": {
+    "sweden": "Sweden",
+    "norway": "Norway",
+    "finland": "Finland",
+    "denmark": "Denmark",
+    "iceland": "Iceland"
   },
   "insightCategories": {
     "analysis": "Analysis",

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -316,6 +316,7 @@
     "filterByIndustry": "Filtrera efter bransch",
     "clearFilters": "Rensa alla",
     "selectIndustry": "Välj bransch",
+    "selectCountry": "Välj land",
     "viewToggle": {
       "showGraph": "Graf",
       "showList": "Lista"
@@ -2108,6 +2109,8 @@
       "errorTitle": "Det gick inte att hämta företagsinformation",
       "errorDescription": "Försök igen senare",
       "filteringOptions": {
+        "country": "Land",
+        "allCountries": "Alla länder",
         "meetsParis": "Klarar Parisavtalet",
         "meetsParisYes": "Ja",
         "meetsParisNo": "Nej",
@@ -2130,6 +2133,13 @@
       "sectionTitle": "Företag",
       "noCompaniesInSection": "Inga företag i denna kategori"
     }
+  },
+  "companyCountries": {
+    "sweden": "Sverige",
+    "norway": "Norge",
+    "finland": "Finland",
+    "denmark": "Danmark",
+    "iceland": "Island"
   },
   "insightCategories": {
     "analysis": "Analys",

--- a/src/pages/CompaniesOverviewPage.tsx
+++ b/src/pages/CompaniesOverviewPage.tsx
@@ -17,6 +17,13 @@ import RankedList from "@/components/ranked/RankedList";
 import CompanyInsightsPanel from "@/components/companies/rankedList/CompanyInsightsPanel";
 import { CompanyKPIVisualization } from "@/components/companies/rankedList/CompanyKPIVisualization";
 import { IndustryFilter } from "@/components/companies/rankedList/IndustryFilter";
+import { CountryFilter } from "@/components/companies/rankedList/CountryFilter";
+import {
+  companyMatchesCountries,
+  getAvailableCountryOptions,
+  parseCountriesFromURL,
+} from "@/hooks/companies/companyCountryFilterUtils";
+import type { CompanyCountryTagSlug } from "@/lib/constants/companyCountryTags";
 import {
   useCompanyKPIs,
   CompanyKPIValue,
@@ -92,6 +99,29 @@ export function CompaniesOverviewPage() {
     [location.search, navigate],
   );
 
+  const selectedCountries = useMemo(
+    () => parseCountriesFromURL(new URLSearchParams(location.search)),
+    [location.search],
+  );
+
+  const availableCountries = useMemo(
+    () => getAvailableCountryOptions(companies ?? []),
+    [companies],
+  );
+
+  const setCountriesInURL = useCallback(
+    (countries: CompanyCountryTagSlug[]) => {
+      const params = new URLSearchParams(location.search);
+      if (countries.length === 0) {
+        params.delete("countries");
+      } else {
+        params.set("countries", countries.join(","));
+      }
+      navigate({ search: params.toString() }, { replace: true });
+    },
+    [location.search, navigate],
+  );
+
   const getViewModeFromURL = useCallback((): OverviewViewMode => {
     const params = new URLSearchParams(location.search);
     return params.get("view") === "list" ? "list" : "graph";
@@ -130,6 +160,10 @@ export function CompaniesOverviewPage() {
     if (!companies || !selectedSector) return [];
 
     const filtered = companies.filter((company) => {
+      if (!companyMatchesCountries(company, selectedCountries)) {
+        return false;
+      }
+
       const sectorCode = company.industry?.industryGics?.sectorCode;
       if (sectorCode !== selectedSector) {
         return false;
@@ -146,10 +180,14 @@ export function CompaniesOverviewPage() {
     });
 
     return filtered.map((company) => enrichCompanyWithKPIs(company));
-  }, [companies, selectedSector, selectedKPI.key]);
+  }, [companies, selectedCountries, selectedSector, selectedKPI.key]);
 
   const handleSectorChange = (sector: string) => {
     setSectorInURL(sector);
+  };
+
+  const handleCountriesChange = (countries: CompanyCountryTagSlug[]) => {
+    setCountriesInURL(countries);
   };
 
   const handleCompanyClick = (company: CompanyWithKPIs) => {
@@ -272,11 +310,16 @@ export function CompaniesOverviewPage() {
         label={t("municipalities.list.dataSelector.label")}
       />
 
-      <div className="mb-4">
+      <div className="mb-4 space-y-4">
         <IndustryFilter
           availableSectors={availableSectors}
           selectedSector={selectedSector}
           onSectorChange={handleSectorChange}
+        />
+        <CountryFilter
+          availableCountries={availableCountries}
+          selectedCountries={selectedCountries}
+          onCountriesChange={handleCountriesChange}
         />
       </div>
 


### PR DESCRIPTION
## Summary
- Add client-side country filtering on Explore (`/explore/companies`) and Companies Overview (`/companies`) using existing `company.tags` from `GET /api/companies/`
- Support multi-select via shared `?countries=` URL param (e.g. `?countries=sweden,finland`)
- Use a hardcoded Nordic allowlist so non-country tags like `csrd`, `public`, and `large-cap` are excluded from filter options

## Test plan
- [ ] Explore: open filter popover, select one or more countries, confirm list updates and chips appear
- [ ] Explore: verify `?countries=finland` in URL filters correctly
- [ ] Overview: toggle country badges (desktop) / checkboxes (mobile), confirm ranked list and KPI panels update
- [ ] Overview + Explore: same `?countries=` param works on both pages
- [ ] Empty country selection shows all companies
- [ ] Countries with no tagged companies do not appear as filter options


Made with [Cursor](https://cursor.com)