### PR TITLE
Remove divider and reduce spacing above data guide

### DIFF
--- a/src/data-guide/SectionWithHelp.tsx
+++ b/src/data-guide/SectionWithHelp.tsx
@@ -32,7 +32,7 @@ export const SectionWithHelp = ({
         {children}
       </div>
       {showDataGuide && (
-        <div className="mt-4 md:mt-8 pt-2 md:pt-8 px-2 md:px-0 border-t border-black-1">
+        <div className="mt-2 md:mt-4 pt-1 md:pt-2 px-2 md:px-0">
           <ProgressiveDataGuide items={helpItems} style="sectionFooter" />
         </div>
       )}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes the top border divider above the "Förstå datan" data guide section and reduces the top margin/padding so it sits closer to the content above.

**Changes:**
- Removed `border-t border-black-1` from the data guide wrapper in `SectionWithHelp`
- Reduced spacing from `mt-4 md:mt-8 pt-2 md:pt-8` to `mt-2 md:mt-4 pt-1 md:pt-2`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ca37828-85cf-436c-8070-2cd22c461006"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ca37828-85cf-436c-8070-2cd22c461006"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

