### PR TITLE
Fix stale chunk load failures after deploys

### DIFF
--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -39,7 +39,7 @@ spec:
               port: 80
             initialDelaySeconds: 10
             periodSeconds: 30
-          readinessProbe:
+          startupProbe:
             exec:
               command:
                 - /bin/sh
@@ -47,6 +47,12 @@ spec:
                 - |
                   MAIN=$(grep -oE 'src="/assets/index-[^"]+\.js"' /usr/share/nginx/html/index.html | head -1 | sed 's/src="//;s/"//')
                   test -n "$MAIN" && test -f "/usr/share/nginx/html$MAIN"
+            periodSeconds: 5
+            failureThreshold: 12
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
             initialDelaySeconds: 5
             periodSeconds: 10
           env:

--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -40,9 +40,13 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 30
           readinessProbe:
-            httpGet:
-              path: /
-              port: 80
+            exec:
+              command:
+                - /bin/sh
+                - -ec
+                - |
+                  MAIN=$(grep -oE 'src="/assets/index-[^"]+\.js"' /usr/share/nginx/html/index.html | head -1 | sed 's/src="//;s/"//')
+                  test -n "$MAIN" && test -f "/usr/share/nginx/html$MAIN"
             initialDelaySeconds: 5
             periodSeconds: 10
           env:

--- a/k8s/overlays/staging/deployment-patch.yaml
+++ b/k8s/overlays/staging/deployment-patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  # Avoid mixed asset versions across replicas during stage deploys.
+  strategy:
+    type: Recreate

--- a/k8s/overlays/staging/kustomization.yaml
+++ b/k8s/overlays/staging/kustomization.yaml
@@ -4,6 +4,7 @@ namespace: frontend-stage
 resources:
   - ../../base
 patches:
+  - path: deployment-patch.yaml
   - patch: |-
       - op: add
         path: /spec/template/spec/containers/0/env/-

--- a/src/lib/chunkLoadRecovery.test.ts
+++ b/src/lib/chunkLoadRecovery.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  isChunkLoadError,
+  registerChunkLoadRecovery,
+  reloadForStaleChunks,
+} from "./chunkLoadRecovery";
+
+describe("chunkLoadRecovery", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    vi.stubGlobal("location", { reload: vi.fn() });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("detects vite dynamic import failures", () => {
+    expect(
+      isChunkLoadError(
+        "Failed to fetch dynamically imported module: https://stage.klimatkollen.se/assets/RegionalOverviewPage-BklbI-0Y.js",
+      ),
+    ).toBe(true);
+    expect(isChunkLoadError("Network request failed")).toBe(false);
+  });
+
+  it("reloads only once per session", () => {
+    reloadForStaleChunks();
+    reloadForStaleChunks();
+
+    expect(window.location.reload).toHaveBeenCalledTimes(1);
+    expect(sessionStorage.getItem("klimatkollen:chunk-reload")).toBe("1");
+  });
+
+  it("handles vite:preloadError", () => {
+    registerChunkLoadRecovery();
+
+    window.dispatchEvent(new Event("vite:preloadError"));
+
+    expect(window.location.reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles unhandled chunk load rejections", () => {
+    registerChunkLoadRecovery();
+
+    const event = new Event("unhandledrejection") as Event & {
+      reason: Error;
+      preventDefault: () => void;
+    };
+    event.reason = new Error("Loading chunk 12 failed.");
+    event.preventDefault = vi.fn();
+
+    window.dispatchEvent(event);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(window.location.reload).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/chunkLoadRecovery.ts
+++ b/src/lib/chunkLoadRecovery.ts
@@ -1,0 +1,43 @@
+const CHUNK_RELOAD_KEY = "klimatkollen:chunk-reload";
+
+const CHUNK_LOAD_ERROR =
+  /Failed to fetch dynamically imported module|Importing a module script failed|Loading chunk [\d]+ failed/i;
+
+export function isChunkLoadError(message: string | undefined): boolean {
+  if (!message) return false;
+  return CHUNK_LOAD_ERROR.test(message);
+}
+
+export function reloadForStaleChunks(): void {
+  if (sessionStorage.getItem(CHUNK_RELOAD_KEY) === "1") {
+    return;
+  }
+
+  sessionStorage.setItem(CHUNK_RELOAD_KEY, "1");
+  window.location.reload();
+}
+
+/** Recover from stale Vite chunks after deploys or mixed replica versions. */
+export function registerChunkLoadRecovery(): void {
+  window.addEventListener("vite:preloadError", (event) => {
+    event.preventDefault();
+    reloadForStaleChunks();
+  });
+
+  window.addEventListener("unhandledrejection", (event) => {
+    const reason = event.reason;
+    const message =
+      reason instanceof Error
+        ? reason.message
+        : typeof reason === "string"
+          ? reason
+          : undefined;
+
+    if (!isChunkLoadError(message)) {
+      return;
+    }
+
+    event.preventDefault();
+    reloadForStaleChunks();
+  });
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,11 +4,14 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { HelmetProvider } from "react-helmet-async";
 import { RouterProvider, createBrowserRouter } from "react-router-dom";
 import AuthProvider from "./contexts/AuthContext";
+import { registerChunkLoadRecovery } from "./lib/chunkLoadRecovery";
 import "./index.css";
 import "./i18n";
 import App from "./App";
 import { Layout } from "./components/layout/Layout";
 import { LanguageProvider } from "./components/LanguageProvider";
+
+registerChunkLoadRecovery();
 
 // Create router with all routes
 const router = createBrowserRouter([


### PR DESCRIPTION
## Summary
- Add client-side recovery for missing Vite lazy chunks (`vite:preloadError` + one guarded reload per session)
- Strengthen Kubernetes readiness: verify `index.html` references an existing `/assets/index-*.js` bundle before marking pods ready
- Use `Recreate` deploy strategy on **stage** to avoid mixed asset versions across replicas during rollouts

## Context
Stage currently serves alternating `index.html` builds across replicas (e.g. `index-CMRidcPe.js` vs `index-D5laMBAt.js`), causing `Failed to fetch dynamically imported module` on lazy routes like Regional Overview. Refresh often works because the user hits a healthy pod.

This is not a hydration issue — it is deploy/asset consistency.

## Test plan
- [ ] Deploy to stage and confirm all pods serve the same `index-*.js` hash
- [ ] Navigate to `/regions`, `/companies`, and other lazy routes without chunk errors
- [ ] Deploy a new RC while a tab is open — tab should auto-reload once instead of showing the React error boundary
- [ ] Confirm broken pods (index references missing bundle) stay out of rotation via readiness probe

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rollout behavior on staging (brief downtime on Recreate) and adds global error listeners that reload the page; startup probe logic must match real `index.html` asset paths or pods may fail to start.
> 
> **Overview**
> Addresses **stale lazy-route chunk failures** after deploys (mixed `index.html` / asset hashes across replicas) with **deploy-time checks**, **staging rollout behavior**, and a **client fallback**.
> 
> The base Deployment gains a **startup probe** that parses `index.html` for the main `index-*.js` asset and fails until that file exists on disk, so broken pods should not fully start serving inconsistent bundles. **Staging** switches to a **Recreate** deploy strategy (via a new patch) so replicas are not mixed during rollouts.
> 
> The app registers **`registerChunkLoadRecovery()`** at bootstrap: on `vite:preloadError` or matching **unhandled rejections**, it performs a **single session-guarded** `location.reload()`. New unit tests cover detection, one-reload behavior, and both event paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9940d8b5fec8736c0ac0a0fe6b976a8ba05577f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->