### PR TITLE
Scale nation story intro map to the viewport

### DIFF
--- a/src/components/nation/story/NationIntroPunch.tsx
+++ b/src/components/nation/story/NationIntroPunch.tsx
@@ -31,12 +31,15 @@ export function NationIntroPunch({ metrics }: NationIntroPunchProps) {
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true, amount: 0.35 }}
       transition={{ duration: 0.45 }}
-      className="py-1 space-y-2"
     >
-      <div className="relative mx-auto w-[112px] md:w-[168px]">
+      {/*
+        Fluid height: small phones stay compact, short laptops shrink,
+        large desktops can grow toward the original silhouette size.
+      */}
+      <div className="relative mx-auto h-[clamp(120px,26svh,180px)] md:h-[clamp(180px,30svh,340px)] w-auto aspect-[100/220]">
         <svg
           viewBox={SWEDEN_OUTLINE_VIEWBOX}
-          className="w-full h-auto"
+          className="h-full w-auto max-w-full mx-auto"
           role="img"
           aria-label={`${reported}–${full} ${t("nation.story.unit.mton")}`}
         >

--- a/src/components/nation/story/NationStoryPage.tsx
+++ b/src/components/nation/story/NationStoryPage.tsx
@@ -37,12 +37,12 @@ export function NationStoryPage({
   return (
     <div className="bg-black text-white pb-16 md:pb-24">
       {/* Intro */}
-      <section className="relative flex items-start justify-center min-h-[100svh] px-4 md:px-8 pt-4 md:pt-8 pb-20 md:pb-28">
-        <div className="max-w-3xl mx-auto text-center space-y-3 md:space-y-5 pt-1 md:pt-2">
+      <section className="relative flex items-start justify-center min-h-[100svh] px-4 md:px-8 pt-1 md:pt-2 pb-12 md:pb-14">
+        <div className="max-w-3xl mx-auto text-center space-y-2 md:space-y-3">
           <img
             src="https://upload.wikimedia.org/wikipedia/commons/4/4c/Flag_of_Sweden.svg"
             alt=""
-            className="h-8 w-12 md:h-10 md:w-16 mx-auto object-contain opacity-90 rounded-sm"
+            className="h-7 w-10 md:h-10 md:w-16 mx-auto object-contain opacity-90 rounded-sm"
           />
           <h1 className={`${NATION_STORY_TYPE.title} text-white`}>
             {t("nation.story.intro.title")}


### PR DESCRIPTION
## Summary
- Size the intro Sweden silhouette with fluid `clamp()` heights so short desktop/laptop viewports keep the full intro above the fold
- Allow the map to grow again on larger screens (up to ~340px)
- Tighten intro padding and spacing slightly to reclaim a bit of vertical room

## Test plan
- [ ] Short laptop / smaller desktop: full intro (including the final “step by step” line) visible without clipping
- [ ] Large desktop: map feels appropriately large, not tiny
- [ ] Mobile (small and regular): intro still reads well; map not oversized


Made with [Cursor](https://cursor.com)