### PR TITLE
Replace company emissions change beeswarm with stacked bar histogram

### DIFF
--- a/src/components/companies/rankedList/visualizations/EmissionsChangeVisualization.tsx
+++ b/src/components/companies/rankedList/visualizations/EmissionsChangeVisualization.tsx
@@ -33,8 +33,8 @@ export function EmissionsChangeVisualization({
   }
 
   return (
-    <div className="w-full h-full flex flex-col gap-3">
-      <div className="relative flex-1 bg-black-2 rounded-level-2 p-4 overflow-hidden">
+    <div className="flex h-full min-h-0 w-full flex-col">
+      <div className="relative flex h-full min-h-0 flex-1 overflow-hidden rounded-level-2 bg-black-2 p-4">
         <EmissionsChangeBarChart
           companies={companies}
           onCompanyClick={onCompanyClick}

--- a/src/components/companies/rankedList/visualizations/EmissionsChangeVisualization.tsx
+++ b/src/components/companies/rankedList/visualizations/EmissionsChangeVisualization.tsx
@@ -1,10 +1,8 @@
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import type { CompanyWithKPIs } from "@/types/company";
-import { createSymmetricRangeGradient } from "@/utils/ui/colorGradients";
-import { useBeeswarmData } from "@/hooks/companies/useBeeswarmData";
-import { BeeswarmChart } from "./shared/BeeswarmChart";
-import { getCompanyUrlSegment } from "@/utils/companyRouting";
+import { buildEmissionsChangeHistogram } from "@/utils/visualizations/emissionsChangeHistogram";
+import { EmissionsChangeBarChart } from "./shared/EmissionsChangeBarChart";
 
 interface EmissionsChangeVisualizationProps {
   companies: CompanyWithKPIs[];
@@ -16,33 +14,13 @@ export function EmissionsChangeVisualization({
   onCompanyClick,
 }: EmissionsChangeVisualizationProps) {
   const { t } = useTranslation();
-  const {
-    valid: withData,
-    min,
-    max,
-    colorForValue,
-  } = useBeeswarmData(
-    companies,
-    (c) => c.emissionsChangeFromBaseYear ?? null,
-    (min, max) => (value: number) =>
-      createSymmetricRangeGradient(min, max, value),
+
+  const histogram = useMemo(
+    () => buildEmissionsChangeHistogram(companies),
+    [companies],
   );
 
-  // Calculate ranks: lower is better (negative change is good)
-  const rankMap = useMemo(() => {
-    const sorted = [...withData].sort(
-      (a, b) =>
-        (a.emissionsChangeFromBaseYear ?? 0) -
-        (b.emissionsChangeFromBaseYear ?? 0),
-    );
-    const map = new Map<string, number>();
-    sorted.forEach((company, index) => {
-      map.set(company.id, index + 1);
-    });
-    return map;
-  }, [withData]);
-
-  if (withData.length === 0) {
+  if (!histogram) {
     return (
       <div className="bg-black-2 rounded-level-2 p-8 h-full flex items-center justify-center">
         <p className="text-grey text-lg text-center px-4">
@@ -57,18 +35,9 @@ export function EmissionsChangeVisualization({
   return (
     <div className="w-full h-full flex flex-col gap-3">
       <div className="relative flex-1 bg-black-2 rounded-level-2 p-4 overflow-hidden">
-        <BeeswarmChart
-          data={withData}
-          getValue={(c) => c.emissionsChangeFromBaseYear as number}
-          getCompanyName={(c) => c.name}
-          getCompanyId={(c) => getCompanyUrlSegment(c)}
-          colorForValue={colorForValue}
-          min={min}
-          max={max}
-          unit="%"
+        <EmissionsChangeBarChart
+          companies={companies}
           onCompanyClick={onCompanyClick}
-          getRank={(c) => rankMap.get(c.id) ?? null}
-          totalCount={withData.length}
         />
       </div>
     </div>

--- a/src/components/companies/rankedList/visualizations/shared/EmissionsChangeBarChart.tsx
+++ b/src/components/companies/rankedList/visualizations/shared/EmissionsChangeBarChart.tsx
@@ -11,7 +11,6 @@ import {
   YAxis,
 } from "recharts";
 import type { CompanyWithKPIs } from "@/types/company";
-import { COLORS } from "@/lib/colors";
 import { useLanguage } from "@/components/LanguageProvider";
 import { useScreenSize } from "@/hooks/useScreenSize";
 import { useChartMotion } from "@/hooks/useChartMotion";
@@ -19,10 +18,12 @@ import {
   formatEmissionsAbsolute,
   formatEmissionsAbsoluteCompact,
 } from "@/utils/formatting/localization";
+import { createSymmetricRangeGradient } from "@/utils/ui/colorGradients";
 import {
   buildEmissionsChangeHistogram,
   type EmissionsChangeCompanyEntry,
 } from "@/utils/visualizations/emissionsChangeHistogram";
+import { BeeswarmLegend } from "./BeeswarmLegend";
 
 interface EmissionsChangeBarChartProps {
   companies: CompanyWithKPIs[];
@@ -42,25 +43,34 @@ function formatCompactBinLabel(label: string): string {
   return start.replace("%", "");
 }
 
-function getBinBarColor(binMid: number): string {
-  if (binMid < 0) {
-    return COLORS.blue3;
-  }
-
-  if (binMid > 0) {
-    return COLORS.pink3;
-  }
-
-  return COLORS.blue3;
+function getChangeColor(
+  changePercent: number,
+  minChange: number,
+  maxChange: number,
+): string {
+  return createSymmetricRangeGradient(minChange, maxChange, changePercent);
 }
 
-function getSegmentOpacity(segmentIndex: number, segmentCount: number): number {
-  if (segmentCount <= 1) {
-    return 1;
+function buildLegendGradient(
+  minChange: number,
+  maxChange: number,
+): string | undefined {
+  if (!Number.isFinite(minChange) || !Number.isFinite(maxChange)) {
+    return undefined;
   }
 
-  const minOpacity = 0.5;
-  return minOpacity + (segmentIndex / (segmentCount - 1)) * (1 - minOpacity);
+  if (minChange === maxChange) {
+    return getChangeColor(minChange, minChange, maxChange);
+  }
+
+  const steps = 5;
+  const stops = Array.from({ length: steps }, (_, index) => {
+    const percent = (index / (steps - 1)) * 100;
+    const value = minChange + ((maxChange - minChange) * index) / (steps - 1);
+    return `${getChangeColor(value, minChange, maxChange)} ${percent}%`;
+  });
+
+  return `linear-gradient(to right, ${stops.join(", ")})`;
 }
 
 function ChartTooltip({
@@ -185,6 +195,26 @@ export function EmissionsChangeBarChart({
     return { chartData, stackCompanies, companyEntryById: entries };
   }, [histogram]);
 
+  const changeRange = useMemo(() => {
+    const values = Array.from(companyEntryById.values()).map(
+      (company) => company.changePercent,
+    );
+
+    if (values.length === 0) {
+      return { min: 0, max: 0 };
+    }
+
+    return {
+      min: Math.min(...values),
+      max: Math.max(...values),
+    };
+  }, [companyEntryById]);
+
+  const legendGradient = useMemo(
+    () => buildLegendGradient(changeRange.min, changeRange.max),
+    [changeRange.max, changeRange.min],
+  );
+
   const handleCompanyClick = useCallback(
     (companyId: string) => {
       const company = companySourceById.get(companyId);
@@ -283,20 +313,19 @@ export function EmissionsChangeBarChart({
                   const companiesInBin = bin.companies.filter(
                     (entry) => entry.emissions > 0,
                   );
-                  const segmentIndex = companiesInBin.findIndex(
-                    (entry) => entry.id === company.id,
+                  const color = getChangeColor(
+                    company.changePercent,
+                    changeRange.min,
+                    changeRange.max,
                   );
-                  const color = getBinBarColor(row.binMid as number);
-                  const opacity = getSegmentOpacity(
-                    segmentIndex,
-                    companiesInBin.length,
-                  );
+                  const hasMultipleCompanies = companiesInBin.length > 1;
 
                   return (
                     <Cell
                       key={`${company.id}-${binIndex}`}
                       fill={color}
-                      fillOpacity={opacity}
+                      stroke={hasMultipleCompanies ? "var(--black-1)" : "none"}
+                      strokeWidth={hasMultipleCompanies ? 1.5 : 0}
                       cursor="pointer"
                       onClick={() => handleCompanyClick(company.id)}
                     />
@@ -308,29 +337,18 @@ export function EmissionsChangeBarChart({
         </ResponsiveContainer>
       </div>
 
-      <div className="flex shrink-0 flex-wrap items-center justify-between gap-3 px-1">
-        <div className="flex items-center gap-2">
-          <span
-            className="inline-block h-3 w-3 shrink-0 rounded-sm"
-            style={{ backgroundColor: COLORS.blue3 }}
-          />
-          <span className="text-xs text-white/40">
-            {t(
-              "companiesOverviewPage.visualizations.emissionsChange.legend.reduction",
-            )}
-          </span>
-        </div>
-        <div className="flex items-center gap-2">
-          <span
-            className="inline-block h-3 w-3 shrink-0 rounded-sm"
-            style={{ backgroundColor: COLORS.pink3 }}
-          />
-          <span className="text-xs text-white/40">
-            {t(
-              "companiesOverviewPage.visualizations.emissionsChange.legend.increase",
-            )}
-          </span>
-        </div>
+      <div className="flex shrink-0 flex-col items-center gap-2 px-1">
+        <BeeswarmLegend
+          min={changeRange.min}
+          max={changeRange.max}
+          unit="%"
+          gradientBackground={legendGradient}
+        />
+        <p className="text-center text-xs text-white/40">
+          {t(
+            "companiesOverviewPage.visualizations.emissionsChange.legend.companyDivider",
+          )}
+        </p>
       </div>
 
       {isMobile && mobileSelectedCompanyId && (

--- a/src/components/companies/rankedList/visualizations/shared/EmissionsChangeBarChart.tsx
+++ b/src/components/companies/rankedList/visualizations/shared/EmissionsChangeBarChart.tsx
@@ -1,16 +1,7 @@
 import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import {
-  Bar,
-  BarChart,
-  CartesianGrid,
-  Cell,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from "recharts";
 import type { CompanyWithKPIs } from "@/types/company";
+import { COLORS } from "@/lib/colors";
 import { useLanguage } from "@/components/LanguageProvider";
 import { useScreenSize } from "@/hooks/useScreenSize";
 import { useChartMotion } from "@/hooks/useChartMotion";
@@ -22,20 +13,16 @@ import { createSymmetricRangeGradient } from "@/utils/ui/colorGradients";
 import {
   buildEmissionsChangeHistogram,
   type EmissionsChangeCompanyEntry,
+  type EmissionsChangeHistogramBin,
 } from "@/utils/visualizations/emissionsChangeHistogram";
 import { BeeswarmLegend } from "./BeeswarmLegend";
+
+const SEGMENT_RADIUS = 6;
+const Y_AXIS_WIDTH = 56;
 
 interface EmissionsChangeBarChartProps {
   companies: CompanyWithKPIs[];
   onCompanyClick?: (company: CompanyWithKPIs) => void;
-}
-
-interface ChartRow {
-  label: string;
-  fullLabel: string;
-  totalEmissions: number;
-  binMid: number;
-  [companyId: string]: number | string;
 }
 
 function formatCompactBinLabel(label: string): string {
@@ -73,58 +60,14 @@ function buildLegendGradient(
   return `linear-gradient(to right, ${stops.join(", ")})`;
 }
 
-function ChartTooltip({
-  active,
-  payload,
-  label,
-  companyById,
-  currentLanguage,
-  t,
-}: {
-  active?: boolean;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  payload?: any[];
-  label?: string;
-  companyById: Map<string, EmissionsChangeCompanyEntry>;
-  currentLanguage: ReturnType<typeof useLanguage>["currentLanguage"];
-  t: ReturnType<typeof useTranslation>["t"];
-}) {
-  if (!active || !payload?.length) {
-    return null;
+function buildYAxisTicks(maxValue: number, tickCount = 4): number[] {
+  if (maxValue <= 0) {
+    return [0];
   }
 
-  const activeSegment = [...payload]
-    .reverse()
-    .find((item) => typeof item.value === "number" && item.value > 0);
-
-  if (!activeSegment) {
-    return null;
-  }
-
-  const company = companyById.get(String(activeSegment.dataKey));
-  if (!company) {
-    return null;
-  }
-
-  return (
-    <div className="rounded-level-1 border border-white/10 bg-black-1 px-3 py-2 text-xs text-white shadow-xl">
-      <p className="font-medium">{company.name}</p>
-      <p className="text-grey">{label}</p>
-      <p className="text-grey">
-        {t(
-          "companiesOverviewPage.visualizations.emissionsChange.tooltip.change",
-          { value: company.changePercent.toFixed(1) },
-        )}
-      </p>
-      <p className="text-grey">
-        {t(
-          "companiesOverviewPage.visualizations.emissionsChange.tooltip.emissions",
-          {
-            value: formatEmissionsAbsolute(company.emissions, currentLanguage),
-          },
-        )}
-      </p>
-    </div>
+  const step = maxValue / tickCount;
+  return Array.from({ length: tickCount + 1 }, (_, index) =>
+    Math.round(index * step),
   );
 }
 
@@ -135,10 +78,15 @@ export function EmissionsChangeBarChart({
   const { t } = useTranslation();
   const { currentLanguage } = useLanguage();
   const { isMobile } = useScreenSize();
-  const { reduceMotion, barDuration } = useChartMotion();
-  const [mobileSelectedCompanyId, setMobileSelectedCompanyId] = useState<
-    string | null
-  >(null);
+  const { reduceMotion } = useChartMotion();
+  const [activeCompanyId, setActiveCompanyId] = useState<string | null>(null);
+  const [hoveredCompanyId, setHoveredCompanyId] = useState<string | null>(null);
+  const [tooltip, setTooltip] = useState<{
+    company: EmissionsChangeCompanyEntry;
+    binLabel: string;
+    x: number;
+    y: number;
+  } | null>(null);
 
   const histogram = useMemo(
     () => buildEmissionsChangeHistogram(companies),
@@ -153,12 +101,12 @@ export function EmissionsChangeBarChart({
     return map;
   }, [companies]);
 
-  const { chartData, stackCompanies, companyEntryById } = useMemo(() => {
+  const { bins, companyEntryById, changeRange } = useMemo(() => {
     if (!histogram) {
       return {
-        chartData: [] as ChartRow[],
-        stackCompanies: [] as EmissionsChangeCompanyEntry[],
+        bins: [] as EmissionsChangeHistogramBin[],
         companyEntryById: new Map<string, EmissionsChangeCompanyEntry>(),
+        changeRange: { min: 0, max: 0 },
       };
     }
 
@@ -169,194 +117,283 @@ export function EmissionsChangeBarChart({
       });
     });
 
-    const stackCompanies = Array.from(entries.values()).sort(
-      (a, b) => a.emissions - b.emissions,
-    );
-
-    const chartData = histogram.bins.map((bin) => {
-      const row: ChartRow = {
-        label: formatCompactBinLabel(bin.label),
-        fullLabel: bin.label,
-        totalEmissions: bin.totalEmissions,
-        binMid: (bin.min + bin.max) / 2,
-      };
-
-      stackCompanies.forEach((company) => {
-        row[company.id] = 0;
-      });
-
-      bin.companies.forEach((company) => {
-        row[company.id] = company.emissions;
-      });
-
-      return row;
-    });
-
-    return { chartData, stackCompanies, companyEntryById: entries };
-  }, [histogram]);
-
-  const changeRange = useMemo(() => {
-    const values = Array.from(companyEntryById.values()).map(
+    const values = Array.from(entries.values()).map(
       (company) => company.changePercent,
     );
 
-    if (values.length === 0) {
-      return { min: 0, max: 0 };
-    }
-
     return {
-      min: Math.min(...values),
-      max: Math.max(...values),
+      bins: histogram.bins,
+      companyEntryById: entries,
+      changeRange: {
+        min: values.length ? Math.min(...values) : 0,
+        max: values.length ? Math.max(...values) : 0,
+      },
     };
-  }, [companyEntryById]);
+  }, [histogram]);
 
   const legendGradient = useMemo(
     () => buildLegendGradient(changeRange.min, changeRange.max),
     [changeRange.max, changeRange.min],
   );
 
-  const handleCompanyClick = useCallback(
-    (companyId: string) => {
-      const company = companySourceById.get(companyId);
-      if (!company) {
-        return;
-      }
+  const maxTotalEmissions = histogram?.maxTotalEmissions ?? 0;
 
-      if (isMobile) {
-        if (mobileSelectedCompanyId === companyId) {
-          onCompanyClick?.(company);
-          setMobileSelectedCompanyId(null);
-          return;
-        }
-
-        setMobileSelectedCompanyId(companyId);
-        return;
-      }
-
-      onCompanyClick?.(company);
-    },
-    [companySourceById, isMobile, mobileSelectedCompanyId, onCompanyClick],
+  const yAxisTicks = useMemo(
+    () => buildYAxisTicks(maxTotalEmissions),
+    [maxTotalEmissions],
   );
 
-  if (!histogram || histogram.bins.length === 0) {
+  const highlightedCompanyId = hoveredCompanyId ?? activeCompanyId;
+
+  const handleSegmentClick = useCallback(
+    (companyId: string) => {
+      if (isMobile) {
+        setActiveCompanyId((current) =>
+          current === companyId ? null : companyId,
+        );
+        return;
+      }
+
+      const company = companySourceById.get(companyId);
+      if (company) {
+        onCompanyClick?.(company);
+      }
+    },
+    [companySourceById, isMobile, onCompanyClick],
+  );
+
+  const handleSegmentPointerEnter = useCallback(
+    (
+      event: React.MouseEvent,
+      company: EmissionsChangeCompanyEntry,
+      binLabel: string,
+    ) => {
+      setHoveredCompanyId(company.id);
+      setTooltip({
+        company,
+        binLabel,
+        x: event.clientX,
+        y: event.clientY,
+      });
+    },
+    [],
+  );
+
+  const handleSegmentPointerMove = useCallback(
+    (
+      event: React.MouseEvent,
+      company: EmissionsChangeCompanyEntry,
+      binLabel: string,
+    ) => {
+      setTooltip({
+        company,
+        binLabel,
+        x: event.clientX,
+        y: event.clientY,
+      });
+    },
+    [],
+  );
+
+  const handleSegmentPointerLeave = useCallback(() => {
+    setHoveredCompanyId(null);
+    setTooltip(null);
+  }, []);
+
+  if (!histogram || bins.length === 0) {
     return null;
   }
 
-  const maxTotalEmissions = histogram.maxTotalEmissions;
-
   return (
-    <div className="relative flex h-full min-h-0 w-full flex-col gap-3">
-      <div className="min-h-0 flex-1">
-        <ResponsiveContainer width="100%" height="100%">
-          <BarChart
-            data={chartData}
-            margin={{ top: 16, right: 4, bottom: 4, left: 0 }}
-          >
-            <CartesianGrid
-              stroke="var(--black-4)"
-              strokeDasharray="3 3"
-              vertical={false}
-            />
-            <XAxis
-              dataKey="label"
-              tick={{ fontSize: 11, fill: "rgba(255,255,255,0.45)" }}
-              tickLine={false}
-              axisLine={false}
-              interval="preserveStartEnd"
-            />
-            <YAxis
-              tick={{ fontSize: 11, fill: "rgba(255,255,255,0.45)" }}
-              tickLine={false}
-              axisLine={false}
-              width={48}
-              tickFormatter={(value) =>
-                formatEmissionsAbsoluteCompact(value, currentLanguage)
-              }
-              domain={[0, maxTotalEmissions]}
-            />
-            <Tooltip
-              cursor={{ fill: "rgba(255,255,255,0.05)" }}
-              content={(props) => (
-                <ChartTooltip
-                  {...props}
-                  companyById={companyEntryById}
-                  currentLanguage={currentLanguage}
-                  t={t}
-                />
+    <div className="relative flex h-full min-h-[400px] w-full flex-col">
+      <div className="relative min-h-[320px] flex-1 border-b border-t border-black-4">
+        <div className="absolute inset-x-0 bottom-8 top-4 flex">
+          <div className="relative shrink-0" style={{ width: Y_AXIS_WIDTH }}>
+            {yAxisTicks
+              .slice()
+              .reverse()
+              .map((tick) => (
+                <span
+                  key={tick}
+                  className="absolute right-2 -translate-y-1/2 text-[11px] text-white/45"
+                  style={{
+                    bottom: `${
+                      maxTotalEmissions > 0
+                        ? (tick / maxTotalEmissions) * 100
+                        : 0
+                    }%`,
+                  }}
+                >
+                  {formatEmissionsAbsoluteCompact(tick, currentLanguage)}
+                </span>
+              ))}
+          </div>
+
+          <div className="flex min-w-0 flex-1 items-end gap-1 px-2">
+            {bins.map((bin) => {
+              const barHeightPercent =
+                maxTotalEmissions > 0
+                  ? (bin.totalEmissions / maxTotalEmissions) * 100
+                  : 0;
+
+              return (
+                <div
+                  key={bin.id}
+                  className="flex h-full min-w-0 flex-1 flex-col items-center justify-end"
+                >
+                  <div
+                    className="flex w-full max-w-[32px] flex-col gap-px overflow-hidden rounded-md"
+                    style={{
+                      height: `${barHeightPercent}%`,
+                      backgroundColor: COLORS.black2,
+                      transition: reduceMotion ? undefined : "height 0.5s ease-out",
+                    }}
+                  >
+                    {bin.companies.map((company) => {
+                      const isHighlighted = highlightedCompanyId === company.id;
+                      const isDimmed =
+                        highlightedCompanyId != null &&
+                        highlightedCompanyId !== company.id;
+
+                      return (
+                        <button
+                          key={company.id}
+                          type="button"
+                          className="w-full min-h-[1px] cursor-pointer border-0 p-0"
+                          style={{
+                            flex: `${company.emissions} 1 0`,
+                            backgroundColor: getChangeColor(
+                              company.changePercent,
+                              changeRange.min,
+                              changeRange.max,
+                            ),
+                            borderRadius: SEGMENT_RADIUS,
+                            opacity: isDimmed ? 0.45 : 1,
+                            boxShadow: isHighlighted
+                              ? "inset 0 0 0 2px rgba(255,255,255,0.9)"
+                              : undefined,
+                          }}
+                          aria-label={company.name}
+                          onClick={() => handleSegmentClick(company.id)}
+                          onMouseEnter={(event) =>
+                            handleSegmentPointerEnter(
+                              event,
+                              company,
+                              bin.label,
+                            )
+                          }
+                          onMouseMove={(event) =>
+                            handleSegmentPointerMove(event, company, bin.label)
+                          }
+                          onMouseLeave={handleSegmentPointerLeave}
+                        />
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="absolute inset-x-0 bottom-1 flex gap-1 px-2">
+          {bins.map((bin) => (
+            <span
+              key={`${bin.id}-label`}
+              className="min-w-0 flex-1 truncate text-center text-[11px] text-white/45"
+              title={bin.label}
+            >
+              {formatCompactBinLabel(bin.label)}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {tooltip && !isMobile && (
+        <div
+          className="pointer-events-none fixed z-50 -translate-x-1/2 -translate-y-full rounded-2xl bg-black/40 p-4 text-white backdrop-blur-sm"
+          style={{
+            left: tooltip.x,
+            top: tooltip.y - 12,
+          }}
+        >
+          <p className="text-xl font-medium">{tooltip.company.name}</p>
+          <div className="mt-2 space-y-1">
+            <p className="text-sm text-white/50">{tooltip.binLabel}</p>
+            <p className="text-white/70">
+              <span className="text-orange-2">
+                {formatEmissionsAbsolute(
+                  tooltip.company.emissions,
+                  currentLanguage,
+                )}{" "}
+                tCO2e
+              </span>
+            </p>
+            <p className="text-sm text-white/50">
+              {t(
+                "companiesOverviewPage.visualizations.emissionsChange.tooltip.change",
+                { value: tooltip.company.changePercent.toFixed(1) },
               )}
-            />
-            {stackCompanies.map((company, stackIndex) => (
-              <Bar
-                key={company.id}
-                dataKey={company.id}
-                stackId="emissions"
-                maxBarSize={32}
-                radius={
-                  stackIndex === stackCompanies.length - 1
-                    ? [3, 3, 0, 0]
-                    : [0, 0, 0, 0]
-                }
-                isAnimationActive={!reduceMotion}
-                animationBegin={0}
-                animationDuration={reduceMotion ? 0 : barDuration * 1000}
-                animationEasing="ease-out"
-              >
-                {chartData.map((row, binIndex) => {
-                  const value = row[company.id];
-                  if (typeof value !== "number" || value <= 0) {
-                    return (
-                      <Cell key={`${company.id}-${binIndex}`} fill="none" />
-                    );
-                  }
+            </p>
+          </div>
+        </div>
+      )}
 
-                  const bin = histogram.bins[binIndex];
-                  const companiesInBin = bin.companies.filter(
-                    (entry) => entry.emissions > 0,
-                  );
-                  const color = getChangeColor(
-                    company.changePercent,
-                    changeRange.min,
-                    changeRange.max,
-                  );
-                  const hasMultipleCompanies = companiesInBin.length > 1;
+      <div className="mt-6 flex flex-col gap-3">
+        <div className="flex flex-col items-center gap-3 md:flex-row md:items-center md:justify-between">
+          <BeeswarmLegend
+            min={changeRange.min}
+            max={changeRange.max}
+            unit="%"
+            gradientBackground={legendGradient}
+          />
+          <span className="px-1 text-xs text-grey">
+            {t(
+              "companiesOverviewPage.visualizations.emissionsChange.companiesCount",
+              { count: companyEntryById.size },
+            )}
+          </span>
+        </div>
 
-                  return (
-                    <Cell
-                      key={`${company.id}-${binIndex}`}
-                      fill={color}
-                      stroke={hasMultipleCompanies ? "var(--black-1)" : "none"}
-                      strokeWidth={hasMultipleCompanies ? 1.5 : 0}
-                      cursor="pointer"
-                      onClick={() => handleCompanyClick(company.id)}
-                    />
-                  );
-                })}
-              </Bar>
-            ))}
-          </BarChart>
-        </ResponsiveContainer>
-      </div>
-
-      <div className="flex shrink-0 flex-col items-center gap-2 px-1">
-        <BeeswarmLegend
-          min={changeRange.min}
-          max={changeRange.max}
-          unit="%"
-          gradientBackground={legendGradient}
-        />
-        <p className="text-center text-xs text-white/40">
+        <p className="px-1 text-center text-xs text-white/40 md:text-left">
           {t(
-            "companiesOverviewPage.visualizations.emissionsChange.legend.companyDivider",
+            "companiesOverviewPage.visualizations.emissionsChange.segmentHint",
           )}
         </p>
       </div>
 
-      {isMobile && mobileSelectedCompanyId && (
-        <p className="shrink-0 px-1 text-xs text-white/50">
-          {t(
-            "companiesOverviewPage.visualizations.emissionsChange.tooltip.tapAgain",
-          )}
-        </p>
+      {isMobile && activeCompanyId && companyEntryById.has(activeCompanyId) && (
+        <button
+          type="button"
+          className="mt-3 w-full rounded-level-2 bg-black-1 px-4 py-3 text-left text-sm text-white transition-colors hover:bg-white/5"
+          onClick={() => {
+            const company = companySourceById.get(activeCompanyId);
+            if (company) {
+              onCompanyClick?.(company);
+            }
+          }}
+        >
+          <span className="font-medium">
+            {companyEntryById.get(activeCompanyId)!.name}
+          </span>
+          <span className="mt-1 block text-orange-2">
+            {formatEmissionsAbsolute(
+              companyEntryById.get(activeCompanyId)!.emissions,
+              currentLanguage,
+            )}{" "}
+            tCO2e
+          </span>
+          <span className="mt-1 block text-sm text-white/50">
+            {t(
+              "companiesOverviewPage.visualizations.emissionsChange.tooltip.change",
+              {
+                value: companyEntryById
+                  .get(activeCompanyId)!
+                  .changePercent.toFixed(1),
+              },
+            )}
+          </span>
+        </button>
       )}
     </div>
   );

--- a/src/components/companies/rankedList/visualizations/shared/EmissionsChangeBarChart.tsx
+++ b/src/components/companies/rankedList/visualizations/shared/EmissionsChangeBarChart.tsx
@@ -1,7 +1,17 @@
 import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
 import type { CompanyWithKPIs } from "@/types/company";
-import { getCompanyColors } from "@/lib/constants/companyColors";
+import { COLORS } from "@/lib/colors";
 import { useLanguage } from "@/components/LanguageProvider";
 import { useScreenSize } from "@/hooks/useScreenSize";
 import { useChartMotion } from "@/hooks/useChartMotion";
@@ -9,11 +19,9 @@ import {
   formatEmissionsAbsolute,
   formatEmissionsAbsoluteCompact,
 } from "@/utils/formatting/localization";
-import { createSymmetricRangeGradient } from "@/utils/ui/colorGradients";
 import {
   buildEmissionsChangeHistogram,
   type EmissionsChangeCompanyEntry,
-  type EmissionsChangeHistogramBin,
 } from "@/utils/visualizations/emissionsChangeHistogram";
 
 interface EmissionsChangeBarChartProps {
@@ -21,47 +29,96 @@ interface EmissionsChangeBarChartProps {
   onCompanyClick?: (company: CompanyWithKPIs) => void;
 }
 
-interface TooltipState {
-  company: EmissionsChangeCompanyEntry;
-  position: { x: number; y: number };
-}
-
-function getYAxisTicks(maxValue: number): number[] {
-  if (maxValue <= 0) {
-    return [0];
-  }
-
-  const roughStep = maxValue / 4;
-  const magnitude = Math.pow(10, Math.floor(Math.log10(roughStep)));
-  const normalized = roughStep / magnitude;
-  const niceNormalized =
-    normalized <= 1 ? 1 : normalized <= 2 ? 2 : normalized <= 5 ? 5 : 10;
-  const step = niceNormalized * magnitude;
-  const ticks: number[] = [];
-
-  for (let value = 0; value <= maxValue; value += step) {
-    ticks.push(Math.round(value));
-  }
-
-  if (ticks[ticks.length - 1] < maxValue) {
-    ticks.push(Math.round(maxValue));
-  }
-
-  return ticks;
-}
-
-function getBinColor(
-  bin: EmissionsChangeHistogramBin,
-  minChange: number,
-  maxChange: number,
-): string {
-  const midpoint = (bin.min + bin.max) / 2;
-  return createSymmetricRangeGradient(minChange, maxChange, midpoint);
+interface ChartRow {
+  label: string;
+  fullLabel: string;
+  totalEmissions: number;
+  binMid: number;
+  [companyId: string]: number | string;
 }
 
 function formatCompactBinLabel(label: string): string {
   const [start] = label.split("–");
   return start.replace("%", "");
+}
+
+function getBinBarColor(binMid: number): string {
+  if (binMid < 0) {
+    return COLORS.blue3;
+  }
+
+  if (binMid > 0) {
+    return COLORS.pink3;
+  }
+
+  return COLORS.blue3;
+}
+
+function getSegmentOpacity(segmentIndex: number, segmentCount: number): number {
+  if (segmentCount <= 1) {
+    return 1;
+  }
+
+  const minOpacity = 0.5;
+  return minOpacity + (segmentIndex / (segmentCount - 1)) * (1 - minOpacity);
+}
+
+function ChartTooltip({
+  active,
+  payload,
+  label,
+  companyById,
+  currentLanguage,
+  t,
+}: {
+  active?: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  payload?: any[];
+  label?: string;
+  companyById: Map<string, EmissionsChangeCompanyEntry>;
+  currentLanguage: ReturnType<typeof useLanguage>["currentLanguage"];
+  t: ReturnType<typeof useTranslation>["t"];
+}) {
+  if (!active || !payload?.length) {
+    return null;
+  }
+
+  const activeSegment = [...payload]
+    .reverse()
+    .find((item) => typeof item.value === "number" && item.value > 0);
+
+  if (!activeSegment) {
+    return null;
+  }
+
+  const company = companyById.get(String(activeSegment.dataKey));
+  if (!company) {
+    return null;
+  }
+
+  return (
+    <div className="rounded-level-1 border border-white/10 bg-black-1 px-3 py-2 text-xs text-white shadow-xl">
+      <p className="font-medium">{company.name}</p>
+      <p className="text-grey">{label}</p>
+      <p className="text-grey">
+        {t(
+          "companiesOverviewPage.visualizations.emissionsChange.tooltip.change",
+          { value: company.changePercent.toFixed(1) },
+        )}
+      </p>
+      <p className="text-grey">
+        {t(
+          "companiesOverviewPage.visualizations.emissionsChange.tooltip.emissions",
+          {
+            value: formatEmissionsAbsolute(
+              company.emissions,
+              currentLanguage,
+            ),
+          },
+        )}
+      </p>
+    </div>
+  );
 }
 
 export function EmissionsChangeBarChart({
@@ -72,8 +129,6 @@ export function EmissionsChangeBarChart({
   const { currentLanguage } = useLanguage();
   const { isMobile } = useScreenSize();
   const { reduceMotion, barDuration } = useChartMotion();
-  const [tooltip, setTooltip] = useState<TooltipState | null>(null);
-  const [mobileTooltipOpen, setMobileTooltipOpen] = useState(false);
   const [mobileSelectedCompanyId, setMobileSelectedCompanyId] = useState<
     string | null
   >(null);
@@ -83,7 +138,7 @@ export function EmissionsChangeBarChart({
     [companies],
   );
 
-  const companyById = useMemo(() => {
+  const companySourceById = useMemo(() => {
     const map = new Map<string, CompanyWithKPIs>();
     companies.forEach((company) => {
       map.set(company.id, company);
@@ -91,209 +146,176 @@ export function EmissionsChangeBarChart({
     return map;
   }, [companies]);
 
-  const changeRange = useMemo(() => {
+  const { chartData, stackCompanies, companyEntryById } = useMemo(() => {
     if (!histogram) {
-      return { min: 0, max: 0 };
+      return {
+        chartData: [] as ChartRow[],
+        stackCompanies: [] as EmissionsChangeCompanyEntry[],
+        companyEntryById: new Map<string, EmissionsChangeCompanyEntry>(),
+      };
     }
 
-    const values = histogram.bins.flatMap((bin) =>
-      bin.companies.map((company) => company.changePercent),
+    const entries = new Map<string, EmissionsChangeCompanyEntry>();
+    histogram.bins.forEach((bin) => {
+      bin.companies.forEach((company) => {
+        entries.set(company.id, company);
+      });
+    });
+
+    const stackCompanies = Array.from(entries.values()).sort(
+      (a, b) => a.emissions - b.emissions,
     );
 
-    return {
-      min: Math.min(...values),
-      max: Math.max(...values),
-    };
+    const chartData = histogram.bins.map((bin) => {
+      const row: ChartRow = {
+        label: formatCompactBinLabel(bin.label),
+        fullLabel: bin.label,
+        totalEmissions: bin.totalEmissions,
+        binMid: (bin.min + bin.max) / 2,
+      };
+
+      stackCompanies.forEach((company) => {
+        row[company.id] = 0;
+      });
+
+      bin.companies.forEach((company) => {
+        row[company.id] = company.emissions;
+      });
+
+      return row;
+    });
+
+    return { chartData, stackCompanies, companyEntryById: entries };
   }, [histogram]);
 
-  const yTicks = useMemo(
-    () => (histogram ? getYAxisTicks(histogram.maxTotalEmissions) : [0]),
-    [histogram],
-  );
+  const handleCompanyClick = useCallback(
+    (companyId: string) => {
+      const company = companySourceById.get(companyId);
+      if (!company) {
+        return;
+      }
 
-  const handleSegmentInteraction = useCallback(
-    (
-      company: EmissionsChangeCompanyEntry,
-      event: React.MouseEvent<HTMLDivElement>,
-    ) => {
       if (isMobile) {
-        if (mobileTooltipOpen && mobileSelectedCompanyId === company.id) {
-          const sourceCompany = companyById.get(company.id);
-          if (sourceCompany) {
-            onCompanyClick?.(sourceCompany);
-          }
-          setMobileTooltipOpen(false);
+        if (mobileSelectedCompanyId === companyId) {
+          onCompanyClick?.(company);
           setMobileSelectedCompanyId(null);
-          setTooltip(null);
           return;
         }
 
-        setMobileTooltipOpen(true);
-        setMobileSelectedCompanyId(company.id);
-        setTooltip({
-          company,
-          position: { x: event.clientX, y: event.clientY },
-        });
+        setMobileSelectedCompanyId(companyId);
         return;
       }
 
-      const sourceCompany = companyById.get(company.id);
-      if (sourceCompany) {
-        onCompanyClick?.(sourceCompany);
-      }
+      onCompanyClick?.(company);
     },
-    [
-      companyById,
-      isMobile,
-      mobileSelectedCompanyId,
-      mobileTooltipOpen,
-      onCompanyClick,
-    ],
-  );
-
-  const handleSegmentHover = useCallback(
-    (company: EmissionsChangeCompanyEntry, event: React.MouseEvent) => {
-      if (isMobile) {
-        return;
-      }
-
-      setTooltip({
-        company,
-        position: { x: event.clientX, y: event.clientY },
-      });
-    },
-    [isMobile],
+    [companySourceById, isMobile, mobileSelectedCompanyId, onCompanyClick],
   );
 
   if (!histogram || histogram.bins.length === 0) {
     return null;
   }
 
+  const maxTotalEmissions = histogram.maxTotalEmissions;
+
   return (
-    <div
-      className="relative flex h-full min-h-0 w-full flex-col gap-3"
-      onClick={() => {
-        if (isMobile && mobileTooltipOpen) {
-          setMobileTooltipOpen(false);
-          setMobileSelectedCompanyId(null);
-          setTooltip(null);
-        }
-      }}
-    >
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-        <div className="flex h-full min-h-0 w-full min-w-0 flex-1 gap-2 overflow-hidden">
-          <div className="flex h-full w-12 shrink-0 flex-col justify-between py-0 text-right text-[10px] text-grey">
-            {[...yTicks].reverse().map((tick) => (
-              <span key={tick}>
-                {formatEmissionsAbsoluteCompact(tick, currentLanguage)}
-              </span>
+    <div className="relative flex h-full min-h-0 w-full flex-col gap-3">
+      <div className="min-h-0 flex-1">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart
+            data={chartData}
+            margin={{ top: 16, right: 4, bottom: 4, left: 0 }}
+          >
+            <CartesianGrid
+              stroke="var(--black-4)"
+              strokeDasharray="3 3"
+              vertical={false}
+            />
+            <XAxis
+              dataKey="label"
+              tick={{ fontSize: 11, fill: "rgba(255,255,255,0.45)" }}
+              tickLine={false}
+              axisLine={false}
+              interval="preserveStartEnd"
+            />
+            <YAxis
+              tick={{ fontSize: 11, fill: "rgba(255,255,255,0.45)" }}
+              tickLine={false}
+              axisLine={false}
+              width={48}
+              tickFormatter={(value) =>
+                formatEmissionsAbsoluteCompact(value, currentLanguage)
+              }
+              domain={[0, maxTotalEmissions]}
+            />
+            <Tooltip
+              cursor={{ fill: "rgba(255,255,255,0.05)" }}
+              content={(props) => (
+                <ChartTooltip
+                  {...props}
+                  companyById={companyEntryById}
+                  currentLanguage={currentLanguage}
+                  t={t}
+                />
+              )}
+            />
+            {stackCompanies.map((company, stackIndex) => (
+              <Bar
+                key={company.id}
+                dataKey={company.id}
+                stackId="emissions"
+                maxBarSize={32}
+                radius={
+                  stackIndex === stackCompanies.length - 1
+                    ? [3, 3, 0, 0]
+                    : [0, 0, 0, 0]
+                }
+                isAnimationActive={!reduceMotion}
+                animationBegin={0}
+                animationDuration={reduceMotion ? 0 : barDuration * 1000}
+                animationEasing="ease-out"
+              >
+                {chartData.map((row, binIndex) => {
+                  const value = row[company.id];
+                  if (typeof value !== "number" || value <= 0) {
+                    return <Cell key={`${company.id}-${binIndex}`} fill="none" />;
+                  }
+
+                  const bin = histogram.bins[binIndex];
+                  const companiesInBin = bin.companies.filter(
+                    (entry) => entry.emissions > 0,
+                  );
+                  const segmentIndex = companiesInBin.findIndex(
+                    (entry) => entry.id === company.id,
+                  );
+                  const color = getBinBarColor(row.binMid as number);
+                  const opacity = getSegmentOpacity(
+                    segmentIndex,
+                    companiesInBin.length,
+                  );
+
+                  return (
+                    <Cell
+                      key={`${company.id}-${binIndex}`}
+                      fill={color}
+                      fillOpacity={opacity}
+                      cursor="pointer"
+                      onClick={() => handleCompanyClick(company.id)}
+                    />
+                  );
+                })}
+              </Bar>
             ))}
-          </div>
-
-          <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-            <div className="flex h-full min-h-0 flex-1 items-end gap-px border-b border-black-4">
-              {histogram.bins.map((bin) => {
-                const barHeight =
-                  histogram.maxTotalEmissions > 0
-                    ? (bin.totalEmissions / histogram.maxTotalEmissions) * 100
-                    : 0;
-                const binColor = getBinColor(
-                  bin,
-                  changeRange.min,
-                  changeRange.max,
-                );
-
-                return (
-                  <div
-                    key={bin.id}
-                    className="flex h-full min-w-0 flex-1 basis-0 flex-col items-center justify-end"
-                  >
-                    <div
-                      className="flex w-full flex-col justify-end overflow-hidden rounded-t-sm border border-black-4/80"
-                      style={{
-                        height: `${barHeight}%`,
-                        minHeight: bin.companies.length > 0 ? "6px" : "0px",
-                        transition: reduceMotion
-                          ? undefined
-                          : `height ${barDuration}s ease-out`,
-                      }}
-                      title={t(
-                        "companiesOverviewPage.visualizations.emissionsChange.binSummary",
-                        {
-                          range: bin.label,
-                          count: bin.companies.length,
-                          emissions: formatEmissionsAbsolute(
-                            bin.totalEmissions,
-                            currentLanguage,
-                          ),
-                        },
-                      )}
-                    >
-                      {bin.companies.map((company) => {
-                        const segmentHeight =
-                          bin.totalEmissions > 0
-                            ? (company.emissions / bin.totalEmissions) * 100
-                            : 0;
-                        const color = getCompanyColors(company.colorIndex).base;
-
-                        return (
-                          <div
-                            key={company.id}
-                            className="w-full min-w-0 cursor-pointer transition-opacity hover:opacity-80"
-                            style={{
-                              height: `${segmentHeight}%`,
-                              minHeight: segmentHeight > 0 ? "1px" : "0px",
-                              backgroundColor: color,
-                              boxShadow: `inset 0 0 0 1px ${binColor}33`,
-                            }}
-                            onMouseEnter={(event) =>
-                              handleSegmentHover(company, event)
-                            }
-                            onMouseMove={(event) =>
-                              handleSegmentHover(company, event)
-                            }
-                            onMouseLeave={() => setTooltip(null)}
-                            onClick={(event) => {
-                              event.stopPropagation();
-                              handleSegmentInteraction(company, event);
-                            }}
-                          />
-                        );
-                      })}
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-
-            <div className="mt-1 flex w-full shrink-0 gap-px overflow-hidden">
-              {histogram.bins.map((bin) => (
-                <div
-                  key={`${bin.id}-label`}
-                  className="min-w-0 flex-1 basis-0 truncate text-center text-[9px] leading-tight text-grey"
-                  title={bin.label}
-                >
-                  {formatCompactBinLabel(bin.label)}
-                </div>
-              ))}
-            </div>
-          </div>
-        </div>
+          </BarChart>
+        </ResponsiveContainer>
       </div>
 
-      <div className="flex shrink-0 flex-wrap items-center gap-3 text-xs text-grey">
+      <div className="flex shrink-0 flex-wrap items-center justify-between gap-3 px-1">
         <div className="flex items-center gap-2">
           <span
-            className="inline-block h-3 w-3 rounded-sm"
-            style={{
-              background: createSymmetricRangeGradient(
-                changeRange.min,
-                changeRange.max,
-                changeRange.min,
-              ),
-            }}
+            className="inline-block h-3 w-3 shrink-0 rounded-sm"
+            style={{ backgroundColor: COLORS.blue3 }}
           />
-          <span>
+          <span className="text-xs text-white/40">
             {t(
               "companiesOverviewPage.visualizations.emissionsChange.legend.reduction",
             )}
@@ -301,33 +323,10 @@ export function EmissionsChangeBarChart({
         </div>
         <div className="flex items-center gap-2">
           <span
-            className="inline-block h-3 w-3 rounded-sm"
-            style={{
-              background: createSymmetricRangeGradient(
-                changeRange.min,
-                changeRange.max,
-                0,
-              ),
-            }}
+            className="inline-block h-3 w-3 shrink-0 rounded-sm"
+            style={{ backgroundColor: COLORS.pink3 }}
           />
-          <span>
-            {t(
-              "companiesOverviewPage.visualizations.emissionsChange.legend.neutral",
-            )}
-          </span>
-        </div>
-        <div className="flex items-center gap-2">
-          <span
-            className="inline-block h-3 w-3 rounded-sm"
-            style={{
-              background: createSymmetricRangeGradient(
-                changeRange.min,
-                changeRange.max,
-                changeRange.max,
-              ),
-            }}
-          />
-          <span>
+          <span className="text-xs text-white/40">
             {t(
               "companiesOverviewPage.visualizations.emissionsChange.legend.increase",
             )}
@@ -335,40 +334,12 @@ export function EmissionsChangeBarChart({
         </div>
       </div>
 
-      {tooltip && (!isMobile || mobileTooltipOpen) && (
-        <div
-          className="pointer-events-none fixed z-50 rounded-level-1 border border-black-4 bg-black-1 px-3 py-2 text-xs text-white shadow-xl"
-          style={{
-            left: tooltip.position.x + 12,
-            top: tooltip.position.y + 12,
-          }}
-        >
-          <p className="font-medium">{tooltip.company.name}</p>
-          <p className="text-grey">
-            {t(
-              "companiesOverviewPage.visualizations.emissionsChange.tooltip.change",
-              { value: tooltip.company.changePercent.toFixed(1) },
-            )}
-          </p>
-          <p className="text-grey">
-            {t(
-              "companiesOverviewPage.visualizations.emissionsChange.tooltip.emissions",
-              {
-                value: formatEmissionsAbsolute(
-                  tooltip.company.emissions,
-                  currentLanguage,
-                ),
-              },
-            )}
-          </p>
-          {isMobile && (
-            <p className="mt-1 text-white/70">
-              {t(
-                "companiesOverviewPage.visualizations.emissionsChange.tooltip.tapAgain",
-              )}
-            </p>
+      {isMobile && mobileSelectedCompanyId && (
+        <p className="shrink-0 px-1 text-xs text-white/50">
+          {t(
+            "companiesOverviewPage.visualizations.emissionsChange.tooltip.tapAgain",
           )}
-        </div>
+        </p>
       )}
     </div>
   );

--- a/src/components/companies/rankedList/visualizations/shared/EmissionsChangeBarChart.tsx
+++ b/src/components/companies/rankedList/visualizations/shared/EmissionsChangeBarChart.tsx
@@ -192,8 +192,8 @@ export function EmissionsChangeBarChart({
         </span>
       </div>
 
-      <div className="flex min-h-0 flex-1 flex-col justify-end overflow-hidden">
-        <div className="flex min-h-[180px] w-full min-w-0 gap-2 overflow-hidden">
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <div className="flex h-full min-h-0 w-full min-w-0 flex-1 gap-2 overflow-hidden">
           <div className="flex h-full w-12 shrink-0 flex-col justify-between py-0 text-right text-[10px] text-grey">
             {[...yTicks].reverse().map((tick) => (
               <span key={tick}>
@@ -202,8 +202,8 @@ export function EmissionsChangeBarChart({
             ))}
           </div>
 
-          <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-            <div className="flex min-h-0 flex-1 items-end gap-px border-b border-black-4">
+          <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+            <div className="flex h-full min-h-0 flex-1 items-end gap-px border-b border-black-4">
               {histogram.bins.map((bin) => {
                 const barHeight =
                   histogram.maxTotalEmissions > 0

--- a/src/components/companies/rankedList/visualizations/shared/EmissionsChangeBarChart.tsx
+++ b/src/components/companies/rankedList/visualizations/shared/EmissionsChangeBarChart.tsx
@@ -180,18 +180,6 @@ export function EmissionsChangeBarChart({
         }
       }}
     >
-      <div className="flex shrink-0 items-center justify-between gap-3 text-xs text-grey">
-        <span>
-          {t("companiesOverviewPage.visualizations.emissionsChange.yAxisLabel")}
-        </span>
-        <span>
-          {t(
-            "companiesOverviewPage.visualizations.emissionsChange.xAxisLabel",
-            { width: histogram.binWidth },
-          )}
-        </span>
-      </div>
-
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         <div className="flex h-full min-h-0 w-full min-w-0 flex-1 gap-2 overflow-hidden">
           <div className="flex h-full w-12 shrink-0 flex-col justify-between py-0 text-right text-[10px] text-grey">
@@ -345,11 +333,6 @@ export function EmissionsChangeBarChart({
             )}
           </span>
         </div>
-        <span className="text-white/50">
-          {t(
-            "companiesOverviewPage.visualizations.emissionsChange.segmentHint",
-          )}
-        </span>
       </div>
 
       {tooltip && (!isMobile || mobileTooltipOpen) && (

--- a/src/components/companies/rankedList/visualizations/shared/EmissionsChangeBarChart.tsx
+++ b/src/components/companies/rankedList/visualizations/shared/EmissionsChangeBarChart.tsx
@@ -246,7 +246,9 @@ export function EmissionsChangeBarChart({
                     style={{
                       height: `${barHeightPercent}%`,
                       backgroundColor: COLORS.black2,
-                      transition: reduceMotion ? undefined : "height 0.5s ease-out",
+                      transition: reduceMotion
+                        ? undefined
+                        : "height 0.5s ease-out",
                     }}
                   >
                     {bin.companies.map((company) => {
@@ -276,11 +278,7 @@ export function EmissionsChangeBarChart({
                           aria-label={company.name}
                           onClick={() => handleSegmentClick(company.id)}
                           onMouseEnter={(event) =>
-                            handleSegmentPointerEnter(
-                              event,
-                              company,
-                              bin.label,
-                            )
+                            handleSegmentPointerEnter(event, company, bin.label)
                           }
                           onMouseMove={(event) =>
                             handleSegmentPointerMove(event, company, bin.label)

--- a/src/components/companies/rankedList/visualizations/shared/EmissionsChangeBarChart.tsx
+++ b/src/components/companies/rankedList/visualizations/shared/EmissionsChangeBarChart.tsx
@@ -112,10 +112,7 @@ export function EmissionsChangeBarChart({
       event: React.MouseEvent<HTMLDivElement>,
     ) => {
       if (isMobile) {
-        if (
-          mobileTooltipOpen &&
-          mobileSelectedCompanyId === company.id
-        ) {
+        if (mobileTooltipOpen && mobileSelectedCompanyId === company.id) {
           const sourceCompany = companyById.get(company.id);
           if (sourceCompany) {
             onCompanyClick?.(sourceCompany);
@@ -182,9 +179,7 @@ export function EmissionsChangeBarChart({
     >
       <div className="flex items-center justify-between gap-3 text-xs text-grey">
         <span>
-          {t(
-            "companiesOverviewPage.visualizations.emissionsChange.yAxisLabel",
-          )}
+          {t("companiesOverviewPage.visualizations.emissionsChange.yAxisLabel")}
         </span>
         <span>
           {t(

--- a/src/components/companies/rankedList/visualizations/shared/EmissionsChangeBarChart.tsx
+++ b/src/components/companies/rankedList/visualizations/shared/EmissionsChangeBarChart.tsx
@@ -1,0 +1,400 @@
+import { useCallback, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import type { CompanyWithKPIs } from "@/types/company";
+import { getCompanyColors } from "@/lib/constants/companyColors";
+import { useLanguage } from "@/components/LanguageProvider";
+import { useScreenSize } from "@/hooks/useScreenSize";
+import { useChartMotion } from "@/hooks/useChartMotion";
+import {
+  formatEmissionsAbsolute,
+  formatEmissionsAbsoluteCompact,
+} from "@/utils/formatting/localization";
+import { createSymmetricRangeGradient } from "@/utils/ui/colorGradients";
+import {
+  buildEmissionsChangeHistogram,
+  type EmissionsChangeCompanyEntry,
+  type EmissionsChangeHistogramBin,
+} from "@/utils/visualizations/emissionsChangeHistogram";
+
+interface EmissionsChangeBarChartProps {
+  companies: CompanyWithKPIs[];
+  onCompanyClick?: (company: CompanyWithKPIs) => void;
+}
+
+interface TooltipState {
+  company: EmissionsChangeCompanyEntry;
+  position: { x: number; y: number };
+}
+
+function getYAxisTicks(maxValue: number): number[] {
+  if (maxValue <= 0) {
+    return [0];
+  }
+
+  const roughStep = maxValue / 4;
+  const magnitude = Math.pow(10, Math.floor(Math.log10(roughStep)));
+  const normalized = roughStep / magnitude;
+  const niceNormalized =
+    normalized <= 1 ? 1 : normalized <= 2 ? 2 : normalized <= 5 ? 5 : 10;
+  const step = niceNormalized * magnitude;
+  const ticks: number[] = [];
+
+  for (let value = 0; value <= maxValue; value += step) {
+    ticks.push(Math.round(value));
+  }
+
+  if (ticks[ticks.length - 1] < maxValue) {
+    ticks.push(Math.round(maxValue));
+  }
+
+  return ticks;
+}
+
+function getBinColor(
+  bin: EmissionsChangeHistogramBin,
+  minChange: number,
+  maxChange: number,
+): string {
+  const midpoint = (bin.min + bin.max) / 2;
+  return createSymmetricRangeGradient(minChange, maxChange, midpoint);
+}
+
+export function EmissionsChangeBarChart({
+  companies,
+  onCompanyClick,
+}: EmissionsChangeBarChartProps) {
+  const { t } = useTranslation();
+  const { currentLanguage } = useLanguage();
+  const { isMobile } = useScreenSize();
+  const { reduceMotion, barDuration } = useChartMotion();
+  const [tooltip, setTooltip] = useState<TooltipState | null>(null);
+  const [mobileTooltipOpen, setMobileTooltipOpen] = useState(false);
+  const [mobileSelectedCompanyId, setMobileSelectedCompanyId] = useState<
+    string | null
+  >(null);
+
+  const histogram = useMemo(
+    () => buildEmissionsChangeHistogram(companies),
+    [companies],
+  );
+
+  const companyById = useMemo(() => {
+    const map = new Map<string, CompanyWithKPIs>();
+    companies.forEach((company) => {
+      map.set(company.id, company);
+    });
+    return map;
+  }, [companies]);
+
+  const changeRange = useMemo(() => {
+    if (!histogram) {
+      return { min: 0, max: 0 };
+    }
+
+    const values = histogram.bins.flatMap((bin) =>
+      bin.companies.map((company) => company.changePercent),
+    );
+
+    return {
+      min: Math.min(...values),
+      max: Math.max(...values),
+    };
+  }, [histogram]);
+
+  const yTicks = useMemo(
+    () => (histogram ? getYAxisTicks(histogram.maxTotalEmissions) : [0]),
+    [histogram],
+  );
+
+  const handleSegmentInteraction = useCallback(
+    (
+      company: EmissionsChangeCompanyEntry,
+      event: React.MouseEvent<HTMLDivElement>,
+    ) => {
+      if (isMobile) {
+        if (
+          mobileTooltipOpen &&
+          mobileSelectedCompanyId === company.id
+        ) {
+          const sourceCompany = companyById.get(company.id);
+          if (sourceCompany) {
+            onCompanyClick?.(sourceCompany);
+          }
+          setMobileTooltipOpen(false);
+          setMobileSelectedCompanyId(null);
+          setTooltip(null);
+          return;
+        }
+
+        setMobileTooltipOpen(true);
+        setMobileSelectedCompanyId(company.id);
+        setTooltip({
+          company,
+          position: { x: event.clientX, y: event.clientY },
+        });
+        return;
+      }
+
+      const sourceCompany = companyById.get(company.id);
+      if (sourceCompany) {
+        onCompanyClick?.(sourceCompany);
+      }
+    },
+    [
+      companyById,
+      isMobile,
+      mobileSelectedCompanyId,
+      mobileTooltipOpen,
+      onCompanyClick,
+    ],
+  );
+
+  const handleSegmentHover = useCallback(
+    (company: EmissionsChangeCompanyEntry, event: React.MouseEvent) => {
+      if (isMobile) {
+        return;
+      }
+
+      setTooltip({
+        company,
+        position: { x: event.clientX, y: event.clientY },
+      });
+    },
+    [isMobile],
+  );
+
+  if (!histogram || histogram.bins.length === 0) {
+    return null;
+  }
+
+  const chartHeight = 320;
+
+  return (
+    <div
+      className="relative flex h-full min-h-[420px] flex-col gap-4"
+      onClick={() => {
+        if (isMobile && mobileTooltipOpen) {
+          setMobileTooltipOpen(false);
+          setMobileSelectedCompanyId(null);
+          setTooltip(null);
+        }
+      }}
+    >
+      <div className="flex items-center justify-between gap-3 text-xs text-grey">
+        <span>
+          {t(
+            "companiesOverviewPage.visualizations.emissionsChange.yAxisLabel",
+          )}
+        </span>
+        <span>
+          {t(
+            "companiesOverviewPage.visualizations.emissionsChange.xAxisLabel",
+            { width: histogram.binWidth },
+          )}
+        </span>
+      </div>
+
+      <div className="flex flex-1 gap-3">
+        <div
+          className="flex w-14 shrink-0 flex-col justify-between text-right text-[11px] text-grey"
+          style={{ height: chartHeight }}
+        >
+          {[...yTicks].reverse().map((tick) => (
+            <span key={tick}>
+              {formatEmissionsAbsoluteCompact(tick, currentLanguage)}
+            </span>
+          ))}
+        </div>
+
+        <div className="relative flex-1 overflow-x-auto pb-2">
+          <div
+            className="flex min-w-full items-end gap-1 border-b border-black-4 px-1"
+            style={{ height: chartHeight }}
+          >
+            {histogram.bins.map((bin) => {
+              const barHeight =
+                histogram.maxTotalEmissions > 0
+                  ? (bin.totalEmissions / histogram.maxTotalEmissions) *
+                    chartHeight
+                  : 0;
+              const binColor = getBinColor(
+                bin,
+                changeRange.min,
+                changeRange.max,
+              );
+
+              return (
+                <div
+                  key={bin.id}
+                  className="flex min-w-[44px] flex-1 flex-col items-center justify-end"
+                >
+                  <div
+                    className="flex w-full flex-col justify-end overflow-hidden rounded-t-md border border-black-4/80"
+                    style={{
+                      height: `${barHeight}px`,
+                      minHeight: bin.companies.length > 0 ? "8px" : "0px",
+                      transition: reduceMotion
+                        ? undefined
+                        : `height ${barDuration}s ease-out`,
+                    }}
+                    title={t(
+                      "companiesOverviewPage.visualizations.emissionsChange.binSummary",
+                      {
+                        range: bin.label,
+                        count: bin.companies.length,
+                        emissions: formatEmissionsAbsolute(
+                          bin.totalEmissions,
+                          currentLanguage,
+                        ),
+                      },
+                    )}
+                  >
+                    {bin.companies.map((company) => {
+                      const segmentHeight =
+                        bin.totalEmissions > 0
+                          ? (company.emissions / bin.totalEmissions) * 100
+                          : 0;
+                      const color = getCompanyColors(company.colorIndex).base;
+
+                      return (
+                        <div
+                          key={company.id}
+                          className="w-full cursor-pointer transition-opacity hover:opacity-80"
+                          style={{
+                            height: `${segmentHeight}%`,
+                            minHeight: segmentHeight > 0 ? "2px" : "0px",
+                            backgroundColor: color,
+                            boxShadow: `inset 0 0 0 1px ${binColor}33`,
+                          }}
+                          onMouseEnter={(event) =>
+                            handleSegmentHover(company, event)
+                          }
+                          onMouseMove={(event) =>
+                            handleSegmentHover(company, event)
+                          }
+                          onMouseLeave={() => setTooltip(null)}
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            handleSegmentInteraction(company, event);
+                          }}
+                        />
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          <div className="mt-2 flex min-w-full gap-1 px-1">
+            {histogram.bins.map((bin) => (
+              <div
+                key={`${bin.id}-label`}
+                className="min-w-[44px] flex-1 text-center text-[10px] leading-tight text-grey"
+              >
+                <span className="block rotate-[-35deg] origin-top-left translate-x-3 whitespace-nowrap">
+                  {bin.label}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-4 text-xs text-grey">
+        <div className="flex items-center gap-2">
+          <span
+            className="inline-block h-3 w-3 rounded-sm"
+            style={{
+              background: createSymmetricRangeGradient(
+                changeRange.min,
+                changeRange.max,
+                changeRange.min,
+              ),
+            }}
+          />
+          <span>
+            {t(
+              "companiesOverviewPage.visualizations.emissionsChange.legend.reduction",
+            )}
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <span
+            className="inline-block h-3 w-3 rounded-sm"
+            style={{
+              background: createSymmetricRangeGradient(
+                changeRange.min,
+                changeRange.max,
+                0,
+              ),
+            }}
+          />
+          <span>
+            {t(
+              "companiesOverviewPage.visualizations.emissionsChange.legend.neutral",
+            )}
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <span
+            className="inline-block h-3 w-3 rounded-sm"
+            style={{
+              background: createSymmetricRangeGradient(
+                changeRange.min,
+                changeRange.max,
+                changeRange.max,
+              ),
+            }}
+          />
+          <span>
+            {t(
+              "companiesOverviewPage.visualizations.emissionsChange.legend.increase",
+            )}
+          </span>
+        </div>
+        <span className="text-white/50">
+          {t(
+            "companiesOverviewPage.visualizations.emissionsChange.segmentHint",
+          )}
+        </span>
+      </div>
+
+      {tooltip && (!isMobile || mobileTooltipOpen) && (
+        <div
+          className="pointer-events-none fixed z-50 rounded-level-1 border border-black-4 bg-black-1 px-3 py-2 text-xs text-white shadow-xl"
+          style={{
+            left: tooltip.position.x + 12,
+            top: tooltip.position.y + 12,
+          }}
+        >
+          <p className="font-medium">{tooltip.company.name}</p>
+          <p className="text-grey">
+            {t(
+              "companiesOverviewPage.visualizations.emissionsChange.tooltip.change",
+              { value: tooltip.company.changePercent.toFixed(1) },
+            )}
+          </p>
+          <p className="text-grey">
+            {t(
+              "companiesOverviewPage.visualizations.emissionsChange.tooltip.emissions",
+              {
+                value: formatEmissionsAbsolute(
+                  tooltip.company.emissions,
+                  currentLanguage,
+                ),
+              },
+            )}
+          </p>
+          {isMobile && (
+            <p className="mt-1 text-white/70">
+              {t(
+                "companiesOverviewPage.visualizations.emissionsChange.tooltip.tapAgain",
+              )}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/companies/rankedList/visualizations/shared/EmissionsChangeBarChart.tsx
+++ b/src/components/companies/rankedList/visualizations/shared/EmissionsChangeBarChart.tsx
@@ -59,6 +59,11 @@ function getBinColor(
   return createSymmetricRangeGradient(minChange, maxChange, midpoint);
 }
 
+function formatCompactBinLabel(label: string): string {
+  const [start] = label.split("–");
+  return start.replace("%", "");
+}
+
 export function EmissionsChangeBarChart({
   companies,
   onCompanyClick,
@@ -164,11 +169,9 @@ export function EmissionsChangeBarChart({
     return null;
   }
 
-  const chartHeight = 320;
-
   return (
     <div
-      className="relative flex h-full min-h-[420px] flex-col gap-4"
+      className="relative flex h-full min-h-0 w-full flex-col gap-3"
       onClick={() => {
         if (isMobile && mobileTooltipOpen) {
           setMobileTooltipOpen(false);
@@ -177,7 +180,7 @@ export function EmissionsChangeBarChart({
         }
       }}
     >
-      <div className="flex items-center justify-between gap-3 text-xs text-grey">
+      <div className="flex shrink-0 items-center justify-between gap-3 text-xs text-grey">
         <span>
           {t("companiesOverviewPage.visualizations.emissionsChange.yAxisLabel")}
         </span>
@@ -189,114 +192,108 @@ export function EmissionsChangeBarChart({
         </span>
       </div>
 
-      <div className="flex flex-1 gap-3">
-        <div
-          className="flex w-14 shrink-0 flex-col justify-between text-right text-[11px] text-grey"
-          style={{ height: chartHeight }}
-        >
-          {[...yTicks].reverse().map((tick) => (
-            <span key={tick}>
-              {formatEmissionsAbsoluteCompact(tick, currentLanguage)}
-            </span>
-          ))}
-        </div>
-
-        <div className="relative flex-1 overflow-x-auto pb-2">
-          <div
-            className="flex min-w-full items-end gap-1 border-b border-black-4 px-1"
-            style={{ height: chartHeight }}
-          >
-            {histogram.bins.map((bin) => {
-              const barHeight =
-                histogram.maxTotalEmissions > 0
-                  ? (bin.totalEmissions / histogram.maxTotalEmissions) *
-                    chartHeight
-                  : 0;
-              const binColor = getBinColor(
-                bin,
-                changeRange.min,
-                changeRange.max,
-              );
-
-              return (
-                <div
-                  key={bin.id}
-                  className="flex min-w-[44px] flex-1 flex-col items-center justify-end"
-                >
-                  <div
-                    className="flex w-full flex-col justify-end overflow-hidden rounded-t-md border border-black-4/80"
-                    style={{
-                      height: `${barHeight}px`,
-                      minHeight: bin.companies.length > 0 ? "8px" : "0px",
-                      transition: reduceMotion
-                        ? undefined
-                        : `height ${barDuration}s ease-out`,
-                    }}
-                    title={t(
-                      "companiesOverviewPage.visualizations.emissionsChange.binSummary",
-                      {
-                        range: bin.label,
-                        count: bin.companies.length,
-                        emissions: formatEmissionsAbsolute(
-                          bin.totalEmissions,
-                          currentLanguage,
-                        ),
-                      },
-                    )}
-                  >
-                    {bin.companies.map((company) => {
-                      const segmentHeight =
-                        bin.totalEmissions > 0
-                          ? (company.emissions / bin.totalEmissions) * 100
-                          : 0;
-                      const color = getCompanyColors(company.colorIndex).base;
-
-                      return (
-                        <div
-                          key={company.id}
-                          className="w-full cursor-pointer transition-opacity hover:opacity-80"
-                          style={{
-                            height: `${segmentHeight}%`,
-                            minHeight: segmentHeight > 0 ? "2px" : "0px",
-                            backgroundColor: color,
-                            boxShadow: `inset 0 0 0 1px ${binColor}33`,
-                          }}
-                          onMouseEnter={(event) =>
-                            handleSegmentHover(company, event)
-                          }
-                          onMouseMove={(event) =>
-                            handleSegmentHover(company, event)
-                          }
-                          onMouseLeave={() => setTooltip(null)}
-                          onClick={(event) => {
-                            event.stopPropagation();
-                            handleSegmentInteraction(company, event);
-                          }}
-                        />
-                      );
-                    })}
-                  </div>
-                </div>
-              );
-            })}
+      <div className="flex min-h-0 flex-1 flex-col justify-end overflow-hidden">
+        <div className="flex min-h-[180px] w-full min-w-0 gap-2 overflow-hidden">
+          <div className="flex h-full w-12 shrink-0 flex-col justify-between py-0 text-right text-[10px] text-grey">
+            {[...yTicks].reverse().map((tick) => (
+              <span key={tick}>
+                {formatEmissionsAbsoluteCompact(tick, currentLanguage)}
+              </span>
+            ))}
           </div>
 
-          <div className="mt-2 flex min-w-full gap-1 px-1">
-            {histogram.bins.map((bin) => (
-              <div
-                key={`${bin.id}-label`}
-                className="min-w-[44px] flex-1 text-center text-[10px] leading-tight text-grey"
-              >
-                <span className="block rotate-[-35deg] origin-top-left translate-x-3 whitespace-nowrap">
-                  {bin.label}
-                </span>
-              </div>
-            ))}
+          <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+            <div className="flex min-h-0 flex-1 items-end gap-px border-b border-black-4">
+              {histogram.bins.map((bin) => {
+                const barHeight =
+                  histogram.maxTotalEmissions > 0
+                    ? (bin.totalEmissions / histogram.maxTotalEmissions) * 100
+                    : 0;
+                const binColor = getBinColor(
+                  bin,
+                  changeRange.min,
+                  changeRange.max,
+                );
+
+                return (
+                  <div
+                    key={bin.id}
+                    className="flex h-full min-w-0 flex-1 basis-0 flex-col items-center justify-end"
+                  >
+                    <div
+                      className="flex w-full flex-col justify-end overflow-hidden rounded-t-sm border border-black-4/80"
+                      style={{
+                        height: `${barHeight}%`,
+                        minHeight: bin.companies.length > 0 ? "6px" : "0px",
+                        transition: reduceMotion
+                          ? undefined
+                          : `height ${barDuration}s ease-out`,
+                      }}
+                      title={t(
+                        "companiesOverviewPage.visualizations.emissionsChange.binSummary",
+                        {
+                          range: bin.label,
+                          count: bin.companies.length,
+                          emissions: formatEmissionsAbsolute(
+                            bin.totalEmissions,
+                            currentLanguage,
+                          ),
+                        },
+                      )}
+                    >
+                      {bin.companies.map((company) => {
+                        const segmentHeight =
+                          bin.totalEmissions > 0
+                            ? (company.emissions / bin.totalEmissions) * 100
+                            : 0;
+                        const color = getCompanyColors(company.colorIndex).base;
+
+                        return (
+                          <div
+                            key={company.id}
+                            className="w-full min-w-0 cursor-pointer transition-opacity hover:opacity-80"
+                            style={{
+                              height: `${segmentHeight}%`,
+                              minHeight: segmentHeight > 0 ? "1px" : "0px",
+                              backgroundColor: color,
+                              boxShadow: `inset 0 0 0 1px ${binColor}33`,
+                            }}
+                            onMouseEnter={(event) =>
+                              handleSegmentHover(company, event)
+                            }
+                            onMouseMove={(event) =>
+                              handleSegmentHover(company, event)
+                            }
+                            onMouseLeave={() => setTooltip(null)}
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              handleSegmentInteraction(company, event);
+                            }}
+                          />
+                        );
+                      })}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+
+            <div className="mt-1 flex w-full shrink-0 gap-px overflow-hidden">
+              {histogram.bins.map((bin) => (
+                <div
+                  key={`${bin.id}-label`}
+                  className="min-w-0 flex-1 basis-0 truncate text-center text-[9px] leading-tight text-grey"
+                  title={bin.label}
+                >
+                  {formatCompactBinLabel(bin.label)}
+                </div>
+              ))}
+            </div>
           </div>
         </div>
       </div>
 
-      <div className="flex flex-wrap items-center gap-4 text-xs text-grey">
+      <div className="flex shrink-0 flex-wrap items-center gap-3 text-xs text-grey">
         <div className="flex items-center gap-2">
           <span
             className="inline-block h-3 w-3 rounded-sm"

--- a/src/components/companies/rankedList/visualizations/shared/EmissionsChangeBarChart.tsx
+++ b/src/components/companies/rankedList/visualizations/shared/EmissionsChangeBarChart.tsx
@@ -110,10 +110,7 @@ function ChartTooltip({
         {t(
           "companiesOverviewPage.visualizations.emissionsChange.tooltip.emissions",
           {
-            value: formatEmissionsAbsolute(
-              company.emissions,
-              currentLanguage,
-            ),
+            value: formatEmissionsAbsolute(company.emissions, currentLanguage),
           },
         )}
       </p>
@@ -277,7 +274,9 @@ export function EmissionsChangeBarChart({
                 {chartData.map((row, binIndex) => {
                   const value = row[company.id];
                   if (typeof value !== "number" || value <= 0) {
-                    return <Cell key={`${company.id}-${binIndex}`} fill="none" />;
+                    return (
+                      <Cell key={`${company.id}-${binIndex}`} fill="none" />
+                    );
                   }
 
                   const bin = histogram.bins[binIndex];

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -329,10 +329,7 @@
         "description": "Only companies with a defined base year and comparable follow-up emissions data are ranked.",
         "noComparableData": "No companies in this sector with comparable emissions change data.",
         "unknown": "Unknown",
-        "yAxisLabel": "Total emissions (latest reported year, tCO2e)",
-        "xAxisLabel": "Change from base year ({{width}}% bins)",
         "binSummary": "{{range}}: {{count}} companies, {{emissions}} tCO2e total",
-        "segmentHint": "Each colored segment is one company, sized by its latest reported emissions.",
         "legend": {
           "reduction": "Reduction",
           "neutral": "Near zero",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -333,7 +333,8 @@
         "legend": {
           "reduction": "Reduction",
           "neutral": "Near zero",
-          "increase": "Increase"
+          "increase": "Increase",
+          "companyDivider": "Dark lines separate companies within each bar"
         },
         "tooltip": {
           "change": "Change from base year: {{value}}%",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -330,6 +330,8 @@
         "noComparableData": "No companies in this sector with comparable emissions change data.",
         "unknown": "Unknown",
         "binSummary": "{{range}}: {{count}} companies, {{emissions}} tCO2e total",
+        "companiesCount": "{{count}} companies",
+        "segmentHint": "Each company is a stacked segment within the bar. Hover or tap a segment for details.",
         "legend": {
           "reduction": "Reduction",
           "neutral": "Near zero",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -328,7 +328,21 @@
         "title": "Emissions Change from Base Year",
         "description": "Only companies with a defined base year and comparable follow-up emissions data are ranked.",
         "noComparableData": "No companies in this sector with comparable emissions change data.",
-        "unknown": "Unknown"
+        "unknown": "Unknown",
+        "yAxisLabel": "Total emissions (latest reported year, tCO2e)",
+        "xAxisLabel": "Change from base year ({{width}}% bins)",
+        "binSummary": "{{range}}: {{count}} companies, {{emissions}} tCO2e total",
+        "segmentHint": "Each colored segment is one company, sized by its latest reported emissions.",
+        "legend": {
+          "reduction": "Reduction",
+          "neutral": "Near zero",
+          "increase": "Increase"
+        },
+        "tooltip": {
+          "change": "Change from base year: {{value}}%",
+          "emissions": "Latest reported emissions: {{value}} tCO2e",
+          "tapAgain": "Tap again to open company"
+        }
       },
       "meetsParis": {
         "legend": {

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -333,7 +333,8 @@
         "legend": {
           "reduction": "Minskning",
           "neutral": "Nära noll",
-          "increase": "Ökning"
+          "increase": "Ökning",
+          "companyDivider": "Mörka linjer skiljer företag åt inom varje stapel"
         },
         "tooltip": {
           "change": "Förändring från basår: {{value}} %",

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -330,6 +330,8 @@
         "noComparableData": "Inga företag i denna sektor med jämförbar utsläppsförändringsdata.",
         "unknown": "Okänt",
         "binSummary": "{{range}}: {{count}} företag, {{emissions}} ton CO2e totalt",
+        "companiesCount": "{{count}} företag",
+        "segmentHint": "Varje företag är ett staplat segment i stapeln. Hovra eller tryck på ett segment för detaljer.",
         "legend": {
           "reduction": "Minskning",
           "neutral": "Nära noll",

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -328,7 +328,21 @@
         "title": "Utsläppsförändring från basår",
         "description": "Endast företag med ett definierat basår och jämförbara uppföljningsdata rankas.",
         "noComparableData": "Inga företag i denna sektor med jämförbar utsläppsförändringsdata.",
-        "unknown": "Okänt"
+        "unknown": "Okänt",
+        "yAxisLabel": "Totala utsläpp (senast rapporterade år, ton CO2e)",
+        "xAxisLabel": "Förändring från basår ({{width}} %-intervall)",
+        "binSummary": "{{range}}: {{count}} företag, {{emissions}} ton CO2e totalt",
+        "segmentHint": "Varje färgat segment är ett företag, storleken baseras på senast rapporterade utsläpp.",
+        "legend": {
+          "reduction": "Minskning",
+          "neutral": "Nära noll",
+          "increase": "Ökning"
+        },
+        "tooltip": {
+          "change": "Förändring från basår: {{value}} %",
+          "emissions": "Senast rapporterade utsläpp: {{value}} ton CO2e",
+          "tapAgain": "Tryck igen för att öppna företaget"
+        }
       },
       "meetsParis": {
         "legend": {

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -329,10 +329,7 @@
         "description": "Endast företag med ett definierat basår och jämförbara uppföljningsdata rankas.",
         "noComparableData": "Inga företag i denna sektor med jämförbar utsläppsförändringsdata.",
         "unknown": "Okänt",
-        "yAxisLabel": "Totala utsläpp (senast rapporterade år, ton CO2e)",
-        "xAxisLabel": "Förändring från basår ({{width}} %-intervall)",
         "binSummary": "{{range}}: {{count}} företag, {{emissions}} ton CO2e totalt",
-        "segmentHint": "Varje färgat segment är ett företag, storleken baseras på senast rapporterade utsläpp.",
         "legend": {
           "reduction": "Minskning",
           "neutral": "Nära noll",

--- a/src/utils/calculations/emissionsCalculations.ts
+++ b/src/utils/calculations/emissionsCalculations.ts
@@ -256,26 +256,30 @@ export function getRegressionPoints(
  *   - Latest period is the same year as base year (no change possible)
  *   - If useLastPeriod is false: no period with >0 emissions found after base year
  */
-export function calculateEmissionsChangeFromBaseYear(
-  company: {
-    baseYear?: { year?: number } | null;
-    reportingPeriods?: Array<{
-      startDate: string;
-      endDate: string;
-      emissions?: {
-        calculatedTotalEmissions?: number | null;
-      } | null;
-    }>;
-  },
+type BaseYearReportingCompany = {
+  baseYear?: { year?: number } | null;
+  reportingPeriods?: Array<{
+    startDate: string;
+    endDate: string;
+    emissions?: {
+      calculatedTotalEmissions?: number | null;
+    } | null;
+  }>;
+};
+
+function getBaseYearComparablePeriods(
+  company: BaseYearReportingCompany,
   options?: {
     useLastPeriod?: boolean;
   },
-): number | null {
+): {
+  baselineEmissions: number;
+  latestEmissions: number;
+} | null {
   if (!company.reportingPeriods || company.reportingPeriods.length === 0) {
     return null;
   }
 
-  // Constraint: require a base year
   if (!company.baseYear?.year) {
     return null;
   }
@@ -283,7 +287,6 @@ export function calculateEmissionsChangeFromBaseYear(
   const baseYear = company.baseYear.year;
   const baseYearStr = baseYear.toString();
 
-  // Sort periods by start date (oldest first)
   const periods = [...company.reportingPeriods].sort((a, b) =>
     a.startDate.localeCompare(b.startDate),
   );
@@ -292,9 +295,8 @@ export function calculateEmissionsChangeFromBaseYear(
     return null;
   }
 
-  // Find baseline period matching the base year (using endDate year)
   const baselinePeriod = periods.find(
-    (p) => yearFromIsoDate(p.endDate) === baseYearStr,
+    (period) => yearFromIsoDate(period.endDate) === baseYearStr,
   );
 
   if (!baselinePeriod) {
@@ -304,9 +306,6 @@ export function calculateEmissionsChangeFromBaseYear(
   const baselineEmissions =
     baselinePeriod.emissions?.calculatedTotalEmissions ?? null;
 
-  // Baseline emissions must be valid and > 0
-  // Exclude companies where base year data is 0, null, or undefined
-  // Cannot calculate meaningful change from base year without valid baseline data
   if (
     baselineEmissions === null ||
     baselineEmissions === undefined ||
@@ -315,23 +314,21 @@ export function calculateEmissionsChangeFromBaseYear(
     return null;
   }
 
-  // Find latest period based on option
   let latestPeriod: (typeof periods)[0] | null = null;
 
   if (options?.useLastPeriod) {
-    // Use the last period in the array (even if 0)
     latestPeriod = periods[periods.length - 1];
   } else {
-    // Find latest period with >0 emissions after the base year
-    for (let i = periods.length - 1; i >= 0; i--) {
-      const periodYear = Number(yearFromIsoDate(periods[i].endDate));
+    for (let index = periods.length - 1; index >= 0; index -= 1) {
+      const periodYear = Number(yearFromIsoDate(periods[index].endDate));
       if (periodYear <= baseYear) {
         continue;
       }
 
-      const emissions = periods[i].emissions?.calculatedTotalEmissions ?? null;
+      const emissions =
+        periods[index].emissions?.calculatedTotalEmissions ?? null;
       if (emissions !== null && emissions > 0) {
-        latestPeriod = periods[i];
+        latestPeriod = periods[index];
         break;
       }
     }
@@ -341,7 +338,6 @@ export function calculateEmissionsChangeFromBaseYear(
     return null;
   }
 
-  // Latest period must be after the base year
   const latestYear = Number(yearFromIsoDate(latestPeriod.endDate));
   if (latestYear <= baseYear) {
     return null;
@@ -349,12 +345,42 @@ export function calculateEmissionsChangeFromBaseYear(
 
   const latestEmissions = latestPeriod.emissions?.calculatedTotalEmissions ?? 0;
 
-  // Calculate percentage change
-  const changePercent =
-    ((latestEmissions - baselineEmissions) / baselineEmissions) * 100;
+  return {
+    baselineEmissions,
+    latestEmissions,
+  };
+}
 
-  // Filter out extreme outliers (>200% in either direction) as likely data quality issues
-  // These often indicate missing base year data, scope changes, mergers, etc.
+export function getLatestComparableEmissions(
+  company: BaseYearReportingCompany,
+  options?: {
+    useLastPeriod?: boolean;
+  },
+): number | null {
+  const periods = getBaseYearComparablePeriods(company, options);
+  if (!periods || periods.latestEmissions <= 0) {
+    return null;
+  }
+
+  return periods.latestEmissions;
+}
+
+export function calculateEmissionsChangeFromBaseYear(
+  company: BaseYearReportingCompany,
+  options?: {
+    useLastPeriod?: boolean;
+  },
+): number | null {
+  const periods = getBaseYearComparablePeriods(company, options);
+  if (!periods) {
+    return null;
+  }
+
+  const changePercent =
+    ((periods.latestEmissions - periods.baselineEmissions) /
+      periods.baselineEmissions) *
+    100;
+
   if (Math.abs(changePercent) > 200) {
     return null;
   }

--- a/src/utils/visualizations/emissionsChangeHistogram.test.ts
+++ b/src/utils/visualizations/emissionsChangeHistogram.test.ts
@@ -79,9 +79,7 @@ describe("emissionsChangeHistogram", () => {
     const allCompanyIds = histogram?.bins.flatMap((bin) =>
       bin.companies.map((company) => company.id),
     );
-    expect(allCompanyIds).toEqual(
-      expect.arrayContaining(["1", "2", "3"]),
-    );
+    expect(allCompanyIds).toEqual(expect.arrayContaining(["1", "2", "3"]));
   });
 
   it("sizes company segments by their latest reported emissions", () => {

--- a/src/utils/visualizations/emissionsChangeHistogram.test.ts
+++ b/src/utils/visualizations/emissionsChangeHistogram.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import type { CompanyWithKPIs } from "@/types/company";
+import {
+  assignValueToBin,
+  buildEmissionsChangeHistogram,
+  buildSymmetricBins,
+  chooseEmissionsChangeBinWidth,
+  formatBinLabel,
+} from "@/utils/visualizations/emissionsChangeHistogram";
+
+function createCompany(
+  id: string,
+  name: string,
+  baseYear: number,
+  baselineEmissions: number,
+  latestEmissions: number,
+): CompanyWithKPIs {
+  const changePercent =
+    ((latestEmissions - baselineEmissions) / baselineEmissions) * 100;
+
+  return {
+    id,
+    name,
+    wikidataId: `Q${id}`,
+    baseYear: { year: baseYear },
+    reportingPeriods: [
+      {
+        startDate: `${baseYear + 5}-01-01`,
+        endDate: `${baseYear + 5}-12-31`,
+        emissions: { calculatedTotalEmissions: latestEmissions },
+      },
+      {
+        startDate: `${baseYear}-01-01`,
+        endDate: `${baseYear}-12-31`,
+        emissions: { calculatedTotalEmissions: baselineEmissions },
+      },
+    ],
+    emissionsChangeFromBaseYear: changePercent,
+  } as CompanyWithKPIs;
+}
+
+describe("emissionsChangeHistogram", () => {
+  it("chooses a readable fixed bin width for the data range", () => {
+    expect(chooseEmissionsChangeBinWidth(4)).toBe(0.5);
+    expect(chooseEmissionsChangeBinWidth(40)).toBe(5);
+    expect(chooseEmissionsChangeBinWidth(120)).toBe(20);
+  });
+
+  it("formats evenly sized percent labels", () => {
+    expect(formatBinLabel(-2, -1)).toBe("-2–-1%");
+    expect(formatBinLabel(0, 0.5)).toBe("0–0.5%");
+  });
+
+  it("assigns values to evenly sized bins", () => {
+    const bins = buildSymmetricBins(5, 1);
+    expect(assignValueToBin(-2.4, bins).min).toBe(-3);
+    expect(assignValueToBin(0, bins).min).toBe(0);
+    expect(assignValueToBin(4.8, bins).max).toBe(5);
+  });
+
+  it("aggregates latest reported emissions per change bin", () => {
+    const companies = [
+      createCompany("1", "Alpha", 2019, 1000, 900),
+      createCompany("2", "Beta", 2019, 1000, 1100),
+      createCompany("3", "Gamma", 2019, 1000, 800),
+    ];
+
+    const histogram = buildEmissionsChangeHistogram(companies);
+
+    expect(histogram).not.toBeNull();
+    expect(histogram?.bins.length).toBeGreaterThan(0);
+
+    const totalEmissions = histogram?.bins.reduce(
+      (sum, bin) => sum + bin.totalEmissions,
+      0,
+    );
+    expect(totalEmissions).toBe(900 + 1100 + 800);
+
+    const allCompanyIds = histogram?.bins.flatMap((bin) =>
+      bin.companies.map((company) => company.id),
+    );
+    expect(allCompanyIds).toEqual(
+      expect.arrayContaining(["1", "2", "3"]),
+    );
+  });
+
+  it("sizes company segments by their latest reported emissions", () => {
+    const companies = [
+      createCompany("1", "Large", 2019, 1000, 1100),
+      {
+        ...createCompany("2", "Small", 2019, 2000, 2200),
+        emissionsChangeFromBaseYear: 10,
+      },
+    ];
+
+    const histogram = buildEmissionsChangeHistogram(companies);
+    const sharedBin = histogram?.bins.find((bin) => bin.companies.length === 2);
+
+    expect(sharedBin).toBeDefined();
+    expect(sharedBin?.companies[0].emissions).toBe(2200);
+    expect(sharedBin?.companies[1].emissions).toBe(1100);
+    expect(sharedBin?.totalEmissions).toBe(3300);
+  });
+});

--- a/src/utils/visualizations/emissionsChangeHistogram.ts
+++ b/src/utils/visualizations/emissionsChangeHistogram.ts
@@ -90,9 +90,7 @@ export function assignValueToBin(
   return bins[bins.length - 1];
 }
 
-export function buildEmissionsChangeHistogram(
-  companies: CompanyWithKPIs[],
-): {
+export function buildEmissionsChangeHistogram(companies: CompanyWithKPIs[]): {
   bins: EmissionsChangeHistogramBin[];
   binWidth: number;
   maxTotalEmissions: number;

--- a/src/utils/visualizations/emissionsChangeHistogram.ts
+++ b/src/utils/visualizations/emissionsChangeHistogram.ts
@@ -1,0 +1,158 @@
+import type { CompanyWithKPIs } from "@/types/company";
+import { getLatestComparableEmissions } from "@/utils/calculations/emissionsCalculations";
+
+export interface EmissionsChangeCompanyEntry {
+  id: string;
+  name: string;
+  changePercent: number;
+  emissions: number;
+  colorIndex: number;
+}
+
+export interface EmissionsChangeHistogramBin {
+  id: string;
+  min: number;
+  max: number;
+  label: string;
+  totalEmissions: number;
+  companies: EmissionsChangeCompanyEntry[];
+}
+
+const BIN_WIDTH_CANDIDATES = [0.5, 1, 2, 5, 10, 20, 50];
+
+export function chooseEmissionsChangeBinWidth(absMax: number): number {
+  if (absMax === 0) {
+    return 1;
+  }
+
+  for (const width of BIN_WIDTH_CANDIDATES) {
+    const binCount = Math.ceil((2 * absMax) / width);
+    if (binCount >= 6 && binCount <= 20) {
+      return width;
+    }
+  }
+
+  for (let index = BIN_WIDTH_CANDIDATES.length - 1; index >= 0; index -= 1) {
+    const width = BIN_WIDTH_CANDIDATES[index];
+    if (Math.ceil((2 * absMax) / width) <= 20) {
+      return width;
+    }
+  }
+
+  return BIN_WIDTH_CANDIDATES[BIN_WIDTH_CANDIDATES.length - 1];
+}
+
+export function formatBinLabel(min: number, max: number): string {
+  const format = (value: number) => {
+    const rounded = Number(value.toFixed(1));
+    return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+  };
+
+  return `${format(min)}–${format(max)}%`;
+}
+
+export function buildSymmetricBins(
+  absMax: number,
+  binWidth: number,
+): EmissionsChangeHistogramBin[] {
+  const halfSpan = Math.ceil(absMax / binWidth) * binWidth;
+  const binCount = Math.ceil((2 * halfSpan) / binWidth);
+  const binStart = -halfSpan;
+
+  return Array.from({ length: binCount }, (_, index) => {
+    const min = binStart + index * binWidth;
+    const max = min + binWidth;
+
+    return {
+      id: `${min}-${max}`,
+      min,
+      max,
+      label: formatBinLabel(min, max),
+      totalEmissions: 0,
+      companies: [],
+    };
+  });
+}
+
+export function assignValueToBin(
+  value: number,
+  bins: EmissionsChangeHistogramBin[],
+): EmissionsChangeHistogramBin {
+  for (let index = 0; index < bins.length; index += 1) {
+    const bin = bins[index];
+    const isLast = index === bins.length - 1;
+
+    if (value >= bin.min && (isLast ? value <= bin.max : value < bin.max)) {
+      return bin;
+    }
+  }
+
+  return bins[bins.length - 1];
+}
+
+export function buildEmissionsChangeHistogram(
+  companies: CompanyWithKPIs[],
+): {
+  bins: EmissionsChangeHistogramBin[];
+  binWidth: number;
+  maxTotalEmissions: number;
+} | null {
+  const entries: EmissionsChangeCompanyEntry[] = [];
+
+  companies.forEach((company, index) => {
+    const changePercent = company.emissionsChangeFromBaseYear;
+    if (
+      changePercent === null ||
+      changePercent === undefined ||
+      Number.isNaN(changePercent)
+    ) {
+      return;
+    }
+
+    const emissions = getLatestComparableEmissions(company);
+    if (emissions === null || emissions <= 0) {
+      return;
+    }
+
+    entries.push({
+      id: company.id,
+      name: company.name,
+      changePercent,
+      emissions,
+      colorIndex: index,
+    });
+  });
+
+  if (entries.length === 0) {
+    return null;
+  }
+
+  const absMax = Math.max(
+    ...entries.map((entry) => Math.abs(entry.changePercent)),
+    0,
+  );
+  const binWidth = chooseEmissionsChangeBinWidth(absMax);
+  const bins = buildSymmetricBins(absMax, binWidth);
+
+  entries.forEach((entry) => {
+    const bin = assignValueToBin(entry.changePercent, bins);
+    bin.companies.push(entry);
+    bin.totalEmissions += entry.emissions;
+  });
+
+  bins.forEach((bin) => {
+    bin.companies.sort((a, b) => b.emissions - a.emissions);
+  });
+
+  const populatedBins = bins.filter((bin) => bin.companies.length > 0);
+  const maxTotalEmissions = Math.max(
+    ...populatedBins.map((bin) => bin.totalEmissions),
+    0,
+  );
+
+  return {
+    bins: populatedBins,
+    binWidth,
+    maxTotalEmissions,
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What's Changed?

The company emissions change graph on the Companies Overview page is now a stacked bar histogram instead of a beeswarm plot.

- **X-axis:** Evenly sized percent-change bins (e.g. 0–0.5%, 0.5–1%), automatically chosen from the data range
- **Y-axis:** Sum of latest reported emissions (tCO2e) for all companies in each bin
- **Segments:** Each colored block inside a bar is one company, sized by its latest reported emissions
- Hover/tooltip shows company name, change %, and emissions; click navigates to the company detail page

### Implementation notes

- Added `buildEmissionsChangeHistogram` utility for symmetric binning and aggregation
- Extracted shared base-year period logic in `emissionsCalculations.ts` (`getLatestComparableEmissions`)
- Added EN/SV labels for axes, legend, and tooltips

### Checklist

- [x] Change runs locally
- [x] Unit tests added for histogram binning logic
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-625dfdef-4001-48ef-8afb-ccb4fd2646c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-625dfdef-4001-48ef-8afb-ccb4fd2646c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

