### PR TITLE
[1585] Fix streched rows in the ranked list on the overview pages

### DIFF
--- a/src/components/companies/list/FilterBadges.tsx
+++ b/src/components/companies/list/FilterBadges.tsx
@@ -36,7 +36,7 @@ export function FilterBadges({ filters, view }: FilterBadgesProps) {
             {filter.type === "filter" && filter.onRemove && (
               <button
                 type="button"
-                title={t("explorePage.companies.removeFilter")}
+                title={t("explorePage.removeFilter")}
                 onClick={(e) => {
                   e.preventDefault();
                   filter.onRemove?.();

--- a/src/components/ranked/RankedList.tsx
+++ b/src/components/ranked/RankedList.tsx
@@ -221,23 +221,21 @@ export function RankedList<T extends Record<string, unknown>>({
     <button
       key={String(index)}
       onClick={() => onItemClick?.(item)}
-      className="w-full p-4 hover:bg-black/70 transition-colors flex items-start justify-between gap-4 group"
+      className="w-full px-4 hover:bg-black/70 transition-colors flex items-center gap-4 group"
     >
-      <div className="flex items-center gap-4">
-        <span className="text-white/30 text-sm w-8 shrink-0 tabular-nums text-left">
-          {selectedDataPoint.isBoolean
-            ? ""
-            : isMissingRankedValue(
-                  item[selectedDataPoint.key],
-                  selectedDataPoint.isBoolean,
-                )
-              ? "—"
-              : getOriginalRank(item)}
-        </span>
-        <span className="text-white/90 text-sm md:text-base text-left break-words">
-          {String(item[searchKey])}
-        </span>
-      </div>
+      <span className="text-white/30 text-sm w-8 shrink-0 tabular-nums text-left">
+        {selectedDataPoint.isBoolean
+          ? ""
+          : isMissingRankedValue(
+                item[selectedDataPoint.key],
+                selectedDataPoint.isBoolean,
+              )
+            ? "—"
+            : getOriginalRank(item)}
+      </span>
+      <span className="text-white/90 w-full text-sm md:text-base text-left break-words line-clamp-2">
+        {String(item[searchKey])}
+      </span>
       <span
         className={cn(
           selectedDataPoint.isBoolean || item[selectedDataPoint.key] === null
@@ -321,6 +319,10 @@ export function RankedList<T extends Record<string, unknown>>({
                   colorItem ? colorItem(item) : defaultColorItem(item),
                 ),
           )}
+          {paginatedData.length < itemsPerPage &&
+            Array(itemsPerPage - paginatedData.length)
+              .fill(0)
+              .map((_, i) => <div key={`empty-${i}`} />)}
         </div>
       </div>
       {totalPages > 1 && (

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -2032,6 +2032,7 @@
       }
     },
     "filter": "Filter:",
+    "removeFilter": "Remove filter",
     "sorting": "Sorting by:",
     "sortingOptions": {
       "aToZ": "A-Z",

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -2082,6 +2082,7 @@
       }
     },
     "filter": "Filter:",
+    "removeFilter": "Ta bort filter",
     "sorting": "Sorterar:",
     "sortingOptions": {
       "aToZ": "A-Ö",


### PR DESCRIPTION
### ✨ What’s Changed?

The rows of the last page of the ranked list were stretched to fill out the entire container which could look quite odd if there were too few rows. Empty rows have been added to make sure that the size of the rows stays consistent on all pages.

There was also an issue where the text in the rows could end up misaligned if the entity name took up more than one row and another where the tooltip text for removing a filter was missing.

### 📸 Screenshots

Before:
<img width="684" height="693" alt="bild" src="https://github.com/user-attachments/assets/9a8bc8c2-7ac8-4108-a2b6-5275ffaf7f29" />
<img width="385" height="534" alt="bild" src="https://github.com/user-attachments/assets/1c23d2ae-500c-4fc9-8f20-507fc88363a5" />

After:
<img width="680" height="691" alt="bild" src="https://github.com/user-attachments/assets/67b3a286-f6d7-4fa4-b673-a40c599d0604" />
<img width="383" height="537" alt="bild" src="https://github.com/user-attachments/assets/73635ce2-3d9a-4924-97b3-082e8096fa22" />

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [ ] I've set the labels, issue, and milestone for the PR

### 🛠 Related Issue

Closes #1585

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout and copy changes in ranked lists and filter badges; no data or API impact.
> 
> **Overview**
> Fixes **overview ranked list** layout where the last page stretched remaining rows to fill the grid, and tightens default row alignment when entity names wrap.
> 
> **`RankedList`** pads each page with empty placeholder rows up to `itemsPerPage` so row height stays consistent when the final page has fewer items. Default list rows are flattened to a single flex row (`items-center`), with **`line-clamp-2`** on the name so rank, label, and value stay aligned.
> 
> **`FilterBadges`** now uses `explorePage.removeFilter` for the remove-button tooltip, backed by new **EN/SV** strings under `explorePage`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58b28abd1fbad51398dd8d1c39d5829dd239ae01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->