### PR TITLE
[feat] Move sector/industry into company detail fact box

### DIFF
--- a/src/components/companies/detail/overview/CompanyOverview.tsx
+++ b/src/components/companies/detail/overview/CompanyOverview.tsx
@@ -125,17 +125,6 @@ export function CompanyOverview({
           </div>
         )}
         <CompanyDescription description={description} />
-        <div className="flex flex-row items-center gap-2 my-4">
-          <Text
-            variant="body"
-            className="text-grey text-sm md:text-base lg:text-lg"
-          >
-            {t("companies.overview.sector")}:
-          </Text>
-          <Text variant="body" className="text-sm md:text-base lg:text-lg">
-            {sectorName}
-          </Text>
-        </div>
       </div>
 
       <div className="mb-2 md:mb-4 space-y-4 md:space-y-6">
@@ -223,6 +212,7 @@ export function CompanyOverview({
       <OverviewStatistics
         selectedPeriod={selectedPeriod}
         currentLanguage={currentLanguage}
+        sectorName={sectorName}
         formattedEmployeeCount={formattedEmployeeCount}
         turnoverAIGenerated={turnoverAIGenerated}
         employeesAIGenerated={employeesAIGenerated}

--- a/src/components/companies/detail/overview/CompanyOverviewNoData.tsx
+++ b/src/components/companies/detail/overview/CompanyOverviewNoData.tsx
@@ -14,6 +14,10 @@ import { getCompanyDescription } from "@/utils/business/company";
 import { CompanyDescription } from "./CompanyDescription";
 import { PageNoData } from "@/components/pageStates/NoData";
 import { CompanyDetailHeader } from "../CompanyDetailHeader";
+import {
+  SupplementalDataField,
+  SupplementalDataPanel,
+} from "@/components/detail/SupplementalDataPanel";
 
 interface CompanyOverviewNoDataProps {
   company: CompanyDetails;
@@ -57,18 +61,13 @@ export function CompanyOverviewNoData({
           </div>
         )}
         <CompanyDescription description={description} />
-        <div className="my-4 flex flex-row items-center gap-2">
-          <Text
-            variant="body"
-            className="text-grey text-sm md:text-base lg:text-lg"
-          >
-            {t("companies.overview.sector")}:
-          </Text>
-          <Text variant="body" className="text-sm md:text-base lg:text-lg">
-            {sectorName}
-          </Text>
-        </div>
       </div>
+
+      <SupplementalDataPanel>
+        <SupplementalDataField label={t("companies.overview.sector")}>
+          <Text>{sectorName}</Text>
+        </SupplementalDataField>
+      </SupplementalDataPanel>
 
       <div className="py-8">
         <PageNoData

--- a/src/components/companies/detail/overview/OverviewStatistics.tsx
+++ b/src/components/companies/detail/overview/OverviewStatistics.tsx
@@ -58,7 +58,7 @@ export function OverviewStatistics({
       </SupplementalDataField>
 
       {selectedPeriod?.reportURL && (
-        <div className="flex items-end self-start">
+        <div className="flex items-end @lg:self-end">
           <a
             href={selectedPeriod.reportURL}
             target="_blank"

--- a/src/components/companies/detail/overview/OverviewStatistics.tsx
+++ b/src/components/companies/detail/overview/OverviewStatistics.tsx
@@ -12,6 +12,7 @@ import { formatTurnoverValue } from "@/utils/formatting/turnoverFormatting";
 interface OverviewStatisticProps {
   selectedPeriod: ReportingPeriod;
   currentLanguage: "sv" | "en";
+  sectorName: string;
   formattedEmployeeCount: string;
   turnoverAIGenerated: boolean;
   employeesAIGenerated: boolean;
@@ -21,6 +22,7 @@ interface OverviewStatisticProps {
 export function OverviewStatistics({
   selectedPeriod,
   currentLanguage,
+  sectorName,
   formattedEmployeeCount,
   turnoverAIGenerated,
   employeesAIGenerated,
@@ -37,6 +39,10 @@ export function OverviewStatistics({
 
   return (
     <SupplementalDataPanel className={className}>
+      <SupplementalDataField label={t("companies.overview.sector")}>
+        <Text>{sectorName}</Text>
+      </SupplementalDataField>
+
       <SupplementalDataField label={t("companies.overview.turnover")}>
         <span className="flex items-center gap-2">
           <Text>{formattedTurnover}</Text>

--- a/src/components/companies/detail/overview/OverviewStatistics.tsx
+++ b/src/components/companies/detail/overview/OverviewStatistics.tsx
@@ -58,16 +58,18 @@ export function OverviewStatistics({
       </SupplementalDataField>
 
       {selectedPeriod?.reportURL && (
-        <div className="flex items-end @lg:self-end">
-          <a
-            href={selectedPeriod.reportURL}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-2 text-blue-2 hover:text-blue-1 transition-colors"
-          >
-            {t("companies.overview.readAnnualReport")}
-            <ArrowUpRight className="w-4 h-4 sm:w-3 sm:h-3" />
-          </a>
+        <div>
+          <div className="md:mb-2">
+            <a
+              href={selectedPeriod.reportURL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 text-blue-2 hover:text-blue-1 transition-colors"
+            >
+              {t("companies.overview.readAnnualReport")}
+              <ArrowUpRight className="w-4 h-4 sm:w-3 sm:h-3" />
+            </a>
+          </div>
         </div>
       )}
     </SupplementalDataPanel>

--- a/src/components/detail/SupplementalDataPanel.tsx
+++ b/src/components/detail/SupplementalDataPanel.tsx
@@ -14,7 +14,7 @@ export function SupplementalDataPanel({
   return (
     <div className={cn("@container mt-3 md:mt-0", className)}>
       <div className="mt-8 @md:mt-12 bg-black-1 rounded-level-2 p-6">
-        <div className="grid grid-cols-1 @md:grid-cols-3 gap-4 @md:gap-8">
+        <div className="grid grid-cols-1 @md:grid-cols-2 @lg:grid-flow-col @lg:grid-cols-none @lg:auto-cols-fr gap-4 @md:gap-8">
           {children}
         </div>
       </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### ✨ What's Changed?

Sector (Bransch) is no longer shown as inline text below the company description. It now appears in the dark supplemental data panel alongside turnover and employees on company detail pages.

- **`OverviewStatistics`**: Added sector as the first field in the fact box
- **`CompanyOverview`**: Removed the standalone sector row; passes `sectorName` to `OverviewStatistics`
- **`CompanyOverviewNoData`**: Uses the same fact box pattern for sector on pages without emissions data

### 📸 Screenshots (if applicable

N/A — layout change only.

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [ ] I've verified the change runs locally both on mobile and desktop
- [ ] I've set the labels, issue, and milestone for the PR

### 🛠 Related Issue

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6448ad8c-6532-4557-9d1f-f375e2324f1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6448ad8c-6532-4557-9d1f-f375e2324f1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

