### PR TITLE
Add loading state for landing page

### DIFF
--- a/src/components/landing/LandingPageLoading.tsx
+++ b/src/components/landing/LandingPageLoading.tsx
@@ -1,0 +1,31 @@
+import { Loader2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+export function LandingPageLoading() {
+  const { t } = useTranslation();
+
+  return (
+    <div
+      className="flex flex-col items-center h-screen bg-black-3"
+      aria-busy="true"
+      aria-live="polite"
+      aria-label={t("common.loading")}
+    >
+      <div className="flex-1 flex flex-col items-center text-center px-4 pt-32 md:pt-48 w-full max-w-4xl mx-auto space-y-8">
+        <div className="w-full max-w-lg md:max-w-4xl mx-auto space-y-4">
+          <div className="h-12 md:h-16 w-3/4 mx-auto animate-pulse bg-black-2 rounded" />
+          <div className="h-20 md:h-28 w-1/2 mx-auto animate-pulse bg-black-2 rounded" />
+        </div>
+        <div className="w-full max-w-xl space-y-4">
+          <div className="h-4 w-full animate-pulse bg-black-2 rounded" />
+          <div className="h-12 w-full animate-pulse bg-black-2 rounded-level-2" />
+        </div>
+        <div className="flex items-center gap-2 text-grey">
+          <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+          <span>{t("common.loading")}</span>
+        </div>
+      </div>
+      <div className="w-full h-48 md:h-64 animate-pulse bg-black-2" />
+    </div>
+  );
+}

--- a/src/hooks/landing/useLandingPageReady.ts
+++ b/src/hooks/landing/useLandingPageReady.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from "react";
+
+const HERO_IMAGE_SRC = "/images/web/hero-globe-image.jpg";
+const LOAD_TIMEOUT_MS = 8000;
+
+function preloadHeroImage() {
+  return new Promise<void>((resolve) => {
+    const img = new Image();
+    img.onload = () => resolve();
+    img.onerror = () => resolve();
+    img.src = HERO_IMAGE_SRC;
+  });
+}
+
+export function useLandingPageReady() {
+  const [isReady, setIsReady] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const timeout = new Promise<void>((resolve) => {
+      setTimeout(resolve, LOAD_TIMEOUT_MS);
+    });
+
+    Promise.race([
+      Promise.all([document.fonts.ready, preloadHeroImage()]),
+      timeout,
+    ]).then(() => {
+      if (!cancelled) {
+        setIsReady(true);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return isReady;
+}

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -12,10 +12,13 @@ import { MunicipalitiesSection } from "@/components/landing/MunicipalitiesSectio
 import { CountriesSection } from "@/components/landing/CountriesSection";
 import { PartnersSection } from "@/components/landing/PartnersSection";
 import { MissionSection } from "../components/landing/MissionSection";
+import { LandingPageLoading } from "@/components/landing/LandingPageLoading";
 import { Text } from "@/components/ui/text";
+import { useLandingPageReady } from "@/hooks/landing/useLandingPageReady";
 
 export function LandingPage() {
   const { t } = useTranslation();
+  const isPageReady = useLandingPageReady();
   const municipalitiesSectionRef = useRef<HTMLDivElement | null>(null);
   const [fadeChevron, setFadeChevron] = useState(false);
 
@@ -66,6 +69,20 @@ export function LandingPage() {
     };
   }, [throttledScroll]);
 
+  if (!isPageReady) {
+    return (
+      <>
+        <PageSEO
+          title={pageTitle}
+          description={pageDescription}
+          canonicalUrl={canonicalUrl}
+          structuredData={structuredData}
+        />
+        <LandingPageLoading />
+      </>
+    );
+  }
+
   return (
     <>
       <PageSEO
@@ -74,7 +91,7 @@ export function LandingPage() {
         canonicalUrl={canonicalUrl}
         structuredData={structuredData}
       />
-      <div className="flex flex-col items-center h-screen">
+      <div className="flex flex-col items-center h-screen animate-in fade-in-0 duration-500">
         <div className="flex-1 flex flex-col items-center text-center px-4 pt-32 md:pt-48 md:pb-2">
           <div className="max-w-lg md:max-w-4xl mx-auto space-y-2">
             <h1 className="text-4xl md:text-7xl font-light tracking-tight">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a full-page loading state to the landing page that displays while critical assets finish loading, then fades in the page content.

## Changes

- **`LandingPageLoading`** — skeleton UI matching the hero layout (title, search, globe image placeholders) with a spinner and localized loading text
- **`useLandingPageReady`** — waits for fonts (`document.fonts.ready`) and the hero globe image to preload before revealing the page
- **`LandingPage`** — shows the loading state until ready, then renders the full page with a fade-in transition

## Behavior

- Loading screen appears immediately on landing page mount
- Page content is revealed once fonts and the hero image are ready
- An 8-second timeout fallback ensures the page is never blocked indefinitely if an asset fails to load

## Testing

- [x] TypeScript check passes (`tsc --noEmit`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a8123d9-c4b4-4ddf-a344-ff4f53a33cb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a8123d9-c4b4-4ddf-a344-ff4f53a33cb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

