### PR TITLE
[feat] Style territory map list on detail pages and improve mobile layout

### DIFF
--- a/src/components/detail/RelatedTerritoriesSection.tsx
+++ b/src/components/detail/RelatedTerritoriesSection.tsx
@@ -81,7 +81,7 @@ export function RelatedTerritoriesSection({
         >
           <div
             className={cn(
-              "grid grid-cols-2 gap-x-3 gap-y-2 content-start",
+              "grid grid-cols-2 gap-2 content-start",
               showPagination && "flex-1 min-h-0",
             )}
           >

--- a/src/components/detail/RelatedTerritoriesSection.tsx
+++ b/src/components/detail/RelatedTerritoriesSection.tsx
@@ -81,7 +81,7 @@ export function RelatedTerritoriesSection({
         >
           <div
             className={cn(
-              "grid grid-cols-2 gap-2 content-start",
+              "grid grid-cols-1 gap-2 content-start md:grid-cols-2",
               showPagination && "flex-1 min-h-0",
             )}
           >

--- a/src/components/detail/TerritoryListRow.tsx
+++ b/src/components/detail/TerritoryListRow.tsx
@@ -38,17 +38,17 @@ export function TerritoryListRow({
         style={{ backgroundColor: territory.fillColor }}
         aria-hidden
       />
-      <div className="min-w-0 flex-1">
+      <div className="flex min-w-0 flex-1 items-center gap-2 md:block">
         <LocalizedLink
           to={getEntityDetailPath(routingEntityType, territory.displayName)}
           aria-label={`${territory.displayName}, ${territory.formattedValue}`}
-          className="block break-words text-sm text-white hover:text-white"
+          className="min-w-0 flex-1 truncate text-sm text-white hover:text-white md:overflow-visible md:whitespace-normal md:break-words"
         >
           {territory.displayName}
         </LocalizedLink>
-        <div className="text-xs tabular-nums text-grey">
+        <span className="shrink-0 text-xs tabular-nums text-grey">
           {territory.formattedValue}
-        </div>
+        </span>
       </div>
     </div>
   );

--- a/src/components/detail/TerritoryListRow.tsx
+++ b/src/components/detail/TerritoryListRow.tsx
@@ -38,18 +38,16 @@ export function TerritoryListRow({
         style={{ backgroundColor: territory.fillColor }}
         aria-hidden
       />
-      <div className="flex min-w-0 flex-1 items-center gap-2 md:block">
-        <LocalizedLink
-          to={getEntityDetailPath(routingEntityType, territory.displayName)}
-          aria-label={`${territory.displayName}, ${territory.formattedValue}`}
-          className="min-w-0 flex-1 truncate text-sm text-white hover:text-white md:overflow-visible md:whitespace-normal md:break-words"
-        >
-          {territory.displayName}
-        </LocalizedLink>
-        <span className="shrink-0 text-xs tabular-nums text-grey">
-          {territory.formattedValue}
-        </span>
-      </div>
+      <LocalizedLink
+        to={getEntityDetailPath(routingEntityType, territory.displayName)}
+        aria-label={`${territory.displayName}, ${territory.formattedValue}`}
+        className="min-w-0 flex-1 truncate text-sm text-white hover:text-white"
+      >
+        {territory.displayName}
+      </LocalizedLink>
+      <span className="shrink-0 text-xs tabular-nums text-grey">
+        {territory.formattedValue}
+      </span>
     </div>
   );
 }

--- a/src/components/detail/TerritoryListRow.tsx
+++ b/src/components/detail/TerritoryListRow.tsx
@@ -18,34 +18,30 @@ export function TerritoryListRow({
 }: TerritoryListRowProps) {
   return (
     <div
-      className="flex min-w-0 items-center gap-2"
+      className={cn(
+        "flex min-w-0 items-center gap-2 rounded-md p-2 transition-colors hover:bg-black-1",
+        isHovered && "bg-black-1",
+      )}
       onMouseEnter={() => onHover(territory.mapName)}
       onMouseLeave={() => onHover(null)}
     >
-      <span
-        className="h-2.5 w-2.5 shrink-0 rounded-sm"
+      <div
+        className="h-3 w-3 shrink-0 rounded"
         style={{ backgroundColor: territory.fillColor }}
         aria-hidden
       />
-      <LocalizedLink
-        to={getEntityDetailPath(routingEntityType, territory.displayName)}
-        aria-label={`${territory.displayName}, ${territory.formattedValue}`}
-        className={cn(
-          "min-w-0 flex-1 truncate text-sm leading-5 text-grey hover:text-white md:text-base",
-          isHovered && "text-white",
-        )}
-      >
-        {territory.displayName}
-      </LocalizedLink>
-      <span
-        className={cn(
-          "shrink-0 text-xs tabular-nums text-grey",
-          isHovered && "text-white",
-        )}
-        aria-hidden
-      >
-        {territory.formattedValue}
-      </span>
+      <div className="min-w-0 flex-1">
+        <LocalizedLink
+          to={getEntityDetailPath(routingEntityType, territory.displayName)}
+          aria-label={`${territory.displayName}, ${territory.formattedValue}`}
+          className="block break-words text-sm text-white hover:text-white"
+        >
+          {territory.displayName}
+        </LocalizedLink>
+        <div className="text-xs tabular-nums text-grey">
+          {territory.formattedValue}
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/components/detail/TerritoryListRow.tsx
+++ b/src/components/detail/TerritoryListRow.tsx
@@ -22,8 +22,16 @@ export function TerritoryListRow({
         "flex min-w-0 items-center gap-2 rounded-md p-2 transition-colors hover:bg-black-1",
         isHovered && "bg-black-1",
       )}
-      onMouseEnter={() => onHover(territory.mapName)}
-      onMouseLeave={() => onHover(null)}
+      onMouseEnter={() => {
+        if (window.matchMedia("(hover: hover)").matches) {
+          onHover(territory.mapName);
+        }
+      }}
+      onMouseLeave={() => {
+        if (window.matchMedia("(hover: hover)").matches) {
+          onHover(null);
+        }
+      }}
     >
       <div
         className="h-3 w-3 shrink-0 rounded"

--- a/src/components/maps/DetailTerritoryMap.tsx
+++ b/src/components/maps/DetailTerritoryMap.tsx
@@ -1,5 +1,10 @@
 import { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
+import { useScreenSize } from "@/hooks/useScreenSize";
+import {
+  DETAIL_MAP_MOBILE_FIT_BOUNDS_PADDING,
+  MAP_FIT_BOUNDS_PADDING,
+} from "./mapConstants";
 import TerritoryMap from "./TerritoryMap";
 
 type DetailTerritoryMapProps = Omit<
@@ -11,11 +16,16 @@ export function DetailTerritoryMap({
   className,
   ...props
 }: DetailTerritoryMapProps) {
+  const { isMobile } = useScreenSize();
+
   return (
     <TerritoryMap
       fitBounds
       showTooltip={false}
       legendPosition="bottom-left"
+      fitBoundsPadding={
+        isMobile ? DETAIL_MAP_MOBILE_FIT_BOUNDS_PADDING : MAP_FIT_BOUNDS_PADDING
+      }
       className={cn("max-w-none", className)}
       {...props}
     />

--- a/src/components/maps/MapContent.tsx
+++ b/src/components/maps/MapContent.tsx
@@ -30,6 +30,7 @@ interface MapContentProps {
   backgroundColor?: string;
   scrollWheelZoom?: boolean;
   fitBounds?: boolean;
+  fitBoundsPadding?: L.FitBoundsOptions["padding"];
 }
 
 function MapContent({
@@ -45,6 +46,7 @@ function MapContent({
   backgroundColor = "var(--black-2)",
   scrollWheelZoom = true,
   fitBounds = false,
+  fitBoundsPadding = MAP_FIT_BOUNDS_PADDING,
 }: MapContentProps) {
   const [isMounted, setIsMounted] = useState(false);
   const mapId = useId();
@@ -96,7 +98,7 @@ function MapContent({
       {fitBounds && (
         <MapInitialBoundsFitter
           bounds={mapBounds}
-          padding={MAP_FIT_BOUNDS_PADDING}
+          padding={fitBoundsPadding}
         />
       )}
       <MapController setPosition={setPosition} />

--- a/src/components/maps/MapContent.tsx
+++ b/src/components/maps/MapContent.tsx
@@ -96,10 +96,7 @@ function MapContent({
         onEachFeature={onEachFeature}
       />
       {fitBounds && (
-        <MapInitialBoundsFitter
-          bounds={mapBounds}
-          padding={fitBoundsPadding}
-        />
+        <MapInitialBoundsFitter bounds={mapBounds} padding={fitBoundsPadding} />
       )}
       <MapController setPosition={setPosition} />
     </MapContainer>

--- a/src/components/maps/MapInitialBoundsFitter.tsx
+++ b/src/components/maps/MapInitialBoundsFitter.tsx
@@ -18,11 +18,13 @@ export function MapInitialBoundsFitter({
 
   useEffect(() => {
     const boundsKey = bounds.toBBoxString();
-    if (lastFittedBoundsKey.current === boundsKey) {
+    const paddingKey = JSON.stringify(padding);
+    const fitKey = `${boundsKey}:${paddingKey}`;
+    if (lastFittedBoundsKey.current === fitKey) {
       return;
     }
 
-    lastFittedBoundsKey.current = boundsKey;
+    lastFittedBoundsKey.current = fitKey;
     fitMapToBounds(map, bounds, padding);
   }, [map, bounds, padding]);
 

--- a/src/components/maps/TerritoryMap.tsx
+++ b/src/components/maps/TerritoryMap.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { FeatureCollection } from "geojson";
+import type L from "leaflet";
 import { cn } from "@/lib/utils";
 import { TERRITORY_MAP_COLORS } from "@/utils/territoryMapUtils";
 import { DataItem, DataKPI, MapEntityType } from "@/types/rankings";
@@ -36,6 +37,7 @@ interface TerritoryMapProps {
   className?: string;
   showTooltip?: boolean;
   fitBounds?: boolean;
+  fitBoundsPadding?: L.FitBoundsOptions["padding"];
   legendPosition?: MapLegendPosition;
   /**
    * Controlled hover state. Must be passed together with `onHoveredAreaChange`;
@@ -61,6 +63,7 @@ function TerritoryMap({
   className,
   showTooltip = true,
   fitBounds = false,
+  fitBoundsPadding,
   legendPosition = "bottom-right",
   hoveredArea: hoveredAreaProp,
   onHoveredAreaChange,
@@ -133,6 +136,7 @@ function TerritoryMap({
         backgroundColor={mapBackgroundColor}
         scrollWheelZoom={scrollWheelZoom}
         fitBounds={fitBounds}
+        fitBoundsPadding={fitBoundsPadding}
       />
       <MapOverlays
         entityType={entityType}

--- a/src/components/maps/mapConstants.ts
+++ b/src/components/maps/mapConstants.ts
@@ -1,1 +1,5 @@
 export const MAP_FIT_BOUNDS_PADDING = [20, 20] as const;
+/** Extra bottom inset on detail maps so fitBounds keeps geography above the mobile legend. */
+export const DETAIL_MAP_MOBILE_FIT_BOUNDS_PADDING = [
+  20, 20, 96, 20,
+] as const;

--- a/src/components/maps/mapConstants.ts
+++ b/src/components/maps/mapConstants.ts
@@ -1,5 +1,3 @@
 export const MAP_FIT_BOUNDS_PADDING = [20, 20] as const;
 /** Extra bottom inset on detail maps so fitBounds keeps geography above the mobile legend. */
-export const DETAIL_MAP_MOBILE_FIT_BOUNDS_PADDING = [
-  20, 20, 96, 20,
-] as const;
+export const DETAIL_MAP_MOBILE_FIT_BOUNDS_PADDING = [20, 20, 96, 20] as const;

--- a/src/hooks/territories/useRelatedTerritoriesSection.ts
+++ b/src/hooks/territories/useRelatedTerritoriesSection.ts
@@ -23,9 +23,18 @@ export function useRelatedTerritoriesSection(
     hoveredMapName,
   );
 
+  const setCurrentPage = useCallback(
+    (page: number) => {
+      setHoveredMapName(null);
+      layout.setCurrentPage(page);
+    },
+    [layout.setCurrentPage],
+  );
+
   return {
     ...mapState,
     ...layout,
+    setCurrentPage,
     hoveredMapName,
     setHoveredMapName,
     isHovered,

--- a/src/hooks/territories/useTerritoryListLayout.ts
+++ b/src/hooks/territories/useTerritoryListLayout.ts
@@ -14,6 +14,9 @@ export const TERRITORY_LIST_PANEL_CLASS =
 export const SIDE_BY_SIDE_MIN_WIDTH = 768;
 
 const LIST_COLUMNS = 2;
+/** Mobile list paginates in pages of this size when item count exceeds the threshold. */
+export const MOBILE_TERRITORY_LIST_PAGE_SIZE = 10;
+export const MOBILE_TERRITORY_LIST_PAGINATION_THRESHOLD = 10;
 /** Matches TerritoryListRow legend-style card row (~52px). */
 const LIST_ROW_HEIGHT = 52;
 /** Matches gap-y-2 between list rows. */
@@ -59,7 +62,10 @@ export function useTerritoryListLayout(
   );
   const [layoutRef, isSideBySide] =
     useContainerQuery<HTMLDivElement>(sideBySideQuery);
-  const shouldPaginateList = isSideBySide && paginationEnabled;
+  const shouldPaginateDesktop = isSideBySide && paginationEnabled;
+  const shouldPaginateMobile =
+    !isSideBySide && itemCount > MOBILE_TERRITORY_LIST_PAGINATION_THRESHOLD;
+  const shouldPaginateList = shouldPaginateDesktop || shouldPaginateMobile;
 
   useEffect(() => {
     setCurrentPage(1);
@@ -68,6 +74,11 @@ export function useTerritoryListLayout(
   useEffect(() => {
     if (!shouldPaginateList) {
       setItemsPerPage(itemCount);
+      return;
+    }
+
+    if (shouldPaginateMobile) {
+      setItemsPerPage(MOBILE_TERRITORY_LIST_PAGE_SIZE);
       return;
     }
 
@@ -84,7 +95,7 @@ export function useTerritoryListLayout(
     observer.observe(panel);
 
     return () => observer.disconnect();
-  }, [itemCount, shouldPaginateList]);
+  }, [itemCount, shouldPaginateList, shouldPaginateMobile]);
 
   const totalPages = Math.max(1, Math.ceil(itemCount / itemsPerPage));
   const currentPageSafe = Math.min(currentPage, totalPages);

--- a/src/hooks/territories/useTerritoryListLayout.ts
+++ b/src/hooks/territories/useTerritoryListLayout.ts
@@ -18,8 +18,8 @@ const LIST_COLUMNS = 2;
 /** Mobile list paginates in pages of this size when item count exceeds the threshold. */
 export const MOBILE_TERRITORY_LIST_PAGE_SIZE = 7;
 export const MOBILE_TERRITORY_LIST_PAGINATION_THRESHOLD = 10;
-/** Matches TerritoryListRow legend-style card row (~52px). */
-const LIST_ROW_HEIGHT = 52;
+/** Matches TerritoryListRow single-line card row (~36px). */
+const LIST_ROW_HEIGHT = 36;
 /** Matches gap-y-2 between list rows. */
 const LIST_ROW_GAP = 8;
 /** Reserved height for MultiPagePagination below the list grid. */

--- a/src/hooks/territories/useTerritoryListLayout.ts
+++ b/src/hooks/territories/useTerritoryListLayout.ts
@@ -14,8 +14,8 @@ export const TERRITORY_LIST_PANEL_CLASS =
 export const SIDE_BY_SIDE_MIN_WIDTH = 768;
 
 const LIST_COLUMNS = 2;
-/** Matches TerritoryListRow text-sm leading-5 row (~28px). */
-const LIST_ROW_HEIGHT = 28;
+/** Matches TerritoryListRow legend-style card row (~52px). */
+const LIST_ROW_HEIGHT = 52;
 /** Matches gap-y-2 between list rows. */
 const LIST_ROW_GAP = 8;
 /** Reserved height for MultiPagePagination below the list grid. */

--- a/src/hooks/territories/useTerritoryListLayout.ts
+++ b/src/hooks/territories/useTerritoryListLayout.ts
@@ -107,11 +107,7 @@ export function useTerritoryListLayout(
   }, [currentPage, currentPageSafe]);
 
   useEffect(() => {
-    if (
-      !shouldPaginateDesktop ||
-      !hoveredMapArea ||
-      itemsPerPage <= 0
-    ) {
+    if (!shouldPaginateDesktop || !hoveredMapArea || itemsPerPage <= 0) {
       return;
     }
 
@@ -122,12 +118,7 @@ export function useTerritoryListLayout(
 
     const targetPage = getTerritoryListPage(index, itemsPerPage);
     setCurrentPage(targetPage);
-  }, [
-    hoveredMapArea,
-    shouldPaginateDesktop,
-    territories,
-    itemsPerPage,
-  ]);
+  }, [hoveredMapArea, shouldPaginateDesktop, territories, itemsPerPage]);
 
   const visibleTerritories = useMemo(() => {
     if (!shouldPaginateList || itemsPerPage <= 0) {

--- a/src/hooks/territories/useTerritoryListLayout.ts
+++ b/src/hooks/territories/useTerritoryListLayout.ts
@@ -7,7 +7,8 @@ import {
 } from "@/utils/territoryMapUtils";
 
 /** Map panel height; keep md: height on TERRITORY_LIST_PANEL_CLASS in sync. */
-export const TERRITORY_PANEL_CLASS = "h-[min(32rem,55vh)] min-h-[20rem]";
+export const TERRITORY_PANEL_CLASS =
+  "h-[min(40rem,72vh)] min-h-[28rem] md:h-[min(32rem,55vh)] md:min-h-[20rem]";
 /** List column uses the same height as the map from the md side-by-side breakpoint. */
 export const TERRITORY_LIST_PANEL_CLASS =
   "flex flex-col min-w-0 md:h-[min(32rem,55vh)] md:min-h-[20rem]";

--- a/src/hooks/territories/useTerritoryListLayout.ts
+++ b/src/hooks/territories/useTerritoryListLayout.ts
@@ -107,7 +107,11 @@ export function useTerritoryListLayout(
   }, [currentPage, currentPageSafe]);
 
   useEffect(() => {
-    if (!shouldPaginateList || !hoveredMapArea || itemsPerPage <= 0) {
+    if (
+      !shouldPaginateDesktop ||
+      !hoveredMapArea ||
+      itemsPerPage <= 0
+    ) {
       return;
     }
 
@@ -117,15 +121,12 @@ export function useTerritoryListLayout(
     }
 
     const targetPage = getTerritoryListPage(index, itemsPerPage);
-    if (targetPage !== currentPageSafe) {
-      setCurrentPage(targetPage);
-    }
+    setCurrentPage(targetPage);
   }, [
     hoveredMapArea,
-    shouldPaginateList,
+    shouldPaginateDesktop,
     territories,
     itemsPerPage,
-    currentPageSafe,
   ]);
 
   const visibleTerritories = useMemo(() => {

--- a/src/hooks/territories/useTerritoryListLayout.ts
+++ b/src/hooks/territories/useTerritoryListLayout.ts
@@ -16,7 +16,7 @@ export const SIDE_BY_SIDE_MIN_WIDTH = 768;
 
 const LIST_COLUMNS = 2;
 /** Mobile list paginates in pages of this size when item count exceeds the threshold. */
-export const MOBILE_TERRITORY_LIST_PAGE_SIZE = 10;
+export const MOBILE_TERRITORY_LIST_PAGE_SIZE = 7;
 export const MOBILE_TERRITORY_LIST_PAGINATION_THRESHOLD = 10;
 /** Matches TerritoryListRow legend-style card row (~52px). */
 const LIST_ROW_HEIGHT = 52;


### PR DESCRIPTION
### ✨ What’s Changed?

Territory map lists on region and nation detail pages have been restyled and made more usable on mobile.

**List styling**
- Legend-style card rows with color dot, name, and KPI value on a single line (mobile and desktop)
- Hover background sync with the map on desktop
- Two-column list grid on desktop; full-width single-column rows on mobile

**Mobile**
- Pagination at 7 items per page when there are more than 10 territories
- Taller map panel with extra fit-bounds bottom padding so geography sits above the color legend
- Fixed pagination getting stuck when a hovered item forced the list back to page 2

**Desktop**
- Height-based pagination updated for shorter single-line rows

### 📸 Screenshots (if applicable)

N/A

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [x] I've set the labels, issue, and milestone for the PR

### 🛠 Related Issue

N/A