### PR TITLE
[feat] Source Valet 2026 story data from additional-nation-data endpoint

### DIFF
--- a/src/hooks/nation/useNationStoryDetails.ts
+++ b/src/hooks/nation/useNationStoryDetails.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { getNationDetails } from "@/lib/api";
+import { getAdditionalNationData } from "@/lib/api";
 import { normalizeNationCountry } from "@/hooks/nation/normalizeNationCountry";
 import { extractYearRecord } from "@/utils/data/nationTerritorialTransforms";
 import type { NationEmissionSeries } from "@/utils/data/nationStoryMetrics";
@@ -53,7 +53,7 @@ function transformRawNation(response: RawNationResponse): NationStoryDetails {
 }
 
 async function fetchNationStoryDetails(): Promise<NationStoryDetails> {
-  const data = await getNationDetails();
+  const data = await getAdditionalNationData();
   const raw = (Array.isArray(data) ? data[0] : data) as RawNationResponse;
 
   if (!hasStorySchema(raw)) {
@@ -71,7 +71,7 @@ export function useNationStoryDetails() {
     isLoading,
     error,
   } = useQuery({
-    queryKey: ["nation-story"],
+    queryKey: ["additional-nation-story"],
     queryFn: fetchNationStoryDetails,
   });
 

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -2803,6 +2803,88 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/additional-nation-data/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get additional national data
+         * @description Retrieve supplementary national (Sweden) data with territorial fossil, production-based, biogenic, consumption abroad, oil export, and e-commerce emissions. Returns 304 Not Modified if the resource has not changed since the last request (based on ETag).
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            country: {
+                                sv: string;
+                                en: string;
+                            };
+                            logoUrl?: string | null;
+                            territorialFossilEmissions: ({
+                                year: string;
+                                value: number;
+                            } | null)[];
+                            productionBasedEmissions: ({
+                                year: string;
+                                value: number;
+                            } | null)[];
+                            biogenicEmissions: ({
+                                year: string;
+                                value: number;
+                            } | null)[];
+                            consumptionAbroadEmissions: ({
+                                year: string;
+                                value: number;
+                            } | null)[];
+                            exportOfOilProductsEmissions: ({
+                                year: string;
+                                value: number;
+                            } | null)[];
+                            eCommerceEmissions: ({
+                                year: string;
+                                value: number;
+                            } | null)[];
+                        };
+                    };
+                };
+                /** @description Default Response */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            code: string;
+                            message?: string;
+                            details?: unknown;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/nation/": {
         parameters: {
             query?: never;

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -2894,7 +2894,7 @@ export interface paths {
         };
         /**
          * Get national data
-         * @description Retrieve national (Sweden) data with territorial fossil, biogenic, consumption abroad, oil export, and e-commerce emissions. Returns 304 Not Modified if the resource has not changed since the last request (based on ETag).
+         * @description Retrieve national (Sweden) data with historical emissions, trends, and Paris agreement compliance status. Returns 304 Not Modified if the resource has not changed since the last request (based on ETag).
          */
         get: {
             parameters: {
@@ -2917,30 +2917,22 @@ export interface paths {
                                 en: string;
                             };
                             logoUrl?: string | null;
-                            territorialFossilEmissions: ({
+                            emissions: ({
                                 year: string;
                                 value: number;
                             } | null)[];
-                            productionBasedEmissions: ({
+                            totalTrend: number;
+                            totalCarbonLaw: number;
+                            approximatedHistoricalEmission: ({
                                 year: string;
                                 value: number;
                             } | null)[];
-                            biogenicEmissions: ({
+                            trend: ({
                                 year: string;
                                 value: number;
                             } | null)[];
-                            consumptionAbroadEmissions: ({
-                                year: string;
-                                value: number;
-                            } | null)[];
-                            exportOfOilProductsEmissions: ({
-                                year: string;
-                                value: number;
-                            } | null)[];
-                            eCommerceEmissions: ({
-                                year: string;
-                                value: number;
-                            } | null)[];
+                            historicalEmissionChangePercent: number;
+                            meetsParis: boolean;
                         };
                     };
                 };

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -331,6 +331,12 @@ export async function getNationDetails() {
   return data;
 }
 
+export async function getAdditionalNationData() {
+  const { data, error } = await GET("/additional-nation-data/", {});
+  if (error) throw error;
+  return data;
+}
+
 export async function getNationSectorEmissions() {
   const { data, error } = await GET("/nation/sector-emissions", {});
   if (error) throw error;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### ✨ What's Changed?

The Valet 2026 story page (`/valet-2026`) now fetches its emission series from the `/additional-nation-data/` API endpoint instead of `/nation/`.

- Added `getAdditionalNationData()` in `src/lib/api.ts`
- Added OpenAPI types for `/additional-nation-data/`
- Updated `useNationStoryDetails` to use the new endpoint and cache key

The regular nation detail page (`/nation`) continues to use `/nation/` via `useNationDetails`.

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [ ] I've verified the change runs locally both on mobile and desktop
- [ ] I've set the labels, issue, and milestone for the PR

### 🛠 Related Issue

Related to the Valet 2026 story page data sourcing.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e2feba9-48b1-49a3-84d4-c001cc448eb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e2feba9-48b1-49a3-84d4-c001cc448eb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

