### PR TITLE
[1604] Fix CompanyWithKPIs memoization on the company overview page

### DIFF
--- a/src/components/ranked/KPIChipSelector.tsx
+++ b/src/components/ranked/KPIChipSelector.tsx
@@ -178,7 +178,7 @@ export function KPIChipSelector<T>({
                 className="hidden md:block grow shrink basis-0 min-w-0 h-0"
                 aria-hidden="true"
               />
-              <div className="flex flex-wrap items-center gap-2 w-full md:w-auto md:max-w-full">
+              <div className="flex flex-wrap md:flex-row-reverse items-center gap-2 w-full md:w-auto md:max-w-full">
                 {actions}
               </div>
             </>

--- a/src/pages/companiesOverviewPageUtils.ts
+++ b/src/pages/companiesOverviewPageUtils.ts
@@ -107,6 +107,8 @@ export function useCompaniesWithKPIs(
   selectedCountries: CompanyCountryTagSlug[],
   selectedKPI: CompanyKPIValue,
 ) {
+  const selectedCountriesKey = [...selectedCountries].sort().join(",");
+
   return useMemo(() => {
     if (!companies) return [];
 
@@ -126,7 +128,7 @@ export function useCompaniesWithKPIs(
     });
 
     return filtered.map((company) => enrichCompanyWithKPIs(company));
-  }, [companies, selectedCountries, selectedSector, selectedKPI.key]);
+  }, [companies, selectedCountriesKey, selectedSector, selectedKPI.key]);
 }
 
 export function asCompanyDataPoint(


### PR DESCRIPTION
### ✨ What’s Changed?

Opening the filter menu on the companies overview page would cause the ranked list to reset because the filtered list of companies sent to the list wasn't correctly memoized, this has been fixed by using a string instead of the selected countries array as a dependency.

There was also another issue where selecting a filter (which adds a filter badge) caused the filter menu to move when in desktop mode, this has been fixed by making sure the filter button is always furthest to the edge of the screen.

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [ ] I've set the labels, issue, and milestone for the PR

### 🛠 Related Issue

Closes #1604

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted memo dependency and layout-only CSS on the companies overview; no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes the company overview ranked list **resetting when opening the filter UI** by stabilizing `useCompaniesWithKPIs` memo dependencies: country filters now depend on a **sorted, comma-joined string** instead of the `selectedCountries` array reference, so unchanged selections no longer force a full re-filter and re-enrich pass.
> 
> On desktop, **KPI chip row actions** (e.g. filter button vs. active filter badges) use `md:flex-row-reverse` so the primary control stays **pinned to the outer edge** when badges wrap, avoiding the filter control shifting when a filter is applied.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bda51f65bf68f3766274d731e9967a3f5322919a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->