### PR TITLE
Link best/worst performers on company overview insights panel

### DIFF
--- a/src/components/companies/rankedList/CompanyInsightsPanel.tsx
+++ b/src/components/companies/rankedList/CompanyInsightsPanel.tsx
@@ -1,5 +1,5 @@
-import { COLORS } from "@/lib/colors";
 import { useTranslation } from "react-i18next";
+import { getCompanyDetailPath } from "@/utils/companyRouting";
 import {
   CompanyWithKPIs,
   CompanyKPIValue,
@@ -83,6 +83,7 @@ function CompanyInsightsPanel({
   const { topPerformer, bottomPerformer } = buildPerformerProps(
     sortedValidData,
     { key: selectedKPI.key, unit, isBoolean: selectedKPI.isBoolean },
+    (company) => getCompanyDetailPath(company),
   );
 
   const colorItem = selectedKPI.createKPIColorGetter

--- a/src/utils/insights/rankedListUtils.ts
+++ b/src/utils/insights/rankedListUtils.ts
@@ -182,11 +182,16 @@ interface PerformerResult {
 export function buildPerformerProps<T extends { name: string }>(
   sortedData: T[],
   kpi: { key: keyof T; unit?: string; isBoolean?: boolean },
-  hrefPrefix?: string,
+  hrefResolver?: string | ((item: T) => string | undefined),
 ): { topPerformer?: PerformerResult; bottomPerformer?: PerformerResult } {
   if (kpi.isBoolean || !sortedData.length) return {};
   const unit = kpi.unit || "";
   const fmt = (item: T) => `${(item[kpi.key] as number)?.toFixed(1)}${unit}`;
+  const getHref = (item: T): string | undefined => {
+    if (!hrefResolver) return undefined;
+    if (typeof hrefResolver === "function") return hrefResolver(item);
+    return `${hrefResolver}/${item.name.toLowerCase()}`;
+  };
   const best = sortedData[0];
   const worst = sortedData[sortedData.length - 1];
   return {
@@ -194,9 +199,7 @@ export function buildPerformerProps<T extends { name: string }>(
       ? {
           name: best.name,
           value: fmt(best),
-          href: hrefPrefix
-            ? `${hrefPrefix}/${best.name.toLowerCase()}`
-            : undefined,
+          href: getHref(best),
         }
       : undefined,
     bottomPerformer:
@@ -204,9 +207,7 @@ export function buildPerformerProps<T extends { name: string }>(
         ? {
             name: worst.name,
             value: fmt(worst),
-            href: hrefPrefix
-              ? `${hrefPrefix}/${worst.name.toLowerCase()}`
-              : undefined,
+            href: getHref(worst),
           }
         : undefined,
   };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On the company overview page, the insights stats panel now shows best and worst performers as clickable links, matching the behavior already used on municipality and region overview pages.

## Changes

- Extended `buildPerformerProps` to accept either a path prefix (for territories) or a custom href resolver function.
- Updated `CompanyInsightsPanel` to pass `getCompanyDetailPath` so best/worst company names link to their detail pages.

## Testing

- `npm test -- --run src/pages/CompaniesOverviewPage.test.tsx`
- `npx tsc --noEmit`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9d7f1588-6d2f-4398-b4eb-517eca8cd7cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d7f1588-6d2f-4398-b4eb-517eca8cd7cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

