### PR TITLE
Polish nation story typography

### DIFF
--- a/src/components/nation/story/NationBathtub.tsx
+++ b/src/components/nation/story/NationBathtub.tsx
@@ -6,7 +6,10 @@ import {
   type NationBathtubDataPoint,
 } from "@/utils/data/nationStoryMetrics";
 import { useLanguage } from "@/components/LanguageProvider";
-import { NATION_STORY_TEXT } from "@/components/nation/story/nationStoryColors";
+import {
+  NATION_STORY_TEXT,
+  NATION_STORY_TYPE,
+} from "@/components/nation/story/nationStoryColors";
 import { usePinnedSteps } from "@/components/nation/story/usePinnedSteps";
 
 /** Sample years so each scroll step adds a visible water chunk. */
@@ -100,7 +103,7 @@ export function NationBathtub({ data }: NationBathtubProps) {
               initial={{ opacity: 0, y: 16 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.45 }}
-              className={`text-sm md:text-xl ${NATION_STORY_TEXT.body} leading-snug md:leading-relaxed`}
+              className={`${NATION_STORY_TYPE.body} ${NATION_STORY_TEXT.body}`}
             >
               {t("nation.story.bathtub.text")}
             </motion.p>
@@ -108,7 +111,7 @@ export function NationBathtub({ data }: NationBathtubProps) {
               initial={{ opacity: 0, y: 12 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.45, delay: 0.1 }}
-              className="text-lg md:text-3xl text-white font-light leading-snug"
+              className={`${NATION_STORY_TYPE.emphasis} text-white`}
             >
               {t("nation.story.bathtub.question")}
             </motion.p>
@@ -191,17 +194,19 @@ export function NationBathtub({ data }: NationBathtubProps) {
                 key={current.year}
                 initial={{ opacity: 0, y: 6 }}
                 animate={{ opacity: 1, y: 0 }}
-                className="text-2xl md:text-4xl font-light tabular-nums"
+                className={NATION_STORY_TYPE.stat}
               >
                 {current.year}
               </motion.p>
-              <p className={`text-sm md:text-lg ${NATION_STORY_TEXT.body}`}>
+              <p
+                className={`${NATION_STORY_TYPE.meta} ${NATION_STORY_TEXT.body}`}
+              >
                 {t("nation.story.bathtub.levelCaption", {
                   value: formatMton(current.cumulativeMton, currentLanguage, 0),
                 })}
               </p>
               <p
-                className={`text-xs md:text-base ${NATION_STORY_TEXT.secondary}`}
+                className={`${NATION_STORY_TYPE.meta} ${NATION_STORY_TEXT.secondary}`}
               >
                 {chunkCaption}
               </p>

--- a/src/components/nation/story/NationConclusion.tsx
+++ b/src/components/nation/story/NationConclusion.tsx
@@ -6,7 +6,10 @@ import {
 } from "@/utils/data/nationStoryMetrics";
 import { formatPercentChange } from "@/utils/formatting/localization";
 import { useLanguage } from "@/components/LanguageProvider";
-import { NATION_STORY_TEXT } from "@/components/nation/story/nationStoryColors";
+import {
+  NATION_STORY_TEXT,
+  NATION_STORY_TYPE,
+} from "@/components/nation/story/nationStoryColors";
 
 type NationConclusionProps = {
   metrics: NationStoryMetrics;
@@ -23,7 +26,7 @@ export function NationConclusion({ metrics }: NationConclusionProps) {
         whileInView={{ opacity: 1, y: 0 }}
         viewport={{ once: false, amount: 0.5 }}
         transition={{ duration: 0.4 }}
-        className={`text-sm md:text-lg uppercase tracking-widest ${NATION_STORY_TEXT.eyebrow}`}
+        className={`${NATION_STORY_TYPE.eyebrow} ${NATION_STORY_TEXT.eyebrow}`}
       >
         {t("nation.story.conclusion.eyebrow")}
       </motion.p>
@@ -33,7 +36,7 @@ export function NationConclusion({ metrics }: NationConclusionProps) {
         whileInView={{ opacity: 1, y: 0 }}
         viewport={{ once: false, amount: 0.5 }}
         transition={{ duration: 0.45, delay: 0.05 }}
-        className="text-2xl md:text-5xl font-light leading-tight"
+        className={`${NATION_STORY_TYPE.title} leading-tight`}
       >
         {t("nation.story.conclusion.title")}
       </motion.h2>
@@ -47,25 +50,27 @@ export function NationConclusion({ metrics }: NationConclusionProps) {
       >
         <div className="p-1 md:p-2">
           <p
-            className={`text-sm md:text-lg uppercase tracking-wide ${NATION_STORY_TEXT.secondary} mb-2 md:mb-3`}
+            className={`${NATION_STORY_TYPE.eyebrow} ${NATION_STORY_TEXT.secondary} mb-2 md:mb-3`}
           >
             {t("nation.story.conclusion.usualLabel")}
           </p>
-          <p className="text-4xl md:text-8xl font-light text-blue-2 tabular-nums leading-none">
+          <p className={`${NATION_STORY_TYPE.display} text-blue-2`}>
             {formatMton(metrics.territorialLatestMton, currentLanguage, 0)}
           </p>
           <p
-            className={`text-base md:text-xl ${NATION_STORY_TEXT.body} mt-1.5 md:mt-2`}
+            className={`${NATION_STORY_TYPE.body} ${NATION_STORY_TEXT.body} mt-1.5 md:mt-2`}
           >
             {t("nation.story.unit.millionTco2e")}
           </p>
-          <p className="mt-3 md:mt-4 text-lg md:text-2xl font-medium text-blue-2 tabular-nums">
+          <p
+            className={`mt-3 md:mt-4 ${NATION_STORY_TYPE.emphasis} text-blue-2 tabular-nums`}
+          >
             {formatPercentChange(
               metrics.territorialChangePercent,
               currentLanguage,
             )}{" "}
             <span
-              className={`text-base md:text-lg font-normal ${NATION_STORY_TEXT.secondary}`}
+              className={`font-normal ${NATION_STORY_TYPE.meta} ${NATION_STORY_TEXT.secondary}`}
             >
               {t("nation.story.conclusion.since1990")}
             </span>
@@ -74,25 +79,27 @@ export function NationConclusion({ metrics }: NationConclusionProps) {
 
         <div className="p-1 md:p-2">
           <p
-            className={`text-sm md:text-lg uppercase tracking-wide ${NATION_STORY_TEXT.secondary} mb-2 md:mb-3`}
+            className={`${NATION_STORY_TYPE.eyebrow} ${NATION_STORY_TEXT.secondary} mb-2 md:mb-3`}
           >
             {t("nation.story.conclusion.fullLabel")}
           </p>
-          <p className="text-4xl md:text-8xl font-light text-pink-3 tabular-nums leading-none">
+          <p className={`${NATION_STORY_TYPE.display} text-pink-3`}>
             {formatMton(metrics.combinedLatestMton, currentLanguage, 0)}
           </p>
           <p
-            className={`text-base md:text-xl ${NATION_STORY_TEXT.body} mt-1.5 md:mt-2`}
+            className={`${NATION_STORY_TYPE.body} ${NATION_STORY_TEXT.body} mt-1.5 md:mt-2`}
           >
             {t("nation.story.unit.millionTco2e")}
           </p>
-          <p className="mt-3 md:mt-4 text-lg md:text-2xl font-medium text-pink-3 tabular-nums">
+          <p
+            className={`mt-3 md:mt-4 ${NATION_STORY_TYPE.emphasis} text-pink-3 tabular-nums`}
+          >
             {formatPercentChange(
               metrics.combinedChangePercent,
               currentLanguage,
             )}{" "}
             <span
-              className={`text-base md:text-lg font-normal ${NATION_STORY_TEXT.secondary}`}
+              className={`font-normal ${NATION_STORY_TYPE.meta} ${NATION_STORY_TEXT.secondary}`}
             >
               {t("nation.story.conclusion.since1990")}
             </span>

--- a/src/components/nation/story/NationEmissionsJourney.tsx
+++ b/src/components/nation/story/NationEmissionsJourney.tsx
@@ -234,7 +234,9 @@ export function NationEmissionsJourney({
                 />
                 {t(current.labelKey)}
               </p>
-              <p className={`${NATION_STORY_TYPE.body} ${NATION_STORY_TEXT.body}`}>
+              <p
+                className={`${NATION_STORY_TYPE.body} ${NATION_STORY_TEXT.body}`}
+              >
                 {t(current.textKey)}
               </p>
               {current.badgeKey && (

--- a/src/components/nation/story/NationEmissionsJourney.tsx
+++ b/src/components/nation/story/NationEmissionsJourney.tsx
@@ -220,6 +220,13 @@ export function NationEmissionsJourney({
               transition={{ duration: 0.4 }}
               className="space-y-2 md:space-y-3"
             >
+              <p className="flex items-center gap-2.5 md:gap-3 text-base md:text-2xl text-white font-medium">
+                <span
+                  className="w-3 h-3 md:w-4 md:h-4 rounded-full shrink-0"
+                  style={{ backgroundColor: current.color }}
+                />
+                {t(current.labelKey)}
+              </p>
               <p
                 className={`text-sm md:text-xl ${NATION_STORY_TEXT.body} leading-snug md:leading-relaxed`}
               >

--- a/src/components/nation/story/NationEmissionsJourney.tsx
+++ b/src/components/nation/story/NationEmissionsJourney.tsx
@@ -9,6 +9,7 @@ import { useScreenSize } from "@/hooks/useScreenSize";
 import {
   NATION_STORY_COLORS,
   NATION_STORY_TEXT,
+  NATION_STORY_TYPE,
 } from "@/components/nation/story/nationStoryColors";
 import { usePinnedSteps } from "@/components/nation/story/usePinnedSteps";
 
@@ -195,9 +196,13 @@ export function NationEmissionsJourney({
 
               {/* Running total on top */}
               <div className="absolute inset-0 flex items-center justify-center">
-                <span className="text-black font-bold text-2xl md:text-5xl tabular-nums select-none leading-none text-center">
+                <span
+                  className={`${NATION_STORY_TYPE.stat} text-black font-bold select-none leading-none text-center`}
+                >
                   {formatMton(current.total, currentLanguage, 0)}
-                  <span className="block text-xs md:text-base font-semibold mt-0.5 md:mt-1">
+                  <span
+                    className={`block ${NATION_STORY_TYPE.meta} font-semibold mt-0.5 md:mt-1`}
+                  >
                     {t("nation.story.unit.mton")}
                   </span>
                 </span>
@@ -205,7 +210,7 @@ export function NationEmissionsJourney({
             </div>
 
             <p
-              className={`text-xs md:text-base ${NATION_STORY_TEXT.secondary} mt-1 md:mt-10`}
+              className={`${NATION_STORY_TYPE.meta} ${NATION_STORY_TEXT.secondary} mt-1 md:mt-10`}
             >
               {t("nation.story.journey.dataYear", { year: metrics.latestYear })}
             </p>
@@ -220,20 +225,20 @@ export function NationEmissionsJourney({
               transition={{ duration: 0.4 }}
               className="space-y-2 md:space-y-3"
             >
-              <p className="flex items-center gap-2.5 md:gap-3 text-base md:text-2xl text-white font-medium">
+              <p
+                className={`flex items-center gap-2.5 md:gap-3 ${NATION_STORY_TYPE.emphasis} text-white`}
+              >
                 <span
                   className="w-3 h-3 md:w-4 md:h-4 rounded-full shrink-0"
                   style={{ backgroundColor: current.color }}
                 />
                 {t(current.labelKey)}
               </p>
-              <p
-                className={`text-sm md:text-xl ${NATION_STORY_TEXT.body} leading-snug md:leading-relaxed`}
-              >
+              <p className={`${NATION_STORY_TYPE.body} ${NATION_STORY_TEXT.body}`}>
                 {t(current.textKey)}
               </p>
               {current.badgeKey && (
-                <p className="text-sm md:text-lg text-pink-1 font-medium">
+                <p className={`${NATION_STORY_TYPE.emphasis} text-pink-1`}>
                   {t(current.badgeKey)}
                 </p>
               )}
@@ -247,7 +252,7 @@ export function NationEmissionsJourney({
                 .map((s, i) => (
                   <div
                     key={s.key}
-                    className="flex items-center gap-2 md:gap-2.5 text-sm md:text-lg"
+                    className={`flex items-center gap-2 md:gap-2.5 ${NATION_STORY_TYPE.meta}`}
                   >
                     <span
                       className="w-2.5 h-2.5 md:w-3.5 md:h-3.5 rounded-full shrink-0"

--- a/src/components/nation/story/NationIntroPunch.tsx
+++ b/src/components/nation/story/NationIntroPunch.tsx
@@ -13,15 +13,9 @@ import {
 
 type NationIntroPunchProps = {
   metrics: NationStoryMetrics;
-  /** Extra classes for the map container width/height constraints. */
-  className?: string;
 };
 
-/** Nested Sweden silhouettes: territorial (inner) vs full emissions (outer). */
-export function NationIntroPunch({
-  metrics,
-  className = "w-[88px] md:w-[120px]",
-}: NationIntroPunchProps) {
+export function NationIntroPunch({ metrics }: NationIntroPunchProps) {
   const { t } = useTranslation();
   const { currentLanguage } = useLanguage();
 
@@ -37,76 +31,78 @@ export function NationIntroPunch({
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true, amount: 0.35 }}
       transition={{ duration: 0.45 }}
-      className={`relative mx-auto shrink-0 ${className}`}
+      className="py-1 space-y-2"
     >
-      <svg
-        viewBox={SWEDEN_OUTLINE_VIEWBOX}
-        className="w-full h-auto max-h-[42vh] md:max-h-[52vh]"
-        role="img"
-        aria-label={`${reported}–${full} ${t("nation.story.unit.mton")}`}
-      >
-        <motion.path
-          d={SWEDEN_OUTLINE_PATH}
-          fill={NATION_STORY_COLORS.consumption}
-          initial={{ opacity: 0, scale: 0.92 }}
-          animate={{ opacity: 1, scale: 1 }}
-          transition={{ duration: 0.5, ease: [0.22, 1, 0.36, 1] }}
-          style={{ transformOrigin: "50% 50%" }}
-        />
-        <motion.g
-          initial={{ opacity: 0, scale: 0.5 }}
-          animate={{ opacity: 1, scale: innerScale }}
-          transition={{
-            duration: 0.5,
-            delay: 0.1,
-            ease: [0.22, 1, 0.36, 1],
-          }}
-          style={{ transformOrigin: "50% 45%" }}
+      <div className="relative mx-auto w-[112px] md:w-[168px]">
+        <svg
+          viewBox={SWEDEN_OUTLINE_VIEWBOX}
+          className="w-full h-auto"
+          role="img"
+          aria-label={`${reported}–${full} ${t("nation.story.unit.mton")}`}
         >
-          <path
+          <motion.path
             d={SWEDEN_OUTLINE_PATH}
-            fill={NATION_STORY_COLORS.territorial}
+            fill={NATION_STORY_COLORS.consumption}
+            initial={{ opacity: 0, scale: 0.92 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{ duration: 0.5, ease: [0.22, 1, 0.36, 1] }}
+            style={{ transformOrigin: "50% 50%" }}
           />
-        </motion.g>
+          <motion.g
+            initial={{ opacity: 0, scale: 0.5 }}
+            animate={{ opacity: 1, scale: innerScale }}
+            transition={{
+              duration: 0.5,
+              delay: 0.1,
+              ease: [0.22, 1, 0.36, 1],
+            }}
+            style={{ transformOrigin: "50% 45%" }}
+          >
+            <path
+              d={SWEDEN_OUTLINE_PATH}
+              fill={NATION_STORY_COLORS.territorial}
+            />
+          </motion.g>
 
-        <text
-          x="50"
-          y="96"
-          textAnchor="middle"
-          className="fill-black font-semibold"
-          style={{ fontSize: 18 }}
-        >
-          {reported}
-        </text>
-        <text
-          x="50"
-          y="110"
-          textAnchor="middle"
-          className="fill-black/70 font-medium"
-          style={{ fontSize: 9 }}
-        >
-          {t("nation.story.unit.mton")}
-        </text>
+          <text
+            x="50"
+            y="96"
+            textAnchor="middle"
+            className="fill-black font-semibold"
+            style={{ fontSize: 18 }}
+          >
+            {reported}
+          </text>
+          <text
+            x="50"
+            y="110"
+            textAnchor="middle"
+            className="fill-black/70 font-medium"
+            style={{ fontSize: 9 }}
+          >
+            {t("nation.story.unit.mton")}
+          </text>
 
-        <text
-          x="72"
-          y="168"
-          textAnchor="middle"
-          className="fill-white font-semibold"
-          style={{ fontSize: 15 }}
-        >
-          {full}
-        </text>
-        <text
-          x="72"
-          y="180"
-          textAnchor="middle"
-          className="fill-white/85 font-medium"
-          style={{ fontSize: 8 }}
-        >
-          {t("nation.story.unit.mton")}
-        </text>
-      </svg>
+          <text
+            x="72"
+            y="168"
+            textAnchor="middle"
+            className="fill-white font-semibold"
+            style={{ fontSize: 15 }}
+          >
+            {full}
+          </text>
+          <text
+            x="72"
+            y="180"
+            textAnchor="middle"
+            className="fill-white/85 font-medium"
+            style={{ fontSize: 8 }}
+          >
+            {t("nation.story.unit.mton")}
+          </text>
+        </svg>
+      </div>
     </motion.div>
   );
 }

--- a/src/components/nation/story/NationIntroPunch.tsx
+++ b/src/components/nation/story/NationIntroPunch.tsx
@@ -13,9 +13,15 @@ import {
 
 type NationIntroPunchProps = {
   metrics: NationStoryMetrics;
+  /** Extra classes for the map container width/height constraints. */
+  className?: string;
 };
 
-export function NationIntroPunch({ metrics }: NationIntroPunchProps) {
+/** Nested Sweden silhouettes: territorial (inner) vs full emissions (outer). */
+export function NationIntroPunch({
+  metrics,
+  className = "w-[88px] md:w-[120px]",
+}: NationIntroPunchProps) {
   const { t } = useTranslation();
   const { currentLanguage } = useLanguage();
 
@@ -31,78 +37,76 @@ export function NationIntroPunch({ metrics }: NationIntroPunchProps) {
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true, amount: 0.35 }}
       transition={{ duration: 0.45 }}
-      className="py-1 space-y-2"
+      className={`relative mx-auto shrink-0 ${className}`}
     >
-      <div className="relative mx-auto w-[112px] md:w-[168px]">
-        <svg
-          viewBox={SWEDEN_OUTLINE_VIEWBOX}
-          className="w-full h-auto"
-          role="img"
-          aria-label={`${reported}–${full} ${t("nation.story.unit.mton")}`}
+      <svg
+        viewBox={SWEDEN_OUTLINE_VIEWBOX}
+        className="w-full h-auto max-h-[42vh] md:max-h-[52vh]"
+        role="img"
+        aria-label={`${reported}–${full} ${t("nation.story.unit.mton")}`}
+      >
+        <motion.path
+          d={SWEDEN_OUTLINE_PATH}
+          fill={NATION_STORY_COLORS.consumption}
+          initial={{ opacity: 0, scale: 0.92 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{ duration: 0.5, ease: [0.22, 1, 0.36, 1] }}
+          style={{ transformOrigin: "50% 50%" }}
+        />
+        <motion.g
+          initial={{ opacity: 0, scale: 0.5 }}
+          animate={{ opacity: 1, scale: innerScale }}
+          transition={{
+            duration: 0.5,
+            delay: 0.1,
+            ease: [0.22, 1, 0.36, 1],
+          }}
+          style={{ transformOrigin: "50% 45%" }}
         >
-          <motion.path
+          <path
             d={SWEDEN_OUTLINE_PATH}
-            fill={NATION_STORY_COLORS.consumption}
-            initial={{ opacity: 0, scale: 0.92 }}
-            animate={{ opacity: 1, scale: 1 }}
-            transition={{ duration: 0.5, ease: [0.22, 1, 0.36, 1] }}
-            style={{ transformOrigin: "50% 50%" }}
+            fill={NATION_STORY_COLORS.territorial}
           />
-          <motion.g
-            initial={{ opacity: 0, scale: 0.5 }}
-            animate={{ opacity: 1, scale: innerScale }}
-            transition={{
-              duration: 0.5,
-              delay: 0.1,
-              ease: [0.22, 1, 0.36, 1],
-            }}
-            style={{ transformOrigin: "50% 45%" }}
-          >
-            <path
-              d={SWEDEN_OUTLINE_PATH}
-              fill={NATION_STORY_COLORS.territorial}
-            />
-          </motion.g>
+        </motion.g>
 
-          <text
-            x="50"
-            y="96"
-            textAnchor="middle"
-            className="fill-black font-semibold"
-            style={{ fontSize: 18 }}
-          >
-            {reported}
-          </text>
-          <text
-            x="50"
-            y="110"
-            textAnchor="middle"
-            className="fill-black/70 font-medium"
-            style={{ fontSize: 9 }}
-          >
-            {t("nation.story.unit.mton")}
-          </text>
+        <text
+          x="50"
+          y="96"
+          textAnchor="middle"
+          className="fill-black font-semibold"
+          style={{ fontSize: 18 }}
+        >
+          {reported}
+        </text>
+        <text
+          x="50"
+          y="110"
+          textAnchor="middle"
+          className="fill-black/70 font-medium"
+          style={{ fontSize: 9 }}
+        >
+          {t("nation.story.unit.mton")}
+        </text>
 
-          <text
-            x="72"
-            y="168"
-            textAnchor="middle"
-            className="fill-white font-semibold"
-            style={{ fontSize: 15 }}
-          >
-            {full}
-          </text>
-          <text
-            x="72"
-            y="180"
-            textAnchor="middle"
-            className="fill-white/85 font-medium"
-            style={{ fontSize: 8 }}
-          >
-            {t("nation.story.unit.mton")}
-          </text>
-        </svg>
-      </div>
+        <text
+          x="72"
+          y="168"
+          textAnchor="middle"
+          className="fill-white font-semibold"
+          style={{ fontSize: 15 }}
+        >
+          {full}
+        </text>
+        <text
+          x="72"
+          y="180"
+          textAnchor="middle"
+          className="fill-white/85 font-medium"
+          style={{ fontSize: 8 }}
+        >
+          {t("nation.story.unit.mton")}
+        </text>
+      </svg>
     </motion.div>
   );
 }

--- a/src/components/nation/story/NationStackedChart.tsx
+++ b/src/components/nation/story/NationStackedChart.tsx
@@ -124,7 +124,9 @@ export const NationStackedChart: FC<NationStackedChartProps> = ({
               "pb-1 md:pb-3 [&>div]:pb-1 [&>div]:mb-0 md:[&>div]:mb-2",
             )}
           >
-            <h2 className={`${NATION_STORY_TYPE.title} text-white mb-2 md:mb-4`}>
+            <h2
+              className={`${NATION_STORY_TYPE.title} text-white mb-2 md:mb-4`}
+            >
               {t("nation.story.stacked.title")}
             </h2>
 

--- a/src/components/nation/story/NationStackedChart.tsx
+++ b/src/components/nation/story/NationStackedChart.tsx
@@ -23,12 +23,12 @@ import {
   getXAxisProps,
   type LegendItem,
 } from "@/components/charts";
-import { CardHeader } from "@/components/layout/CardHeader";
 import { SectionWithHelp } from "@/data-guide/SectionWithHelp";
 import { cn } from "@/lib/utils";
 import {
   NATION_STORY_CHART,
   NATION_STORY_COLORS,
+  NATION_STORY_TYPE,
 } from "@/components/nation/story/nationStoryColors";
 import { usePinnedSteps } from "@/components/nation/story/usePinnedSteps";
 
@@ -124,11 +124,9 @@ export const NationStackedChart: FC<NationStackedChartProps> = ({
               "pb-1 md:pb-3 [&>div]:pb-1 [&>div]:mb-0 md:[&>div]:mb-2",
             )}
           >
-            <CardHeader
-              title={t("nation.story.stacked.title")}
-              unit={t("nation.story.unit.mton")}
-              className="[&>div]:mb-2 md:[&>div]:mb-4 [&>div]:@lg:mb-6 [&_.text-4xl]:!text-xl md:[&_.text-4xl]:!text-4xl [&_[class*='text-grey']]:text-white/85 [&_[class*='text-grey']]:text-sm md:[&_[class*='text-grey']]:text-lg"
-            />
+            <h2 className={`${NATION_STORY_TYPE.title} text-white mb-2 md:mb-4`}>
+              {t("nation.story.stacked.title")}
+            </h2>
 
             {/* Caption explaining the layer currently being drawn */}
             <div className="min-h-[2rem] md:min-h-[2.5rem] mb-1 md:mb-2">
@@ -137,7 +135,7 @@ export const NationStackedChart: FC<NationStackedChartProps> = ({
                 initial={{ opacity: 0, y: 6 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.4 }}
-                className="flex items-center gap-2 md:gap-3 text-sm md:text-lg text-white font-medium"
+                className={`flex items-center gap-2 md:gap-3 ${NATION_STORY_TYPE.emphasis} text-white`}
               >
                 <span
                   className="w-3 h-3 md:w-4 md:h-4 rounded-full shrink-0"
@@ -217,7 +215,7 @@ export const NationStackedChart: FC<NationStackedChartProps> = ({
             <ChartFooter className="mt-1 mb-0 space-y-2">
               <EnhancedLegend
                 items={visibleLegendItems}
-                className="gap-1.5 md:gap-3 [&_span]:text-xs md:[&_span]:text-lg"
+                className="gap-1.5 md:gap-3 [&_span]:text-sm md:[&_span]:text-base"
               />
             </ChartFooter>
           </SectionWithHelp>

--- a/src/components/nation/story/NationStoryPage.tsx
+++ b/src/components/nation/story/NationStoryPage.tsx
@@ -7,7 +7,10 @@ import { NationEmissionsJourney } from "@/components/nation/story/NationEmission
 import { NationIntroPunch } from "@/components/nation/story/NationIntroPunch";
 import { NationStackedChart } from "@/components/nation/story/NationStackedChart";
 import { StoryScrollHint } from "@/components/nation/story/StoryScrollHint";
-import { NATION_STORY_TEXT, NATION_STORY_TYPE } from "@/components/nation/story/nationStoryColors";
+import {
+  NATION_STORY_TEXT,
+  NATION_STORY_TYPE,
+} from "@/components/nation/story/nationStoryColors";
 import type { NationStoryDetails } from "@/hooks/nation/useNationStoryDetails";
 import type { NationStoryMetrics } from "@/utils/data/nationStoryMetrics";
 

--- a/src/components/nation/story/NationStoryPage.tsx
+++ b/src/components/nation/story/NationStoryPage.tsx
@@ -33,45 +33,31 @@ export function NationStoryPage({
 
   return (
     <div className="bg-black text-white pb-16 md:pb-24">
-      {/* Intro: text + tall Sweden map side-by-side on desktop */}
-      <section className="relative flex items-center justify-center min-h-[100svh] px-4 md:px-8 pt-4 md:pt-8 pb-20 md:pb-28">
-        <div className="w-full max-w-4xl mx-auto pt-1 md:pt-2">
-          <div className="flex flex-col items-center text-center md:text-left md:items-start gap-2 mb-4 md:mb-6">
-            <img
-              src="https://upload.wikimedia.org/wikipedia/commons/4/4c/Flag_of_Sweden.svg"
-              alt=""
-              className="h-8 w-12 md:h-10 md:w-16 object-contain opacity-90 rounded-sm"
-            />
-            <h1 className="text-2xl md:text-5xl font-light text-white">
-              {t("nation.story.intro.title")}
-            </h1>
-          </div>
-
-          <div className="grid grid-cols-1 md:grid-cols-[minmax(0,1fr)_auto] gap-5 md:gap-10 items-center">
-            <div className="space-y-3 md:space-y-5 text-center md:text-left order-2 md:order-1">
-              <p
-                className={`text-base md:text-xl ${NATION_STORY_TEXT.body} leading-snug md:leading-relaxed`}
-              >
-                {t("nation.story.intro.paragraph1")}
-              </p>
-              <p
-                className={`text-sm md:text-lg ${NATION_STORY_TEXT.body} leading-snug md:leading-relaxed`}
-              >
-                {t("nation.story.intro.paragraph2")}
-              </p>
-              <p className="text-base md:text-xl text-white leading-snug md:leading-relaxed font-medium">
-                {t("nation.story.intro.paragraph3")}
-              </p>
-            </div>
-
-            {/* Narrow column keeps the tall silhouette from dominating */}
-            <div className="order-1 md:order-2 flex justify-center md:justify-end">
-              <NationIntroPunch
-                metrics={metrics}
-                className="w-[100px] sm:w-[112px] md:w-[128px] md:mx-0"
-              />
-            </div>
-          </div>
+      {/* Intro */}
+      <section className="relative flex items-start justify-center min-h-[100svh] px-4 md:px-8 pt-4 md:pt-8 pb-20 md:pb-28">
+        <div className="max-w-3xl mx-auto text-center space-y-3 md:space-y-5 pt-1 md:pt-2">
+          <img
+            src="https://upload.wikimedia.org/wikipedia/commons/4/4c/Flag_of_Sweden.svg"
+            alt=""
+            className="h-8 w-12 md:h-10 md:w-16 mx-auto object-contain opacity-90 rounded-sm"
+          />
+          <h1 className="text-2xl md:text-5xl font-light text-white">
+            {t("nation.story.intro.title")}
+          </h1>
+          <p
+            className={`text-base md:text-xl ${NATION_STORY_TEXT.body} leading-snug md:leading-relaxed`}
+          >
+            {t("nation.story.intro.paragraph1")}
+          </p>
+          <NationIntroPunch metrics={metrics} />
+          <p
+            className={`text-sm md:text-lg ${NATION_STORY_TEXT.body} leading-snug md:leading-relaxed`}
+          >
+            {t("nation.story.intro.paragraph2")}
+          </p>
+          <p className="text-base md:text-xl text-white leading-snug md:leading-relaxed font-medium">
+            {t("nation.story.intro.paragraph3")}
+          </p>
         </div>
       </section>
 

--- a/src/components/nation/story/NationStoryPage.tsx
+++ b/src/components/nation/story/NationStoryPage.tsx
@@ -7,7 +7,7 @@ import { NationEmissionsJourney } from "@/components/nation/story/NationEmission
 import { NationIntroPunch } from "@/components/nation/story/NationIntroPunch";
 import { NationStackedChart } from "@/components/nation/story/NationStackedChart";
 import { StoryScrollHint } from "@/components/nation/story/StoryScrollHint";
-import { NATION_STORY_TEXT } from "@/components/nation/story/nationStoryColors";
+import { NATION_STORY_TEXT, NATION_STORY_TYPE } from "@/components/nation/story/nationStoryColors";
 import type { NationStoryDetails } from "@/hooks/nation/useNationStoryDetails";
 import type { NationStoryMetrics } from "@/utils/data/nationStoryMetrics";
 
@@ -41,21 +41,17 @@ export function NationStoryPage({
             alt=""
             className="h-8 w-12 md:h-10 md:w-16 mx-auto object-contain opacity-90 rounded-sm"
           />
-          <h1 className="text-2xl md:text-5xl font-light text-white">
+          <h1 className={`${NATION_STORY_TYPE.title} text-white`}>
             {t("nation.story.intro.title")}
           </h1>
-          <p
-            className={`text-base md:text-xl ${NATION_STORY_TEXT.body} leading-snug md:leading-relaxed`}
-          >
+          <p className={`${NATION_STORY_TYPE.body} ${NATION_STORY_TEXT.body}`}>
             {t("nation.story.intro.paragraph1")}
           </p>
           <NationIntroPunch metrics={metrics} />
-          <p
-            className={`text-sm md:text-lg ${NATION_STORY_TEXT.body} leading-snug md:leading-relaxed`}
-          >
+          <p className={`${NATION_STORY_TYPE.body} ${NATION_STORY_TEXT.body}`}>
             {t("nation.story.intro.paragraph2")}
           </p>
-          <p className="text-base md:text-xl text-white leading-snug md:leading-relaxed font-medium">
+          <p className={`${NATION_STORY_TYPE.body} text-white font-medium`}>
             {t("nation.story.intro.paragraph3")}
           </p>
         </div>
@@ -75,7 +71,7 @@ export function NationStoryPage({
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: false, amount: 0.5 }}
             transition={{ duration: 0.4 }}
-            className={`text-sm md:text-lg uppercase tracking-widest ${NATION_STORY_TEXT.eyebrow}`}
+            className={`${NATION_STORY_TYPE.eyebrow} ${NATION_STORY_TEXT.eyebrow}`}
           >
             {t("nation.story.interlude.eyebrow")}
           </motion.p>
@@ -84,7 +80,7 @@ export function NationStoryPage({
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: false, amount: 0.5 }}
             transition={{ duration: 0.45, delay: 0.05 }}
-            className="text-2xl md:text-5xl font-light leading-tight"
+            className={`${NATION_STORY_TYPE.title} leading-tight`}
           >
             {t("nation.story.interlude.title")}
           </motion.h2>
@@ -93,7 +89,7 @@ export function NationStoryPage({
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: false, amount: 0.5 }}
             transition={{ duration: 0.5, delay: 0.15 }}
-            className={`text-base md:text-2xl ${NATION_STORY_TEXT.body} leading-snug md:leading-relaxed`}
+            className={`${NATION_STORY_TYPE.body} ${NATION_STORY_TEXT.body}`}
           >
             {t("nation.story.interlude.body")}
           </motion.p>

--- a/src/components/nation/story/NationStoryPage.tsx
+++ b/src/components/nation/story/NationStoryPage.tsx
@@ -33,31 +33,45 @@ export function NationStoryPage({
 
   return (
     <div className="bg-black text-white pb-16 md:pb-24">
-      {/* Intro */}
-      <section className="relative flex items-start justify-center min-h-[100svh] px-4 md:px-8 pt-4 md:pt-8 pb-20 md:pb-28">
-        <div className="max-w-3xl mx-auto text-center space-y-3 md:space-y-5 pt-1 md:pt-2">
-          <img
-            src="https://upload.wikimedia.org/wikipedia/commons/4/4c/Flag_of_Sweden.svg"
-            alt=""
-            className="h-8 w-12 md:h-10 md:w-16 mx-auto object-contain opacity-90 rounded-sm"
-          />
-          <h1 className="text-2xl md:text-5xl font-light text-white">
-            {t("nation.story.intro.title")}
-          </h1>
-          <p
-            className={`text-base md:text-xl ${NATION_STORY_TEXT.body} leading-snug md:leading-relaxed`}
-          >
-            {t("nation.story.intro.paragraph1")}
-          </p>
-          <NationIntroPunch metrics={metrics} />
-          <p
-            className={`text-sm md:text-lg ${NATION_STORY_TEXT.body} leading-snug md:leading-relaxed`}
-          >
-            {t("nation.story.intro.paragraph2")}
-          </p>
-          <p className="text-base md:text-xl text-white leading-snug md:leading-relaxed font-medium">
-            {t("nation.story.intro.paragraph3")}
-          </p>
+      {/* Intro: text + tall Sweden map side-by-side on desktop */}
+      <section className="relative flex items-center justify-center min-h-[100svh] px-4 md:px-8 pt-4 md:pt-8 pb-20 md:pb-28">
+        <div className="w-full max-w-4xl mx-auto pt-1 md:pt-2">
+          <div className="flex flex-col items-center text-center md:text-left md:items-start gap-2 mb-4 md:mb-6">
+            <img
+              src="https://upload.wikimedia.org/wikipedia/commons/4/4c/Flag_of_Sweden.svg"
+              alt=""
+              className="h-8 w-12 md:h-10 md:w-16 object-contain opacity-90 rounded-sm"
+            />
+            <h1 className="text-2xl md:text-5xl font-light text-white">
+              {t("nation.story.intro.title")}
+            </h1>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-[minmax(0,1fr)_auto] gap-5 md:gap-10 items-center">
+            <div className="space-y-3 md:space-y-5 text-center md:text-left order-2 md:order-1">
+              <p
+                className={`text-base md:text-xl ${NATION_STORY_TEXT.body} leading-snug md:leading-relaxed`}
+              >
+                {t("nation.story.intro.paragraph1")}
+              </p>
+              <p
+                className={`text-sm md:text-lg ${NATION_STORY_TEXT.body} leading-snug md:leading-relaxed`}
+              >
+                {t("nation.story.intro.paragraph2")}
+              </p>
+              <p className="text-base md:text-xl text-white leading-snug md:leading-relaxed font-medium">
+                {t("nation.story.intro.paragraph3")}
+              </p>
+            </div>
+
+            {/* Narrow column keeps the tall silhouette from dominating */}
+            <div className="order-1 md:order-2 flex justify-center md:justify-end">
+              <NationIntroPunch
+                metrics={metrics}
+                className="w-[100px] sm:w-[112px] md:w-[128px] md:mx-0"
+              />
+            </div>
+          </div>
         </div>
       </section>
 

--- a/src/components/nation/story/nationStoryColors.ts
+++ b/src/components/nation/story/nationStoryColors.ts
@@ -18,3 +18,24 @@ export const NATION_STORY_TEXT = {
   secondary: "text-white/75",
   eyebrow: "text-white/70",
 } as const;
+
+/**
+ * Tight type scale for the story so each viewport uses a few sizes,
+ * not a unique size per line. Mobile and desktop still step independently.
+ */
+export const NATION_STORY_TYPE = {
+  /** Section titles (intro, interlude, conclusion, stacked chart) */
+  title: "text-2xl md:text-5xl font-light",
+  /** Narrative paragraphs and step body copy */
+  body: "text-base md:text-xl leading-snug md:leading-relaxed",
+  /** Step/layer headers with color dots – same size as body, heavier weight */
+  emphasis: "text-base md:text-xl font-medium",
+  /** Eyebrows like “Conclusion” */
+  eyebrow: "text-sm md:text-lg uppercase tracking-widest",
+  /** Legend rows, data-year, bathtub captions */
+  meta: "text-sm md:text-base",
+  /** Large stats (conclusion totals) */
+  display: "text-4xl md:text-8xl font-light tabular-nums leading-none",
+  /** Mid stats (bathtub year, onion total) */
+  stat: "text-2xl md:text-5xl font-light tabular-nums",
+} as const;


### PR DESCRIPTION
## Summary
- Add a shared `NATION_STORY_TYPE` scale so body, meta, emphasis, and titles stay consistent within mobile and within desktop
- Align stacked chart title with intro (“Sweden’s emissions”), remove the redundant Mt under the chart title
- Soften bathtub question sizing to match step headers; keep conclusion display numbers larger as intentional stats

Also includes earlier polish on this branch: restore onion step headers, and revert the side-by-side intro map experiment.

## Test plan
- [ ] Scroll the Sweden nation story on desktop and confirm paragraphs / legends / data-year share sizes
- [ ] Confirm stacked chart title matches intro title size and has no Mt under the title
- [ ] Spot-check onion journey, bathtub, interlude, and conclusion on mobile


Made with [Cursor](https://cursor.com)