### PR TITLE
Nation story scroll fix, bathtub layout, methodology stub

### DIFF
--- a/src/components/methods/content/NationEmissionsLayersContent.tsx
+++ b/src/components/methods/content/NationEmissionsLayersContent.tsx
@@ -1,38 +1,10 @@
 import { Trans, useTranslation } from "react-i18next";
 import { MethodSection } from "@/components/layout/MethodSection";
 
-const RESULTS_SHEET_URL =
-  "https://docs.google.com/spreadsheets/d/1_qFzu0h0sjyrQTYEPDaAQCYeLAVYsbt3";
-
 function Paragraph({ i18nKey }: { i18nKey: string }) {
   return (
     <p>
       <Trans i18nKey={i18nKey} />
-    </p>
-  );
-}
-
-function ParagraphWithLinks({
-  i18nKey,
-  hrefs,
-}: {
-  i18nKey: string;
-  hrefs: string[];
-}) {
-  return (
-    <p>
-      <Trans
-        i18nKey={i18nKey}
-        components={hrefs.map((href) => (
-          <a
-            key={href}
-            href={href}
-            className="underline hover:text-white transition-colors"
-            target="_blank"
-            rel="noopener noreferrer"
-          />
-        ))}
-      />
     </p>
   );
 }
@@ -78,11 +50,7 @@ export const NationEmissionsLayersContent = () => {
       <MethodSection title={t(`${base}.intro.title`)}>
         <Paragraph i18nKey={`${base}.intro.paragraph1`} />
         <Paragraph i18nKey={`${base}.intro.paragraph2`} />
-        <ParagraphWithLinks
-          i18nKey={`${base}.intro.paragraph3`}
-          hrefs={[RESULTS_SHEET_URL]}
-        />
-        <Paragraph i18nKey={`${base}.intro.paragraph4`} />
+        <Paragraph i18nKey={`${base}.intro.paragraph3`} />
       </MethodSection>
 
       <MethodSection title={t(`${base}.perspectives.title`)}>

--- a/src/components/methods/content/NationEmissionsLayersContent.tsx
+++ b/src/components/methods/content/NationEmissionsLayersContent.tsx
@@ -1,19 +1,204 @@
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import { MethodSection } from "@/components/layout/MethodSection";
 
+const RESULTS_SHEET_URL =
+  "https://docs.google.com/spreadsheets/d/1_qFzu0h0sjyrQTYEPDaAQCYeLAVYsbt3";
+
+function Paragraph({ i18nKey }: { i18nKey: string }) {
+  return (
+    <p>
+      <Trans i18nKey={i18nKey} />
+    </p>
+  );
+}
+
+function ParagraphWithLinks({
+  i18nKey,
+  hrefs,
+}: {
+  i18nKey: string;
+  hrefs: string[];
+}) {
+  return (
+    <p>
+      <Trans
+        i18nKey={i18nKey}
+        components={hrefs.map((href) => (
+          <a
+            key={href}
+            href={href}
+            className="underline hover:text-white transition-colors"
+            target="_blank"
+            rel="noopener noreferrer"
+          />
+        ))}
+      />
+    </p>
+  );
+}
+
+function SourceList({
+  items,
+}: {
+  items: { labelKey: string; href?: string }[];
+}) {
+  const { t } = useTranslation();
+  return (
+    <ul className="list-disc pl-5 space-y-2">
+      {items.map((item) => (
+        <li key={item.labelKey}>
+          {item.href ? (
+            <a
+              href={item.href}
+              className="underline hover:text-white transition-colors"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {t(item.labelKey)}
+            </a>
+          ) : (
+            t(item.labelKey)
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
 /**
- * Placeholder for Sweden national emissions methodology (full picture / story layers).
- * Detailed copy will be filled in later.
+ * Methodology for Sweden’s full national emissions picture
+ * (production, consumption abroad, biogenic) used in the nation story.
  */
 export const NationEmissionsLayersContent = () => {
   const { t } = useTranslation();
+  const base = "methodsPage.nation.nationEmissionsLayers";
 
   return (
-    <div className="prose prose-invert mx-auto space-y-8">
-      <MethodSection
-        title={t("methodsPage.nation.nationEmissionsLayers.sectionTitle")}
-      >
-        <p>{t("methodsPage.nation.nationEmissionsLayers.placeholder")}</p>
+    <div className="prose prose-invert mx-auto space-y-10">
+      <MethodSection title={t(`${base}.intro.title`)}>
+        <Paragraph i18nKey={`${base}.intro.paragraph1`} />
+        <Paragraph i18nKey={`${base}.intro.paragraph2`} />
+        <ParagraphWithLinks
+          i18nKey={`${base}.intro.paragraph3`}
+          hrefs={[RESULTS_SHEET_URL]}
+        />
+        <Paragraph i18nKey={`${base}.intro.paragraph4`} />
+      </MethodSection>
+
+      <MethodSection title={t(`${base}.perspectives.title`)}>
+        <Paragraph i18nKey={`${base}.perspectives.paragraph1`} />
+        <ul className="list-disc pl-5 space-y-2">
+          <li>{t(`${base}.perspectives.production`)}</li>
+          <li>{t(`${base}.perspectives.consumption`)}</li>
+          <li>{t(`${base}.perspectives.biogenic`)}</li>
+        </ul>
+        <Paragraph i18nKey={`${base}.perspectives.paragraph2`} />
+      </MethodSection>
+
+      <MethodSection title={t(`${base}.territorial.title`)}>
+        <Paragraph i18nKey={`${base}.territorial.paragraph1`} />
+        <Paragraph i18nKey={`${base}.territorial.paragraph2`} />
+        <SourceList
+          items={[
+            {
+              labelKey: `${base}.territorial.sources.nv`,
+              href: "https://www.naturvardsverket.se/data-och-statistik/klimat/sveriges-utslapp-och-upptag-av-vaxthusgaser",
+            },
+          ]}
+        />
+      </MethodSection>
+
+      <MethodSection title={t(`${base}.production.title`)}>
+        <Paragraph i18nKey={`${base}.production.paragraph1`} />
+        <Paragraph i18nKey={`${base}.production.paragraph2`} />
+        <Paragraph i18nKey={`${base}.production.paragraph3`} />
+        <SourceList
+          items={[
+            {
+              labelKey: `${base}.production.sources.scbBunker`,
+              href: "https://www.statistikdatabasen.scb.se/pxweb/sv/ssd/START__MI__MI0107/TotaltUtslappN",
+            },
+            {
+              labelKey: `${base}.production.sources.scbAccounts`,
+              href: "https://www.statistikdatabasen.scb.se/pxweb/sv/ssd/START__MI__MI1301__MI1301B/MiljoUtslappAmneSNIK",
+            },
+            {
+              labelKey: `${base}.production.sources.scbQuality`,
+              href: "https://www.scb.se/contentassets/f0d9c7eda5be4b8a96c5827e4bebf513/mi1301_kd_2024_fk_20260326.pdf",
+            },
+          ]}
+        />
+      </MethodSection>
+
+      <MethodSection title={t(`${base}.consumption.title`)}>
+        <Paragraph i18nKey={`${base}.consumption.paragraph1`} />
+        <Paragraph i18nKey={`${base}.consumption.paragraph2`} />
+        <Paragraph i18nKey={`${base}.consumption.paragraph3`} />
+        <Paragraph i18nKey={`${base}.consumption.paragraph4`} />
+        <Paragraph i18nKey={`${base}.consumption.paragraph5`} />
+        <Paragraph i18nKey={`${base}.consumption.paragraph6`} />
+        <SourceList
+          items={[
+            {
+              labelKey: `${base}.consumption.sources.gcp`,
+              href: "https://www.icos-cp.eu/science-and-impact/global-carbon-budget/2025",
+            },
+            {
+              labelKey: `${base}.consumption.sources.edgar`,
+              href: "https://edgar.jrc.ec.europa.eu/report_2025",
+            },
+            {
+              labelKey: `${base}.consumption.sources.scb`,
+              href: "https://www.statistikdatabasen.scb.se/pxweb/sv/ssd/START__MI__MI1301__MI1301F/MI1301MPSPINN",
+            },
+            {
+              labelKey: `${base}.consumption.sources.chalmers`,
+              href: "https://research.chalmers.se/publication/506746",
+            },
+            {
+              labelKey: `${base}.consumption.sources.trafa`,
+              href: "https://www.trafa.se/luftfart2/luftfart",
+            },
+            {
+              labelKey: `${base}.consumption.sources.svenskHandel`,
+              href: "https://www.svenskhandel.se/rapporter/e-handelsindikatorn/e-handelsindikatorn-helar-2025",
+            },
+          ]}
+        />
+      </MethodSection>
+
+      <MethodSection title={t(`${base}.biogenic.title`)}>
+        <Paragraph i18nKey={`${base}.biogenic.paragraph1`} />
+        <Paragraph i18nKey={`${base}.biogenic.paragraph2`} />
+        <Paragraph i18nKey={`${base}.biogenic.paragraph3`} />
+        <SourceList
+          items={[
+            {
+              labelKey: `${base}.biogenic.sources.nv`,
+              href: "https://www.naturvardsverket.se/data-och-statistik/klimat/utslapp-av-biogen-koldioxid-fran-forbranning-av-biomassa-i-sverige",
+            },
+            {
+              labelKey: `${base}.biogenic.sources.scb`,
+              href: "https://www.statistikdatabasen.scb.se/pxweb/sv/ssd/START__MI__MI1301__MI1301B/MiljoUtslappAmneSNIK",
+            },
+          ]}
+        />
+      </MethodSection>
+
+      <MethodSection title={t(`${base}.total.title`)}>
+        <Paragraph i18nKey={`${base}.total.paragraph1`} />
+        <Paragraph i18nKey={`${base}.total.paragraph2`} />
+        <Paragraph i18nKey={`${base}.total.paragraph3`} />
+      </MethodSection>
+
+      <MethodSection title={t(`${base}.limitations.title`)}>
+        <Paragraph i18nKey={`${base}.limitations.paragraph1`} />
+        <ul className="list-disc pl-5 space-y-2">
+          <li>{t(`${base}.limitations.item1`)}</li>
+          <li>{t(`${base}.limitations.item2`)}</li>
+          <li>{t(`${base}.limitations.item3`)}</li>
+          <li>{t(`${base}.limitations.item4`)}</li>
+        </ul>
       </MethodSection>
     </div>
   );

--- a/src/components/methods/content/NationEmissionsLayersContent.tsx
+++ b/src/components/methods/content/NationEmissionsLayersContent.tsx
@@ -1,0 +1,20 @@
+import { useTranslation } from "react-i18next";
+import { MethodSection } from "@/components/layout/MethodSection";
+
+/**
+ * Placeholder for Sweden national emissions methodology (full picture / story layers).
+ * Detailed copy will be filled in later.
+ */
+export const NationEmissionsLayersContent = () => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="prose prose-invert mx-auto space-y-8">
+      <MethodSection
+        title={t("methodsPage.nation.nationEmissionsLayers.sectionTitle")}
+      >
+        <p>{t("methodsPage.nation.nationEmissionsLayers.placeholder")}</p>
+      </MethodSection>
+    </div>
+  );
+};

--- a/src/components/methods/methodContentRegistry.ts
+++ b/src/components/methods/methodContentRegistry.ts
@@ -12,6 +12,7 @@ import { CarbonLawContent } from "./content/CarbonLaw";
 import { MunicipalityAndRegionDataOverviewContent } from "./content/MunicipalityAndRegionDataOverview";
 import { MunicipalityKPIsContent } from "./content/MunicipalityKPIsContent";
 import { NationDataOverviewContent } from "./content/NationDataOverview";
+import { NationEmissionsLayersContent } from "./content/NationEmissionsLayersContent";
 import { ParisAlignmentMethodContent } from "./content/OnTrackForParisContent";
 import { TrendlineContent } from "./content/TrendLineMethodContent";
 import { InterpretingOnTrackContent } from "./content/InprepretingOnTrackContent";
@@ -33,6 +34,7 @@ const METHOD_CONTENT_COMPONENTS: Record<string, ComponentType> = {
   companyDataCollection: DataCollectionProcessContent,
   relatableNumbers: RelatableNumbersContent,
   nationDataOverview: NationDataOverviewContent,
+  nationEmissionsLayers: NationEmissionsLayersContent,
 };
 
 export function getMethodContentComponent(method: string) {

--- a/src/components/nation/story/NationBathtub.tsx
+++ b/src/components/nation/story/NationBathtub.tsx
@@ -40,11 +40,103 @@ type NationBathtubProps = {
   data: NationBathtubDataPoint[];
 };
 
-const TUB_WATER_TOP = 52;
-const TUB_INNER_BOTTOM = 168;
+/** Wide tub geometry (viewBox 520×280) – used full-bleed on desktop with copy inside. */
+const TUB_WATER_TOP = 72;
+const TUB_INNER_BOTTOM = 232;
 const TUB_WATER_HEIGHT = TUB_INNER_BOTTOM - TUB_WATER_TOP;
+const TUB_WATER_LEFT = 48;
+const TUB_WATER_WIDTH = 424;
 const TUB_WATER_CLIP_PATH =
-  "M40 52 h140 v82 c0 24 -26 34 -70 34 s-70 -10 -70 -34 z";
+  "M48 72 h424 v118 c0 32 -48 42 -212 42 s-212 -10 -212 -42 z";
+const TUB_OUTLINE_PATH =
+  "M40 64 h440 v126 c0 36 -52 48 -220 48 s-220 -12 -220 -48 z";
+
+type TubGraphicProps = {
+  waterClipId: string;
+  waterClipUrl: string;
+  chunks: NationBathtubDataPoint[];
+  maxCumulative: number;
+  waterTop: number;
+  /** Stronger fill when copy is not overlaid (mobile). */
+  strongerWater?: boolean;
+  className?: string;
+};
+
+function TubGraphic({
+  waterClipId,
+  waterClipUrl,
+  chunks,
+  maxCumulative,
+  waterTop,
+  strongerWater = false,
+  className,
+}: TubGraphicProps) {
+  return (
+    <svg viewBox="0 0 520 280" className={className} aria-hidden>
+      <path
+        d="M390 18 h36 a7 7 0 0 1 7 7 v12 h-12 v-7 h-31 z"
+        fill="none"
+        stroke="rgba(255,255,255,0.55)"
+        strokeWidth="2.5"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M426 37 v18"
+        stroke="rgba(125, 211, 252, 0.7)"
+        strokeWidth="3"
+        strokeLinecap="round"
+      />
+      <path
+        d={TUB_OUTLINE_PATH}
+        fill="none"
+        stroke="rgba(255,255,255,0.7)"
+        strokeWidth="3"
+        strokeLinejoin="round"
+      />
+      <defs>
+        <clipPath id={waterClipId}>
+          <path d={TUB_WATER_CLIP_PATH} />
+        </clipPath>
+      </defs>
+      <g clipPath={waterClipUrl}>
+        {chunks.map((chunk, index) => {
+          const prevCumulative =
+            index === 0 ? 0 : chunks[index - 1].cumulativeMton;
+          const bottom =
+            TUB_INNER_BOTTOM -
+            (prevCumulative / maxCumulative) * TUB_WATER_HEIGHT;
+          const top =
+            TUB_INNER_BOTTOM -
+            (chunk.cumulativeMton / maxCumulative) * TUB_WATER_HEIGHT;
+          const height = Math.max(bottom - top, 0);
+          const fillAlpha = strongerWater
+            ? 0.28 + (index / Math.max(chunks.length, 1)) * 0.4
+            : 0.1 + (index / Math.max(chunks.length, 1)) * 0.22;
+          return (
+            <motion.rect
+              key={chunk.year}
+              x={TUB_WATER_LEFT}
+              width={TUB_WATER_WIDTH}
+              initial={{ y: bottom, height: 0, opacity: 0 }}
+              animate={{ y: top, height, opacity: 1 }}
+              transition={{ duration: 0.45, ease: [0.22, 1, 0.36, 1] }}
+              fill={`rgba(56, 189, 248, ${fillAlpha})`}
+            />
+          );
+        })}
+        <motion.line
+          x1={TUB_WATER_LEFT}
+          x2={TUB_WATER_LEFT + TUB_WATER_WIDTH}
+          stroke="rgba(186, 230, 253, 0.75)"
+          strokeWidth="2"
+          initial={false}
+          animate={{ y1: waterTop, y2: waterTop }}
+          transition={{ duration: 0.45, ease: [0.22, 1, 0.36, 1] }}
+        />
+      </g>
+    </svg>
+  );
+}
 
 export function NationBathtub({ data }: NationBathtubProps) {
   const { t } = useTranslation();
@@ -87,9 +179,34 @@ export function NationBathtub({ data }: NationBathtubProps) {
           toYear: chunkToYear,
         });
 
+  const yearBlock = (
+    <div className="text-center space-y-0.5 md:space-y-1 min-h-[3.5rem] md:min-h-[4.5rem]">
+      <motion.p
+        key={current.year}
+        initial={{ opacity: 0, y: 6 }}
+        animate={{ opacity: 1, y: 0 }}
+        className={NATION_STORY_TYPE.stat}
+      >
+        {current.year}
+      </motion.p>
+      <p className={`${NATION_STORY_TYPE.meta} ${NATION_STORY_TEXT.body}`}>
+        {t("nation.story.bathtub.levelCaption", {
+          value: formatMton(current.cumulativeMton, currentLanguage, 0),
+        })}
+      </p>
+      <p className={`${NATION_STORY_TYPE.meta} ${NATION_STORY_TEXT.secondary}`}>
+        {chunkCaption}
+      </p>
+    </div>
+  );
+
   return (
     <section
       ref={ref}
+      data-story-section
+      data-story-step={step}
+      data-story-steps={steps.length}
+      data-story-step-vh={70}
       className="relative"
       style={{ height: `${sectionVh}vh` }}
     >
@@ -97,10 +214,23 @@ export function NationBathtub({ data }: NationBathtubProps) {
         className="h-[100svh] flex items-center px-4 md:px-8 py-3 md:py-0"
         style={stageStyle}
       >
-        <div className="w-full max-w-3xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-14 items-center">
-          <div className="space-y-3 md:space-y-6 text-center md:text-left order-2 md:order-1">
+        {/* Mobile: compact tub on top, copy below (Swedish text is too long for the basin). */}
+        <div className="w-full max-w-3xl mx-auto md:hidden space-y-3">
+          <div className="flex flex-col items-center gap-2">
+            <TubGraphic
+              waterClipId={waterClipId}
+              waterClipUrl={waterClipUrl}
+              chunks={chunks}
+              maxCumulative={maxCumulative}
+              waterTop={waterTop}
+              strongerWater
+              className="w-44 h-auto"
+            />
+            {yearBlock}
+          </div>
+          <div className="space-y-2.5 text-center">
             <motion.p
-              initial={{ opacity: 0, y: 16 }}
+              initial={{ opacity: 0, y: 12 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.45 }}
               className={`${NATION_STORY_TYPE.body} ${NATION_STORY_TEXT.body}`}
@@ -108,7 +238,7 @@ export function NationBathtub({ data }: NationBathtubProps) {
               {t("nation.story.bathtub.text")}
             </motion.p>
             <motion.p
-              initial={{ opacity: 0, y: 12 }}
+              initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.45, delay: 0.1 }}
               className={`${NATION_STORY_TYPE.emphasis} text-white`}
@@ -116,102 +246,39 @@ export function NationBathtub({ data }: NationBathtubProps) {
               {t("nation.story.bathtub.question")}
             </motion.p>
           </div>
+        </div>
 
-          <div className="flex flex-col items-center gap-2 md:gap-4 order-1 md:order-2">
-            <svg
-              viewBox="0 0 220 200"
-              className="w-40 md:w-72 h-auto"
-              aria-hidden
-            >
-              {/* Tap */}
-              <path
-                d="M150 18 h28 a6 6 0 0 1 6 6 v10 h-10 v-6 h-24 z"
-                fill="none"
-                stroke="rgba(255,255,255,0.55)"
-                strokeWidth="2.5"
-                strokeLinejoin="round"
-              />
-              <path
-                d="M178 34 v14"
-                stroke="rgba(125, 211, 252, 0.85)"
-                strokeWidth="3"
-                strokeLinecap="round"
-              />
-              {/* Tub outline */}
-              <path
-                d="M36 48 h148 v88 c0 28 -28 40 -74 40 s-74 -12 -74 -40 z"
-                fill="none"
-                stroke="rgba(255,255,255,0.7)"
-                strokeWidth="3"
-                strokeLinejoin="round"
-              />
-              {/* Water chunks clipped inside tub */}
-              <defs>
-                <clipPath id={waterClipId}>
-                  <path d={TUB_WATER_CLIP_PATH} />
-                </clipPath>
-              </defs>
-              <g clipPath={waterClipUrl}>
-                {chunks.map((chunk, index) => {
-                  const prevCumulative =
-                    index === 0 ? 0 : chunks[index - 1].cumulativeMton;
-                  const bottom =
-                    TUB_INNER_BOTTOM -
-                    (prevCumulative / maxCumulative) * TUB_WATER_HEIGHT;
-                  const top =
-                    TUB_INNER_BOTTOM -
-                    (chunk.cumulativeMton / maxCumulative) * TUB_WATER_HEIGHT;
-                  const height = Math.max(bottom - top, 0);
-                  const fillAlpha =
-                    0.35 + (index / Math.max(chunks.length, 1)) * 0.45;
-                  return (
-                    <motion.rect
-                      key={chunk.year}
-                      x={40}
-                      width={140}
-                      initial={{ y: bottom, height: 0, opacity: 0 }}
-                      animate={{ y: top, height, opacity: 1 }}
-                      transition={{ duration: 0.45, ease: [0.22, 1, 0.36, 1] }}
-                      fill={`rgba(56, 189, 248, ${fillAlpha})`}
-                    />
-                  );
-                })}
-                {/* Surface line */}
-                <motion.line
-                  x1={40}
-                  x2={180}
-                  stroke="rgba(186, 230, 253, 0.95)"
-                  strokeWidth="2"
-                  initial={false}
-                  animate={{ y1: waterTop, y2: waterTop }}
-                  transition={{ duration: 0.45, ease: [0.22, 1, 0.36, 1] }}
-                />
-              </g>
-            </svg>
-
-            <div className="text-center space-y-0.5 md:space-y-1 min-h-[3.5rem] md:min-h-[4.5rem]">
+        {/* Desktop: wide tub with copy inside translucent water. */}
+        <div className="hidden md:block w-full max-w-4xl mx-auto">
+          <div className="relative mx-auto w-full">
+            <TubGraphic
+              waterClipId={`${waterClipId}-desktop`}
+              waterClipUrl={svgLocalUrl(`${waterClipId}-desktop`)}
+              chunks={chunks}
+              maxCumulative={maxCumulative}
+              waterTop={waterTop}
+              className="w-full h-auto"
+            />
+            <div className="pointer-events-none absolute inset-x-[12%] top-[28%] bottom-[26%] flex flex-col items-center justify-center gap-4 text-center px-6">
               <motion.p
-                key={current.year}
-                initial={{ opacity: 0, y: 6 }}
+                initial={{ opacity: 0, y: 12 }}
                 animate={{ opacity: 1, y: 0 }}
-                className={NATION_STORY_TYPE.stat}
+                transition={{ duration: 0.45 }}
+                className="text-lg leading-relaxed text-white [text-shadow:0_1px_10px_rgba(0,0,0,0.55)]"
               >
-                {current.year}
+                {t("nation.story.bathtub.text")}
               </motion.p>
-              <p
-                className={`${NATION_STORY_TYPE.meta} ${NATION_STORY_TEXT.body}`}
+              <motion.p
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.45, delay: 0.1 }}
+                className="text-xl font-medium text-white [text-shadow:0_1px_10px_rgba(0,0,0,0.55)]"
               >
-                {t("nation.story.bathtub.levelCaption", {
-                  value: formatMton(current.cumulativeMton, currentLanguage, 0),
-                })}
-              </p>
-              <p
-                className={`${NATION_STORY_TYPE.meta} ${NATION_STORY_TEXT.secondary}`}
-              >
-                {chunkCaption}
-              </p>
+                {t("nation.story.bathtub.question")}
+              </motion.p>
             </div>
           </div>
+          <div className="mt-4">{yearBlock}</div>
         </div>
       </div>
     </section>

--- a/src/components/nation/story/NationConclusion.tsx
+++ b/src/components/nation/story/NationConclusion.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { motion } from "framer-motion";
 import {
@@ -17,7 +18,7 @@ type NationConclusionProps = {
 
 export function NationConclusion({ metrics }: NationConclusionProps) {
   const { t } = useTranslation();
-  const { currentLanguage } = useLanguage();
+  const { currentLanguage, getLocalizedPath } = useLanguage();
 
   return (
     <div className="max-w-3xl mx-auto text-center space-y-5 md:space-y-8">
@@ -106,6 +107,21 @@ export function NationConclusion({ metrics }: NationConclusionProps) {
           </p>
         </div>
       </motion.div>
+
+      <motion.p
+        initial={{ opacity: 0, y: 12 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: false, amount: 0.4 }}
+        transition={{ duration: 0.4, delay: 0.2 }}
+        className={`${NATION_STORY_TYPE.meta} ${NATION_STORY_TEXT.secondary}`}
+      >
+        <Link
+          to={getLocalizedPath("/methodology?view=nationEmissionsLayers")}
+          className="underline underline-offset-4 decoration-white/40 hover:text-white hover:decoration-white transition-colors"
+        >
+          {t("nation.story.conclusion.methodologyLink")}
+        </Link>
+      </motion.p>
     </div>
   );
 }

--- a/src/components/nation/story/NationEmissionsJourney.tsx
+++ b/src/components/nation/story/NationEmissionsJourney.tsx
@@ -142,6 +142,10 @@ export function NationEmissionsJourney({
   return (
     <section
       ref={ref}
+      data-story-section
+      data-story-step={step}
+      data-story-steps={steps.length}
+      data-story-step-vh={JOURNEY_STEP_VH}
       className="relative"
       style={{ height: `${sectionVh}vh` }}
     >

--- a/src/components/nation/story/NationStackedChart.tsx
+++ b/src/components/nation/story/NationStackedChart.tsx
@@ -109,6 +109,10 @@ export const NationStackedChart: FC<NationStackedChartProps> = ({
   return (
     <section
       ref={ref}
+      data-story-section
+      data-story-step={step}
+      data-story-steps={LAYERS.length}
+      data-story-step-vh={90}
       className="relative"
       style={{ height: `${sectionVh}vh` }}
     >

--- a/src/components/nation/story/NationStoryPage.tsx
+++ b/src/components/nation/story/NationStoryPage.tsx
@@ -21,7 +21,10 @@ type NationStoryPageProps = {
 
 function FullScreenSection({ children }: { children: React.ReactNode }) {
   return (
-    <section className="relative min-h-[70vh] md:min-h-[80vh] flex items-center justify-center px-4 md:px-8 py-8 md:py-10">
+    <section
+      data-story-section
+      className="relative min-h-[70vh] md:min-h-[80vh] flex items-center justify-center px-4 md:px-8 py-8 md:py-10"
+    >
       <div className="w-full max-w-4xl mx-auto">{children}</div>
     </section>
   );
@@ -37,7 +40,10 @@ export function NationStoryPage({
   return (
     <div className="bg-black text-white pb-16 md:pb-24">
       {/* Intro */}
-      <section className="relative flex items-start justify-center min-h-[100svh] px-4 md:px-8 pt-1 md:pt-2 pb-12 md:pb-14">
+      <section
+        data-story-section
+        className="relative flex items-start justify-center min-h-[100svh] px-4 md:px-8 pt-1 md:pt-2 pb-12 md:pb-14"
+      >
         <div className="max-w-3xl mx-auto text-center space-y-2 md:space-y-3">
           <img
             src="https://upload.wikimedia.org/wikipedia/commons/4/4c/Flag_of_Sweden.svg"
@@ -105,6 +111,7 @@ export function NationStoryPage({
       {/* Conclusion – the punchline tying the journey together */}
       <section
         ref={conclusionRef}
+        data-story-section
         className="relative min-h-[80vh] flex items-center justify-center px-4 md:px-8 py-10"
       >
         <div className="w-full max-w-4xl mx-auto">

--- a/src/components/nation/story/StoryScrollHint.tsx
+++ b/src/components/nation/story/StoryScrollHint.tsx
@@ -8,6 +8,58 @@ type StoryScrollHintProps = {
   endRef: RefObject<HTMLElement | null>;
 };
 
+/**
+ * Advance one pin-step inside a multi-step section, or jump to the next
+ * `[data-story-section]` when on its last step. Avoids the “black gap”
+ * that a fixed scrollBy leaves at the end of tall pinned sections.
+ */
+function scrollToNextStoryBeat() {
+  const sections = Array.from(
+    document.querySelectorAll<HTMLElement>("[data-story-section]"),
+  );
+  if (sections.length === 0) {
+    window.scrollBy({ top: window.innerHeight * 0.85, behavior: "smooth" });
+    return;
+  }
+
+  const probeY = window.innerHeight * 0.45;
+  const currentIndex = sections.findIndex((section) => {
+    const rect = section.getBoundingClientRect();
+    return rect.top <= probeY && rect.bottom > probeY;
+  });
+
+  if (currentIndex >= 0) {
+    const current = sections[currentIndex];
+    const step = Number(current.dataset.storyStep ?? "0");
+    const stepCount = Number(current.dataset.storySteps ?? "1");
+    const stepVh = Number(current.dataset.storyStepVh ?? "100");
+
+    if (stepCount > 1 && step < stepCount - 1) {
+      window.scrollBy({
+        top: (stepVh / 100) * window.innerHeight,
+        behavior: "smooth",
+      });
+      return;
+    }
+
+    const next = sections[currentIndex + 1];
+    if (next) {
+      next.scrollIntoView({ behavior: "smooth", block: "start" });
+      return;
+    }
+  }
+
+  const nextBelow = sections.find(
+    (section) => section.getBoundingClientRect().top > probeY,
+  );
+  if (nextBelow) {
+    nextBelow.scrollIntoView({ behavior: "smooth", block: "start" });
+    return;
+  }
+
+  window.scrollBy({ top: window.innerHeight * 0.85, behavior: "smooth" });
+}
+
 /** Fixed bounce chevron shown through the story until the conclusion. */
 export function StoryScrollHint({ endRef }: StoryScrollHintProps) {
   const { t } = useTranslation();
@@ -15,35 +67,31 @@ export function StoryScrollHint({ endRef }: StoryScrollHintProps) {
   const endReached = useInView(endRef, { amount: 0.35 });
   const visible = !endReached;
 
-  const scrollDown = () => {
-    window.scrollBy({ top: window.innerHeight * 0.85, behavior: "smooth" });
-  };
-
   return (
     <motion.button
       ref={ref}
       type="button"
-      onClick={scrollDown}
+      onClick={scrollToNextStoryBeat}
       aria-label={t("nation.story.scrollHint.label")}
       aria-hidden={!visible}
       tabIndex={visible ? 0 : -1}
       initial={false}
       animate={
         visible
-          ? { opacity: [0.35, 1, 0.35], y: [0, 10, 0] }
+          ? { opacity: [0.55, 1, 0.55], y: [0, 10, 0] }
           : { opacity: 0, y: 0 }
       }
       transition={
         visible
           ? {
-              opacity: { repeat: Infinity, duration: 1.6, ease: "easeInOut" },
-              y: { repeat: Infinity, duration: 1.6, ease: "easeInOut" },
+              opacity: { repeat: Infinity, duration: 1.4, ease: "easeInOut" },
+              y: { repeat: Infinity, duration: 1.4, ease: "easeInOut" },
             }
           : { duration: 0.35 }
       }
-      className={`fixed inset-x-0 bottom-6 md:bottom-10 z-50 mx-auto flex w-fit items-center justify-center text-white/75 transition-colors hover:text-white ${visible ? "" : "pointer-events-none"}`}
+      className={`fixed inset-x-0 bottom-6 md:bottom-10 z-50 mx-auto flex w-fit items-center justify-center text-white/90 transition-colors hover:text-white ${visible ? "" : "pointer-events-none"}`}
     >
-      <ChevronDown className="h-8 w-8" strokeWidth={2} aria-hidden />
+      <ChevronDown className="h-9 w-9" strokeWidth={2.25} aria-hidden />
     </motion.button>
   );
 }

--- a/src/lib/methods/methodologyData.ts
+++ b/src/lib/methods/methodologyData.ts
@@ -28,7 +28,10 @@ export const methodologySections: MethodologySectionType = {
     { id: "sources", category: "municipalityAndRegion" },
     { id: "municipalityKPIs", category: "municipalityAndRegion" },
   ],
-  nation: [{ id: "nationDataOverview", category: "nation" }],
+  nation: [
+    { id: "nationDataOverview", category: "nation" },
+    { id: "nationEmissionsLayers", category: "nation" },
+  ],
   company: [
     { id: "companyDataOverview", category: "company" },
     { id: "companyDataCollection", category: "company" },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -788,7 +788,7 @@
         }
       },
       "nationEmissionsLayers": {
-        "title": "Sweden’s emissions – the full picture",
+        "title": "Sweden's Emissions - Full Picture",
         "description": "How Klimatkollen presents territorial, production-based, consumption-based and biogenic emissions for Sweden.",
         "sectionTitle": "Sources and method",
         "placeholder": "Detailed methodology for this section is coming soon."

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -788,7 +788,7 @@
         }
       },
       "nationEmissionsLayers": {
-        "title": "Sweden's Emissions - Full Picture",
+        "title": "Nation Data Details",
         "description": "How Klimatkollen presents territorial, production-based, consumption-based and biogenic emissions for Sweden.",
         "sectionTitle": "Sources and method",
         "placeholder": "Detailed methodology for this section is coming soon."

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -794,8 +794,7 @@
           "title": "Why a fuller picture",
           "paragraph1": "Official climate debate often focuses on territorial fossil emissions within Sweden’s borders – the measure used for Sweden’s climate targets and reported internationally. Those figures matter, but they do not cover everything Sweden can influence.",
           "paragraph2": "Klimatkollen does not replace official statistics. We present a broader picture based on influence (rådighet): emissions that Swedish decisions and activities can affect in different ways – at home and abroad.",
-          "paragraph3": "Detailed calculations live in our working spreadsheet. Published results are available in this <0>Google Sheet</0>. Unit throughout: tonnes CO₂e per year.",
-          "paragraph4": "The series run from 1990 through 2025. Where official series end earlier, we document how gaps are filled so the time series stay consistent."
+          "paragraph3": "The series run from 1990 through 2025. Where official series end earlier, we document how gaps are filled so the time series stay consistent."
         },
         "perspectives": {
           "title": "Three perspectives we combine",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -789,9 +789,82 @@
       },
       "nationEmissionsLayers": {
         "title": "Nation Data Details",
-        "description": "How Klimatkollen presents territorial, production-based, consumption-based and biogenic emissions for Sweden.",
-        "sectionTitle": "Sources and method",
-        "placeholder": "Detailed methodology for this section is coming soon."
+        "description": "How Klimatkollen builds a fuller picture of Sweden’s greenhouse gas emissions based on influence (rådighet), 1990–2025.",
+        "intro": {
+          "title": "Why a fuller picture",
+          "paragraph1": "Official climate debate often focuses on territorial fossil emissions within Sweden’s borders – the measure used for Sweden’s climate targets and reported internationally. Those figures matter, but they do not cover everything Sweden can influence.",
+          "paragraph2": "Klimatkollen does not replace official statistics. We present a broader picture based on influence (rådighet): emissions that Swedish decisions and activities can affect in different ways – at home and abroad.",
+          "paragraph3": "Detailed calculations live in our working spreadsheet. Published results are available in this <0>Google Sheet</0>. Unit throughout: tonnes CO₂e per year.",
+          "paragraph4": "The series run from 1990 through 2025. Where official series end earlier, we document how gaps are filled so the time series stay consistent."
+        },
+        "perspectives": {
+          "title": "Three perspectives we combine",
+          "paragraph1": "The nation story and charts build on three complementary perspectives:",
+          "production": "Production-based emissions – emissions linked to the Swedish economy (similar to territorial emissions, but including Swedish shipping and airlines in international traffic).",
+          "consumption": "Consumption-based emissions abroad – emissions caused by Swedish final demand where the emissions occur outside Sweden, including adjusted figures for international flights and an estimate of private e-commerce imports.",
+          "biogenic": "Biogenic CO₂ emissions – CO₂ released when biomass is burned in Sweden (for example in district heating, the pulp and paper industry, and vehicles using biofuels).",
+          "paragraph2": "Territorial fossil emissions are the familiar “headline” figure. We show them for context, then build toward the fuller total Sweden has influence over by combining production-based emissions, consumption-based emissions abroad, and biogenic CO₂ – without double-counting domestic emissions."
+        },
+        "territorial": {
+          "title": "Territorial emissions",
+          "paragraph1": "National total from the Swedish Environmental Protection Agency (Naturvårdsverket), 1990–2024. This is the official territorial greenhouse gas series commonly used when people say “Sweden’s emissions”.",
+          "paragraph2": "Internationally, methane from the energy sector may be under-reported in some inventories. Work is ongoing to improve reporting; we follow the official Swedish series here.",
+          "sources": {
+            "nv": "Naturvårdsverket – Sweden’s greenhouse gas emissions and removals"
+          }
+        },
+        "production": {
+          "title": "Production-based emissions",
+          "paragraph1": "Production-based emissions link greenhouse gases to the Swedish economy rather than to geography. Under the residence principle, emissions abroad from Swedish shipping companies and airlines are included.",
+          "paragraph2": "For 2008–2025 we use Statistics Sweden’s (SCB) environmental accounts. For earlier years we bridge back to 1990 using SCB territorial series with and without international bunker fuels. In 2008, the environmental-accounts value sits 54% of the way up the gap between emissions excluding and including bunkering; we apply that same share back to 1990 so the long series stays consistent.",
+          "paragraph3": "This is not identical to a pure bunkering approach (fuels sold in Swedish ports and airports), which can be used by both Swedish and foreign carriers. The environmental accounts follow Swedish economic actors instead.",
+          "sources": {
+            "scbBunker": "SCB – Total greenhouse gas emissions by gas and sector (incl. bunkering variants)",
+            "scbAccounts": "SCB – Environmental accounts, air emissions by industry",
+            "scbQuality": "SCB – Quality declaration, environmental accounts – air emissions"
+          }
+        },
+        "consumption": {
+          "title": "Consumption-based emissions abroad",
+          "paragraph1": "These figures cover emissions driven by Swedish final demand (households, public consumption and investment) that occur outside Sweden. Domestic emissions already covered in the production-based series are removed so the two can be added without double-counting.",
+          "paragraph2": "For 2008–2023 we start from SCB’s consumption-based statistics (sum of domestic demand components). For 2024–2025 we hold the 2023 level for the SCB-based part of the series. For 1990–2007 we scale Global Carbon Project consumption-based CO₂ for Sweden up to all greenhouse gases using the global GHG/CO₂ ratio from EDGAR, which tracks SCB’s ratio within about 5% for 2008–2023.",
+          "paragraph3": "International flights: we replace SCB flight emissions with Chalmers estimates for the Swedish population’s outbound flights (1990–2017), extended to 2025 using Trafikanalys passenger-kilometre trends. A similar SEI approach differs by at most about 1.6% in overlapping years.",
+          "paragraph4": "Private e-commerce imports (2020–2025): parcels to private individuals from outside official trade statistics thresholds are largely missing from SCB consumption categories. We estimate emissions using Svensk Handel turnover for foreign e-commerce, multiplied by the consumption-based emission intensity of clothing (COICOP 03.1.2). Clothing and electronics dominate Swedish e-commerce; their intensities are similar. The 2025 estimate is about 326,000 tonnes CO₂e – roughly Gävle’s municipal emissions in 2024.",
+          "paragraph5": "How the abroad-only series is built (simplified): remove SCB flight emissions from consumption totals; remove the share of remaining emissions that arise in Sweden; add Chalmers/Trafikanalys international flight emissions; add the e-commerce estimate from 2020 onward. For pre-2008 years, flight and import shares are back-cast with SCB monetary and GDP/import data, cross-checked against SCB for 2008–2023.",
+          "paragraph6": "Uncertainty remains around e-commerce (Svensk Handel value trends vs parcel-count growth in Transportföretagen’s Paketindex) and around embedded transport in intensities. We document these assumptions rather than treating the series as official statistics.",
+          "sources": {
+            "gcp": "Global Carbon Project – Global Carbon Budget supplemental data",
+            "edgar": "EDGAR – GHG emissions of all world countries",
+            "scb": "SCB – Environmental impact from consumption by product group",
+            "chalmers": "Kamb & Larsson (Chalmers) – Climate impact of Swedes’ air travel 1990–2017",
+            "trafa": "Trafikanalys – Civil aviation statistics",
+            "svenskHandel": "Svensk Handel – E-commerce indicator, full year 2025"
+          }
+        },
+        "biogenic": {
+          "title": "Biogenic CO₂ emissions",
+          "paragraph1": "Territorial biogenic CO₂ from burning biomass in Sweden, 1990–2025. Naturvårdsverket data are used for 1990–2024 and extended to 2025 with the year-on-year change in SCB data for 2024–2025.",
+          "paragraph2": "Only CO₂ can be biogenic in this sense: biomass carbon is assumed to be reabsorbed by growing biomass. Other greenhouse gases from biomass are not treated the same way. Black liquor emissions are included in the current national biogenic series.",
+          "paragraph3": "We use territorial biogenic CO₂ rather than a production-based residence adjustment, because the difference is marginal for this series and one consistent national source/method can then cover the full time span. We do not include LULUCF net land-use fluxes here; the focus is combustion emissions. Biogenic CO₂ still affects the climate here and now if re-uptake takes decades.",
+          "sources": {
+            "nv": "Naturvårdsverket – Biogenic CO₂ from biomass combustion in Sweden",
+            "scb": "SCB – Environmental accounts, air emissions (for 2024–2025 extension)"
+          }
+        },
+        "total": {
+          "title": "Total emissions Sweden has influence over",
+          "paragraph1": "The combined figure used in the nation story is the sum of: production-based emissions; biogenic CO₂; and consumption-based emissions abroad (with Chalmers/Trafikanalys flights and foreign e-commerce included, and domestic consumption emissions removed to avoid double-counting).",
+          "paragraph2": "In 2025 this fuller total is about 159 Mt CO₂e, compared with about 47 Mt for territorial fossil emissions alone – roughly three times larger. Trends differ by layer: production-based emissions have fallen since 1990, consumption-based emissions abroad have fallen more modestly, and biogenic CO₂ has more than doubled as heating and fuels shifted toward biomass.",
+          "paragraph3": "Influence is not equally strong for every tonne. Sweden has more direct legal and economic control over domestic production than over a foreign supplier in a value chain. The quantitative total shows scale; interpreting policy leverage still depends on the emission flow."
+        },
+        "limitations": {
+          "title": "Limitations and further work",
+          "paragraph1": "Known gaps and priorities for improving the series include:",
+          "item1": "A fully Swedish model for consumption-based greenhouse gases 1990–2007 (instead of the current bridging approach).",
+          "item2": "Extending flight emissions after 2017 with primary data rather than passenger-kilometre proxies where possible.",
+          "item3": "Better measurement of foreign e-commerce (for example card or tourism-account data) and of consumption-based biogenic emissions.",
+          "item4": "Exploring whether LULUCF and financial-sector emissions linked to Swedish savings can be included in a consistent way."
+        }
       }
     },
     "municipalityAndRegion": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -786,6 +786,12 @@
           "title": "Sweden's National Emissions",
           "text": "View Sweden's national emissions data on Klimatkollen"
         }
+      },
+      "nationEmissionsLayers": {
+        "title": "Sweden’s emissions – the full picture",
+        "description": "How Klimatkollen presents territorial, production-based, consumption-based and biogenic emissions for Sweden.",
+        "sectionTitle": "Sources and method",
+        "placeholder": "Detailed methodology for this section is coming soon."
       }
     },
     "municipalityAndRegion": {
@@ -1522,7 +1528,8 @@
         "title": "Sweden's emissions are larger than we think and have not fallen as much as we think",
         "usualLabel": "What we usually discuss",
         "fullLabel": "Sweden's actual emissions",
-        "since1990": "since 1990"
+        "since1990": "since 1990",
+        "methodologyLink": "Read more about how we calculate Sweden’s emissions"
       }
     }
   },

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -840,9 +840,82 @@
       },
       "nationEmissionsLayers": {
         "title": "Nationell data detaljer",
-        "description": "Hur Klimatkollen presenterar territoriella, produktionsbaserade, konsumtionsbaserade och biogena utsläpp för Sverige.",
-        "sectionTitle": "Källor och metod",
-        "placeholder": "Detaljerad metodbeskrivning för det här avsnittet kommer snart."
+        "description": "Hur Klimatkollen bygger en bredare bild av Sveriges växthusgasutsläpp utifrån rådighet, 1990–2025.",
+        "intro": {
+          "title": "Varför en bredare bild",
+          "paragraph1": "I klimatdebatten avses ofta de territoriella fossila utsläppen inom Sveriges gränser – det mått som används i klimatmålen och rapporteras internationellt. De siffrorna är viktiga, men de täcker inte allt som Sverige kan påverka.",
+          "paragraph2": "Klimatkollen ersätter inte den officiella statistiken. Vi redovisar en bredare bild utifrån rådighet: utsläpp som svenska beslut och aktiviteter kan påverka på olika sätt – hemma och utomlands.",
+          "paragraph3": "Detaljerade beräkningar finns i vårt arbetsark. Publicerade resultat finns i detta <0>Google-ark</0>. Enhet genomgående: ton CO₂e per år.",
+          "paragraph4": "Tidsserierna löper från 1990 till 2025. Där officiella serier tar slut tidigare dokumenterar vi hur luckor fylls så att serierna förblir jämförbara."
+        },
+        "perspectives": {
+          "title": "Tre perspektiv som vi kombinerar",
+          "paragraph1": "Nationsberättelsen och diagrammen bygger på tre kompletterande perspektiv:",
+          "production": "Produktionsbaserade utsläpp – utsläpp kopplade till den svenska ekonomin (ungefär som territoriella utsläpp, men inklusive svenska rederier och flygbolag i internationell trafik).",
+          "consumption": "Konsumtionsbaserade utsläpp utomlands – utsläpp orsakade av svensk slutlig efterfrågan där utsläppen sker utanför Sverige, inklusive justerade siffror för utrikesflyg och en uppskattning av privat e-handel från utlandet.",
+          "biogenic": "Biogena koldioxidutsläpp – CO₂ som frigörs när biomassa förbränns i Sverige (till exempel i fjärrvärme, massa- och pappersindustri samt fordon på biodrivmedel).",
+          "paragraph2": "Territoriella fossila utsläpp är den välkända “rubriksiffran”. Vi visar dem som kontext och bygger sedan mot den större totalen som Sverige har rådighet över genom att kombinera produktionsbaserade utsläpp, konsumtionsbaserade utsläpp utomlands och biogen CO₂ – utan dubbelräkning av inhemska utsläpp."
+        },
+        "territorial": {
+          "title": "Territoriella utsläpp",
+          "paragraph1": "Nationell total från Naturvårdsverket, 1990–2024. Det är den officiella territoriella växthusgasserien som ofta används när man talar om “Sveriges utsläpp”.",
+          "paragraph2": "Internationellt kan metan från energisektorn vara underrapporterat i vissa inventeringar. Arbete pågår för att förbättra rapporteringen; här följer vi den officiella svenska serien.",
+          "sources": {
+            "nv": "Naturvårdsverket – Sveriges utsläpp och upptag av växthusgaser"
+          }
+        },
+        "production": {
+          "title": "Produktionsbaserade utsläpp",
+          "paragraph1": "Produktionsbaserade utsläpp kopplar växthusgaser till den svenska ekonomin snarare än till territoriet. Enligt residensprincipen ingår utsläpp utomlands från svenska rederier och flygbolag.",
+          "paragraph2": "För 2008–2025 använder vi SCB:s miljöräkenskaper. För tidigare år bryggar vi tillbaka till 1990 med SCB:s territoriella serier med och utan internationella transporter (bunkring). År 2008 ligger miljöräkenskapernas värde 54 procent upp i gapet mellan utsläpp exklusive och inklusive bunkring; samma andel används tillbaka till 1990 så att långserien blir konsistent.",
+          "paragraph3": "Detta är inte samma sak som en ren bunkringsansats (bränslen sålda i svenska hamnar och på flygplatser), som kan tankas av både svenska och utländska aktörer. Miljöräkenskaperna följer i stället svenska ekonomiska aktörer.",
+          "sources": {
+            "scbBunker": "SCB – Totala utsläpp och upptag av växthusgaser efter växthusgas och sektor",
+            "scbAccounts": "SCB – Miljöräkenskaper, utsläpp till luft efter näringsgren",
+            "scbQuality": "SCB – Kvalitetsdeklaration, miljöräkenskaperna – utsläpp till luft"
+          }
+        },
+        "consumption": {
+          "title": "Konsumtionsbaserade utsläpp utomlands",
+          "paragraph1": "Dessa siffror omfattar utsläpp drivna av svensk slutlig efterfrågan (hushåll, offentlig konsumtion och investeringar) som uppstår utanför Sverige. Inhemska utsläpp som redan ingår i den produktionsbaserade serien tas bort så att de två kan summeras utan dubbelräkning.",
+          "paragraph2": "För 2008–2023 utgår vi från SCB:s konsumtionsbaserade statistik (summan av inhemska efterfrågekomponenter). För 2024–2025 håller vi 2023 års nivå för den SCB-baserade delen. För 1990–2007 skalas Global Carbon Projects konsumtionsbaserade CO₂ för Sverige upp till alla växthusgaser med global GHG/CO₂-kvot från EDGAR, som spårar SCB:s kvot inom cirka 5 procent för 2008–2023.",
+          "paragraph3": "Utrikesflyg: vi ersätter SCB:s flygutsläpp med Chalmers beräkningar för svenskarnas utrikesflyg (1990–2017), framskrivna till 2025 med Trafikanalys personkilometer. En liknande SEI-ansats skiljer sig som mest med cirka 1,6 procent i överlappande år.",
+          "paragraph4": "Privat e-handel från utlandet (2020–2025): försändelser till privatpersoner under vissa trösklar saknas i stor utsträckning i SCB:s konsumtionskategorier. Vi skattar utsläpp med Svensk Handels omsättning för utländsk e-handel multiplicerad med den konsumtionsbaserade utsläppsintensiteten för kläder (COICOP 03.1.2). Kläder och elektronik dominerar svensk e-handel; intensiteterna är likartade. Uppskattningen för 2025 är cirka 326 000 ton CO₂e – ungefär Gävles kommunala utsläpp 2024.",
+          "paragraph5": "Så byggs serien “enbart utomlands” (förenklat): ta bort SCB:s flygutsläpp från konsumtionstotalen; ta bort andelen kvarvarande utsläpp med uppkomst i Sverige; lägg till Chalmers/Trafikanalys utrikesflyg; lägg till e-handelsuppskattningen från 2020. För åren före 2008 bakåtskrivs flyg- och importandelar med SCB:s monetära data samt BNP/import, och korskontrolleras mot SCB för 2008–2023.",
+          "paragraph6": "Osäkerhet finns kring e-handel (Svensk Handels värdeutveckling kontra paketvolymer i Transportföretagens Paketindex) och kring inbäddade transporter i intensiteterna. Vi dokumenterar antagandena snarare än att behandla serien som officiell statistik.",
+          "sources": {
+            "gcp": "Global Carbon Project – supplemental data till Global Carbon Budget",
+            "edgar": "EDGAR – växthusgasutsläpp för världens länder",
+            "scb": "SCB – Miljöpåverkan från konsumtion efter produktgrupp",
+            "chalmers": "Kamb & Larsson (Chalmers) – Klimatpåverkan från svenskars flygresor 1990–2017",
+            "trafa": "Trafikanalys – luftfartsstatistik",
+            "svenskHandel": "Svensk Handel – E-handelsindikatorn helår 2025"
+          }
+        },
+        "biogenic": {
+          "title": "Biogena koldioxidutsläpp",
+          "paragraph1": "Territoriella biogena CO₂-utsläpp från förbränning av biomassa i Sverige, 1990–2025. Naturvårdsverkets data används för 1990–2024 och skrivs fram till 2025 med utvecklingstalet i SCB:s data för 2024–2025.",
+          "paragraph2": "Endast CO₂ kan vara biogen i den här meningen: kolet i biomassa antas kunna tas upp igen av växande biomassa. Övriga växthusgaser från biomassa behandlas inte på samma sätt. Utsläpp från svartlut ingår i den nuvarande nationella biogena serien.",
+          "paragraph3": "Vi använder territoriell biogen CO₂ snarare än en produktionsbaserad residensjustering, eftersom skillnaden är marginell för den här serien och vi då kan hålla en konsekvent nationell källa/metod över hela perioden. Vi inkluderar inte LULUCF (netto från markanvändning) här; fokus är förbränningsutsläpp. Biogen CO₂ påverkar ändå klimatet här och nu om upptaget tar decennier.",
+          "sources": {
+            "nv": "Naturvårdsverket – Utsläpp av biogen koldioxid från förbränning av biomassa i Sverige",
+            "scb": "SCB – Miljöräkenskaper, utsläpp till luft (för framskrivning 2024–2025)"
+          }
+        },
+        "total": {
+          "title": "Totala utsläpp som Sverige har rådighet över",
+          "paragraph1": "Den samlade siffra som används i nationsberättelsen är summan av: produktionsbaserade utsläpp; biogen CO₂; och konsumtionsbaserade utsläpp utomlands (med Chalmers/Trafikanalys-flyg och utländsk e-handel, där inhemska konsumtionsutsläpp har tagits bort för att undvika dubbelräkning).",
+          "paragraph2": "År 2025 är denna bredare total cirka 159 Mton CO₂e, jämfört med cirka 47 Mton för enbart territoriella fossila utsläpp – ungefär tre gånger så stor. Trenderna skiljer sig mellan lagren: produktionsbaserade utsläpp har minskat sedan 1990, konsumtionsbaserade utsläpp utomlands har minskat mer måttligt, och biogen CO₂ har mer än fördubblats när uppvärmning och bränslen ställts om mot biomassa.",
+          "paragraph3": "Rådighet är inte lika stark för varje ton. Sverige har mer direkt rättslig och ekonomisk kontroll över inhemsk produktion än över en utländsk underleverantör i en värdekedja. Den kvantitativa totalen visar storleksordningen; att tolka politisk påverkan beror fortfarande på vilket utsläppsflöde det gäller."
+        },
+        "limitations": {
+          "title": "Begränsningar och vidare arbete",
+          "paragraph1": "Kända luckor och prioriteringar för att förbättra serierna inkluderar:",
+          "item1": "En helt svensk modell för konsumtionsbaserade växthusgaser 1990–2007 (i stället för nuvarande brygga).",
+          "item2": "Att förlänga flygutsläpp efter 2017 med primärdata där det är möjligt, snarare än enbart personkilometerproxy.",
+          "item3": "Bättre mätning av utländsk e-handel (till exempel kort- eller turistdata) och av konsumtionsbaserade biogena utsläpp.",
+          "item4": "Att undersöka om LULUCF och finanssektorns utsläpp kopplade till svenskars sparande kan inkluderas på ett konsekvent sätt."
+        }
       }
     },
     "municipalityAndRegion": {

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -845,8 +845,7 @@
           "title": "Varför en bredare bild",
           "paragraph1": "I klimatdebatten avses ofta de territoriella fossila utsläppen inom Sveriges gränser – det mått som används i klimatmålen och rapporteras internationellt. De siffrorna är viktiga, men de täcker inte allt som Sverige kan påverka.",
           "paragraph2": "Klimatkollen ersätter inte den officiella statistiken. Vi redovisar en bredare bild utifrån rådighet: utsläpp som svenska beslut och aktiviteter kan påverka på olika sätt – hemma och utomlands.",
-          "paragraph3": "Detaljerade beräkningar finns i vårt arbetsark. Publicerade resultat finns i detta <0>Google-ark</0>. Enhet genomgående: ton CO₂e per år.",
-          "paragraph4": "Tidsserierna löper från 1990 till 2025. Där officiella serier tar slut tidigare dokumenterar vi hur luckor fylls så att serierna förblir jämförbara."
+          "paragraph3": "Tidsserierna löper från 1990 till 2025. Där officiella serier tar slut tidigare dokumenterar vi hur luckor fylls så att serierna förblir jämförbara."
         },
         "perspectives": {
           "title": "Tre perspektiv som vi kombinerar",

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -837,6 +837,12 @@
           "title": "Sveriges nationella utsläpp",
           "text": "Se Sveriges nationella utsläppsdata på Klimatkollen"
         }
+      },
+      "nationEmissionsLayers": {
+        "title": "Sveriges utsläpp – hela bilden",
+        "description": "Hur Klimatkollen presenterar territoriella, produktionsbaserade, konsumtionsbaserade och biogena utsläpp för Sverige.",
+        "sectionTitle": "Källor och metod",
+        "placeholder": "Detaljerad metodbeskrivning för det här avsnittet kommer snart."
       }
     },
     "municipalityAndRegion": {
@@ -1572,7 +1578,8 @@
         "title": "Sveriges utsläpp är större än vad vi tror och har inte minskat så mycket som vi tror",
         "usualLabel": "Det vi vanligtvis diskuterar",
         "fullLabel": "Sveriges egentliga utsläpp",
-        "since1990": "sedan 1990"
+        "since1990": "sedan 1990",
+        "methodologyLink": "Läs mer om hur vi räknar på Sveriges utsläpp"
       }
     }
   },

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -839,7 +839,7 @@
         }
       },
       "nationEmissionsLayers": {
-        "title": "Sveriges utsläpp – hela bilden",
+        "title": "Nationell data detaljer",
         "description": "Hur Klimatkollen presenterar territoriella, produktionsbaserade, konsumtionsbaserade och biogena utsläpp för Sverige.",
         "sectionTitle": "Källor och metod",
         "placeholder": "Detaljerad metodbeskrivning för det här avsnittet kommer snart."


### PR DESCRIPTION
## Summary
- Fix scroll chevron so it advances one pin-step (or jumps to the next section on the last step), avoiding the biogenic → black-gap bug
- Slightly brighten the chevron without a glow/halo
- Redesign bathtub: wide tub with copy inside translucent water on desktop; compact tub-on-top + copy below on mobile
- Add a methodology link at the end of the nation story to a new placeholder section (`nationEmissionsLayers`) on the methods page (copy TBD)

## Test plan
- [ ] From the last onion (biogenic) step, click the chevron and land fully on the next section (bathtub)
- [ ] Chevron is visible but not overly bright / no halo
- [ ] Desktop bathtub: text readable inside wide tub; year/amounts under the tub
- [ ] Mobile bathtub: tub → year/amounts → body + question; no overflow
- [ ] Conclusion link opens `/methodology?view=nationEmissionsLayers` with placeholder content in EN and SV


Made with [Cursor](https://cursor.com)