### PR TITLE
[1608] Add filter badges for country filters on the sector overview page

### DIFF
--- a/src/pages/SectorsOverviewPage.tsx
+++ b/src/pages/SectorsOverviewPage.tsx
@@ -17,30 +17,10 @@ export function SectorsOverviewPage() {
   const [filterOpen, setFilterOpen] = useState(false);
   const sectorNames = useSectorNames();
 
-  const {
-    meetsParisFilter,
-    setMeetsParisFilter,
-    filteredCompanies,
-    filterGroups,
-  } = useCompanyFilters(companies, { includeSectorFilter: false });
-
-  const activeFilters = [
-    ...(meetsParisFilter !== "all"
-      ? [
-          {
-            type: "filter" as const,
-            label: `${t("sectorsOverviewPage.filteringOptions.meetsParis")}: ${
-              meetsParisFilter === "yes"
-                ? t("sectorsOverviewPage.filteringOptions.meetsParisYes")
-                : meetsParisFilter === "no"
-                  ? t("sectorsOverviewPage.filteringOptions.meetsParisNo")
-                  : t("sectorsOverviewPage.filteringOptions.meetsParisUnknown")
-            }`,
-            onRemove: () => setMeetsParisFilter("all"),
-          },
-        ]
-      : []),
-  ];
+  const { filteredCompanies, filterGroups, activeFilters } = useCompanyFilters(
+    companies,
+    { includeSectorFilter: false },
+  );
 
   if (companiesLoading) {
     return (


### PR DESCRIPTION
### ✨ What’s Changed?

Filter badges has been added for the countries filter on the sector overview, they already existed for the Meet Paris filter and this keeps thing consistent.

### 📸 Screenshots

Before:
<img width="894" height="489" alt="bild" src="https://github.com/user-attachments/assets/7057caed-df64-4bd1-a849-b54712416d02" />

After:
<img width="883" height="500" alt="bild" src="https://github.com/user-attachments/assets/261e1bfd-998e-44e8-b984-9471a27208e6" />

### 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] I've verified the change runs locally both on mobile and desktop
- [ ] I've set the labels, issue, and milestone for the PR

### 🛠 Related Issue

Closes #1608 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only refactor on the sectors page; filter state still comes from the existing hook and URL params.
> 
> **Overview**
> **Sector overview** now drives filter chips from `useCompanyFilters`’s shared `activeFilters` instead of building Meet Paris badges only in the page.
> 
> That removes the local `meetsParisFilter` / `setMeetsParisFilter` wiring and the hand-rolled Meet Paris badge list, so **country** (and any other filters the hook already exposes) show as removable badges next to the filter popover—the same pattern as the company explore views.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c612aeec90f4116c8945a956f9d4c3c11440b62c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->