### PR TITLE
[fix] Remove year selector from company detail page header

### DIFF
--- a/src/components/companies/detail/overview/CompanyOverview.tsx
+++ b/src/components/companies/detail/overview/CompanyOverview.tsx
@@ -2,13 +2,6 @@ import { Pen } from "lucide-react";
 import { type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Text } from "@/components/ui/text";
 import type { CompanyDetails, ReportingPeriod } from "@/types/company";
 import { useAuth } from "@/contexts/AuthContext";
@@ -39,8 +32,6 @@ interface CompanyOverviewProps {
   company: CompanyDetails;
   selectedPeriod: ReportingPeriod;
   previousPeriod?: ReportingPeriod;
-  onYearSelect: (year: string) => void;
-  selectedYear: string;
   yearOverYearChange: number | null;
   headerChip?: ReactNode;
 }
@@ -49,8 +40,6 @@ export function CompanyOverview({
   company,
   selectedPeriod,
   previousPeriod,
-  onYearSelect,
-  selectedYear,
   yearOverYearChange,
   headerChip,
 }: CompanyOverviewProps) {
@@ -146,27 +135,6 @@ export function CompanyOverview({
           <Text variant="body" className="text-sm md:text-base lg:text-lg">
             {sectorName}
           </Text>
-        </div>
-        <div className="my-4 w-full max-w-[180px]">
-          <Select value={selectedYear} onValueChange={onYearSelect}>
-            <SelectTrigger className="w-full bg-black-1 text-white px-3 py-2 rounded-md">
-              <SelectValue placeholder={t("companies.overview.selectYear")} />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="latest">
-                {t("companies.overview.latestYear")}
-              </SelectItem>
-              {sortedPeriods.map((period) => {
-                const year = yearFromIsoDate(period.endDate);
-                return period.emissions?.calculatedTotalEmissions === null ||
-                  period.emissions?.calculatedTotalEmissions === 0 ? null : (
-                  <SelectItem key={year} value={year}>
-                    {year}
-                  </SelectItem>
-                );
-              })}
-            </SelectContent>
-          </Select>
         </div>
       </div>
 

--- a/src/pages/CompanyDetailPage.tsx
+++ b/src/pages/CompanyDetailPage.tsx
@@ -137,8 +137,6 @@ export function CompanyDetailPage() {
           company={company}
           selectedPeriod={selectedPeriod}
           previousPeriod={previousPeriod}
-          onYearSelect={setSelectedYear}
-          selectedYear={selectedYear}
           yearOverYearChange={yearOverYearChange}
           headerChip={comparisonChip}
         />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### ✨ What's Changed?

Removes the year dropdown from the company detail page header (overview section). The overview now always shows data for the latest reporting period by default.

Year selection is still available via the emissions history charts further down the page.

### 📸 Screenshots (if applicable)

N/A

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [ ] I've set the labels, issue, and milestone for the PR

### 🛠 Related Issue

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5a50980-e55d-4eee-8433-41e034c4b596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5a50980-e55d-4eee-8433-41e034c4b596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

