### PR TITLE
Redesign Valet 2026 nation story page to unify with site design system

### DIFF
--- a/src/components/nation/story/NationBathtub.tsx
+++ b/src/components/nation/story/NationBathtub.tsx
@@ -1,6 +1,6 @@
 import { useId, useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { motion } from "framer-motion";
+import { motion, useReducedMotion } from "framer-motion";
 import {
   formatMton,
   type NationBathtubDataPoint,
@@ -10,9 +10,10 @@ import {
   NATION_STORY_TEXT,
   NATION_STORY_TYPE,
 } from "@/components/nation/story/nationStoryColors";
+import { svgLocalUrl } from "@/components/nation/story/svgLocalUrl";
 import { usePinnedSteps } from "@/components/nation/story/usePinnedSteps";
 
-/** Sample years so each scroll step adds a visible water chunk. */
+/** Sample years so the caption advances in readable 5-year milestones. */
 function sampleBathtubYears(
   data: NationBathtubDataPoint[],
 ): NationBathtubDataPoint[] {
@@ -26,114 +27,257 @@ function sampleBathtubYears(
   return sampled;
 }
 
-/**
- * Absolute fragment URL so SVG clipPath works with <base href="/">.
- * Bare url(#id) resolves against the base and breaks on locale routes.
- */
-function svgLocalUrl(elementId: string): string {
-  if (typeof window === "undefined") return `url(#${elementId})`;
-  const { origin, pathname, search } = window.location;
-  return `url(${origin}${pathname}${search}#${elementId})`;
+/** Cumulative level interpolated continuously across the full yearly series. */
+function levelAtProgress(
+  data: NationBathtubDataPoint[],
+  progress: number,
+): number {
+  if (data.length === 0) return 0;
+  const position = progress * (data.length - 1);
+  const index = Math.floor(position);
+  const fraction = position - index;
+  const from = data[index];
+  const to = data[Math.min(index + 1, data.length - 1)];
+  return (
+    from.cumulativeMton + (to.cumulativeMton - from.cumulativeMton) * fraction
+  );
 }
 
 type NationBathtubProps = {
   data: NationBathtubDataPoint[];
 };
 
-/** Wide tub geometry (viewBox 520×280) – used full-bleed on desktop with copy inside. */
-const TUB_WATER_TOP = 72;
-const TUB_INNER_BOTTOM = 232;
+/**
+ * Claw-foot tub geometry (viewBox 520×260): elliptical rim with a visible
+ * lip, curved basin walls, two claw feet and a rim-mounted faucet.
+ */
+const TUB_WATER_TOP = 84;
+const TUB_INNER_BOTTOM = 212;
 const TUB_WATER_HEIGHT = TUB_INNER_BOTTOM - TUB_WATER_TOP;
-const TUB_WATER_LEFT = 48;
-const TUB_WATER_WIDTH = 424;
+const TUB_WATER_LEFT = 58;
+const TUB_WATER_WIDTH = 404;
+/** Inner basin: walls curving to a rounded floor, closed straight across the top. */
 const TUB_WATER_CLIP_PATH =
-  "M48 72 h424 v118 c0 32 -48 42 -212 42 s-212 -10 -212 -42 z";
-const TUB_OUTLINE_PATH =
-  "M40 64 h440 v126 c0 36 -52 48 -220 48 s-220 -12 -220 -48 z";
+  "M58 84 C58 158 88 204 150 212 L370 212 C432 204 462 158 462 84 Z";
+/** Outer wall, from left rim edge down around the basin to the right rim edge. */
+const TUB_BODY_PATH =
+  "M40 78 C40 160 74 214 142 224 L378 224 C446 214 480 160 480 78";
+/** Body outline closed along the underside of the rim – fillable enamel shape. */
+const TUB_BODY_FILL_PATH = `${TUB_BODY_PATH} A220 16 0 0 1 40 78 Z`;
+/** Rolled rim: band between the outer lip and the inner opening. */
+const TUB_RIM_BAND_PATH =
+  "M40 78 a220 16 0 1 0 440 0 a220 16 0 1 0 -440 0 " +
+  "M58 80 a202 10 0 1 0 404 0 a202 10 0 1 0 -404 0";
+const TUB_STROKE = "rgba(255,255,255,0.4)";
+
+/**
+ * Basin interior half-width sampled along the wall curve, so the water
+ * surface ellipse can match the tub's width at the current level.
+ */
+const BASIN_HALF_WIDTH_SAMPLES: ReadonlyArray<readonly [number, number]> = [
+  [84, 202],
+  [134, 196],
+  [173, 179],
+  [199, 150],
+  [208, 128],
+  [212, 110],
+];
+
+function basinHalfWidthAt(y: number): number {
+  const samples = BASIN_HALF_WIDTH_SAMPLES;
+  if (y <= samples[0][0]) return samples[0][1];
+  for (let i = 1; i < samples.length; i++) {
+    const [y1, w1] = samples[i];
+    if (y <= y1) {
+      const [y0, w0] = samples[i - 1];
+      return w0 + ((y - y0) / (y1 - y0)) * (w1 - w0);
+    }
+  }
+  return samples[samples.length - 1][1];
+}
+
+const WATER_SPRING = {
+  type: "spring" as const,
+  stiffness: 60,
+  damping: 20,
+  mass: 0.8,
+};
 
 type TubGraphicProps = {
-  waterClipId: string;
-  waterClipUrl: string;
-  chunks: NationBathtubDataPoint[];
-  maxCumulative: number;
+  idPrefix: string;
+  /** SVG y coordinate of the current water surface. */
   waterTop: number;
-  /** Stronger fill when copy is not overlaid (mobile). */
-  strongerWater?: boolean;
   className?: string;
 };
 
-function TubGraphic({
-  waterClipId,
-  waterClipUrl,
-  chunks,
-  maxCumulative,
-  waterTop,
-  strongerWater = false,
-  className,
-}: TubGraphicProps) {
+function TubGraphic({ idPrefix, waterTop, className }: TubGraphicProps) {
+  const reducedMotion = useReducedMotion();
+  const clipId = `${idPrefix}-clip`;
+  const gradientId = `${idPrefix}-gradient`;
+  const enamelId = `${idPrefix}-enamel`;
+  const waterHeight = Math.max(TUB_INNER_BOTTOM - waterTop, 0);
+  const waterTransition = reducedMotion ? { duration: 0 } : WATER_SPRING;
+  // Water surface ellipse matches the basin width at the current level
+  const surfaceRx = Math.max(basinHalfWidthAt(waterTop) - 3, 0);
+  const surfaceRy = Math.max(surfaceRx * 0.055, 4);
+
   return (
-    <svg viewBox="0 0 520 280" className={className} aria-hidden>
-      <path
-        d="M390 18 h36 a7 7 0 0 1 7 7 v12 h-12 v-7 h-31 z"
-        fill="none"
-        stroke="rgba(255,255,255,0.55)"
-        strokeWidth="2.5"
-        strokeLinejoin="round"
-      />
-      <path
-        d="M426 37 v18"
-        stroke="rgba(125, 211, 252, 0.7)"
-        strokeWidth="3"
-        strokeLinecap="round"
-      />
-      <path
-        d={TUB_OUTLINE_PATH}
-        fill="none"
-        stroke="rgba(255,255,255,0.7)"
-        strokeWidth="3"
-        strokeLinejoin="round"
-      />
+    <svg viewBox="0 0 520 260" className={className} aria-hidden>
       <defs>
-        <clipPath id={waterClipId}>
+        <clipPath id={clipId}>
           <path d={TUB_WATER_CLIP_PATH} />
         </clipPath>
+        <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="var(--blue-3)" stopOpacity="0.85" />
+          <stop offset="100%" stopColor="var(--blue-4)" stopOpacity="0.85" />
+        </linearGradient>
+        <linearGradient id={enamelId} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="rgba(255,255,255,0.08)" />
+          <stop offset="100%" stopColor="rgba(255,255,255,0.02)" />
+        </linearGradient>
       </defs>
-      <g clipPath={waterClipUrl}>
-        {chunks.map((chunk, index) => {
-          const prevCumulative =
-            index === 0 ? 0 : chunks[index - 1].cumulativeMton;
-          const bottom =
-            TUB_INNER_BOTTOM -
-            (prevCumulative / maxCumulative) * TUB_WATER_HEIGHT;
-          const top =
-            TUB_INNER_BOTTOM -
-            (chunk.cumulativeMton / maxCumulative) * TUB_WATER_HEIGHT;
-          const height = Math.max(bottom - top, 0);
-          const fillAlpha = strongerWater
-            ? 0.28 + (index / Math.max(chunks.length, 1)) * 0.4
-            : 0.1 + (index / Math.max(chunks.length, 1)) * 0.22;
-          return (
-            <motion.rect
-              key={chunk.year}
-              x={TUB_WATER_LEFT}
-              width={TUB_WATER_WIDTH}
-              initial={{ y: bottom, height: 0, opacity: 0 }}
-              animate={{ y: top, height, opacity: 1 }}
-              transition={{ duration: 0.45, ease: [0.22, 1, 0.36, 1] }}
-              fill={`rgba(56, 189, 248, ${fillAlpha})`}
-            />
-          );
-        })}
-        <motion.line
-          x1={TUB_WATER_LEFT}
-          x2={TUB_WATER_LEFT + TUB_WATER_WIDTH}
-          stroke="rgba(186, 230, 253, 0.75)"
+
+      {/* Rim-mounted faucet: riser with a cross handle, gooseneck spout */}
+      <path
+        d="M424 76 V42 Q424 26 408 26 H400 V30"
+        fill="none"
+        stroke={TUB_STROKE}
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {/* Handle on the riser */}
+      <path
+        d="M429 48 h10"
+        stroke={TUB_STROKE}
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+      <circle
+        cx="441"
+        cy="48"
+        r="3"
+        fill="none"
+        stroke={TUB_STROKE}
+        strokeWidth="2"
+      />
+      {/* Spout mouth */}
+      <path d="M396 30 h8 v4 h-8 z" fill={TUB_STROKE} />
+      {/* Drip in brand blue – falls from the spout on a loop */}
+      {reducedMotion ? (
+        <circle cx="400" cy="46" r="3.2" fill="var(--blue-2)" />
+      ) : (
+        <motion.circle
+          cx={400}
+          r={3.2}
+          fill="var(--blue-2)"
+          initial={false}
+          animate={{ cy: [38, 74], opacity: [0, 1, 1, 0] }}
+          transition={{
+            cy: {
+              repeat: Infinity,
+              duration: 1.3,
+              ease: "easeIn",
+              repeatDelay: 0.5,
+            },
+            opacity: {
+              repeat: Infinity,
+              duration: 1.3,
+              times: [0, 0.15, 0.8, 1],
+              repeatDelay: 0.5,
+            },
+          }}
+        />
+      )}
+
+      {/* Enamel body – a subtle fill so the tub reads as a solid object */}
+      <path d={TUB_BODY_FILL_PATH} fill={svgLocalUrl(enamelId)} />
+
+      {/* Single continuous water body (behind the rim so the lip overlaps it) */}
+      <g clipPath={svgLocalUrl(clipId)}>
+        <motion.rect
+          x={TUB_WATER_LEFT}
+          width={TUB_WATER_WIDTH}
+          initial={false}
+          animate={{ y: waterTop, height: waterHeight }}
+          transition={waterTransition}
+          fill={svgLocalUrl(gradientId)}
+        />
+        {/* Elliptical surface gives the water a 3D lens matching the rim */}
+        <motion.ellipse
+          cx={260}
+          fill="var(--blue-2)"
+          fillOpacity={0.32}
+          stroke="var(--blue-2)"
           strokeWidth="2"
           initial={false}
-          animate={{ y1: waterTop, y2: waterTop }}
-          transition={{ duration: 0.45, ease: [0.22, 1, 0.36, 1] }}
+          animate={{ cy: waterTop, rx: surfaceRx, ry: surfaceRy }}
+          transition={waterTransition}
         />
       </g>
+
+      {/* Basin walls and rounded floor */}
+      <path
+        d={TUB_BODY_PATH}
+        fill="none"
+        stroke={TUB_STROKE}
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+
+      {/* Rolled rim: filled band between outer lip and inner opening */}
+      <path
+        d={TUB_RIM_BAND_PATH}
+        fill="rgba(255,255,255,0.07)"
+        fillRule="evenodd"
+      />
+      <ellipse
+        cx="260"
+        cy="78"
+        rx="220"
+        ry="16"
+        fill="none"
+        stroke={TUB_STROKE}
+        strokeWidth="2"
+      />
+      <ellipse
+        cx="260"
+        cy="80"
+        rx="202"
+        ry="10"
+        fill="none"
+        stroke={TUB_STROKE}
+        strokeWidth="1"
+        strokeOpacity="0.6"
+      />
+
+      {/* Sheen on the left enamel wall */}
+      <path
+        d="M76 100 C72 134 80 172 98 194"
+        fill="none"
+        stroke="rgba(255,255,255,0.09)"
+        strokeWidth="7"
+        strokeLinecap="round"
+      />
+
+      {/* Ball-claw feet, curling outward */}
+      <path
+        d="M152 224 Q152 238 140 245"
+        fill="none"
+        stroke={TUB_STROKE}
+        strokeWidth="2.5"
+        strokeLinecap="round"
+      />
+      <circle cx="137" cy="247" r="3.5" fill={TUB_STROKE} />
+      <path
+        d="M368 224 Q368 238 380 245"
+        fill="none"
+        stroke={TUB_STROKE}
+        strokeWidth="2.5"
+        strokeLinecap="round"
+      />
+      <circle cx="383" cy="247" r="3.5" fill={TUB_STROKE} />
     </svg>
   );
 }
@@ -142,12 +286,11 @@ export function NationBathtub({ data }: NationBathtubProps) {
   const { t } = useTranslation();
   const { currentLanguage } = useLanguage();
   // useId can include ":" which is awkward in url(#…) fragments
-  const waterClipId = `tub-water-clip-${useId().replace(/:/g, "")}`;
-  const waterClipUrl = useMemo(() => svgLocalUrl(waterClipId), [waterClipId]);
+  const idPrefix = `tub-${useId().replace(/:/g, "")}`;
   const steps = useMemo(() => sampleBathtubYears(data), [data]);
-  const maxCumulative = steps.at(-1)?.cumulativeMton ?? 1;
+  const maxCumulative = data.at(-1)?.cumulativeMton ?? 1;
 
-  const { ref, step, sectionVh, stageStyle } = usePinnedSteps(
+  const { ref, step, progress, sectionVh, stageStyle } = usePinnedSteps(
     Math.max(steps.length, 1),
     70,
   );
@@ -155,17 +298,17 @@ export function NationBathtub({ data }: NationBathtubProps) {
   const current = steps[step] ?? steps[0];
   if (!current) return null;
 
+  // Water rises continuously with scroll; captions advance in milestones.
+  const level = levelAtProgress(data, progress);
+  const fillRatio = Math.min(level / maxCumulative, 1);
+  const waterTop = TUB_INNER_BOTTOM - fillRatio * TUB_WATER_HEIGHT;
+
   const previous = step === 0 ? null : steps[step - 1];
   const previousCumulative = previous?.cumulativeMton ?? 0;
   const chunkMton = current.cumulativeMton - previousCumulative;
   // Milestone chunks cover the years after the previous sample through current.
   const chunkFromYear = previous ? previous.year + 1 : current.year;
   const chunkToYear = current.year;
-  const fillRatio = Math.min(current.cumulativeMton / maxCumulative, 1);
-  const waterTop = TUB_INNER_BOTTOM - fillRatio * TUB_WATER_HEIGHT;
-
-  // Chunk bands: each sampled year contributes a layer of water
-  const chunks = steps.slice(0, step + 1);
 
   const chunkCaption =
     chunkFromYear === chunkToYear
@@ -178,27 +321,6 @@ export function NationBathtub({ data }: NationBathtubProps) {
           fromYear: chunkFromYear,
           toYear: chunkToYear,
         });
-
-  const yearBlock = (
-    <div className="text-center space-y-0.5 md:space-y-1 min-h-[3.5rem] md:min-h-[4.5rem]">
-      <motion.p
-        key={current.year}
-        initial={{ opacity: 0, y: 6 }}
-        animate={{ opacity: 1, y: 0 }}
-        className={NATION_STORY_TYPE.stat}
-      >
-        {current.year}
-      </motion.p>
-      <p className={`${NATION_STORY_TYPE.meta} ${NATION_STORY_TEXT.body}`}>
-        {t("nation.story.bathtub.levelCaption", {
-          value: formatMton(current.cumulativeMton, currentLanguage, 0),
-        })}
-      </p>
-      <p className={`${NATION_STORY_TYPE.meta} ${NATION_STORY_TEXT.secondary}`}>
-        {chunkCaption}
-      </p>
-    </div>
-  );
 
   return (
     <section
@@ -214,24 +336,22 @@ export function NationBathtub({ data }: NationBathtubProps) {
         className="h-[100svh] flex items-center px-4 md:px-8 py-3 md:py-0"
         style={stageStyle}
       >
-        {/* Mobile: compact tub on top, copy below (Swedish text is too long for the basin). */}
-        <div className="w-full max-w-3xl mx-auto md:hidden space-y-3">
-          <div className="flex flex-col items-center gap-2">
-            <TubGraphic
-              waterClipId={waterClipId}
-              waterClipUrl={waterClipUrl}
-              chunks={chunks}
-              maxCumulative={maxCumulative}
-              waterTop={waterTop}
-              strongerWater
-              className="w-44 h-auto"
-            />
-            {yearBlock}
-          </div>
-          <div className="space-y-2.5 text-center">
+        <div className="w-full max-w-3xl mx-auto space-y-4 md:space-y-6">
+          {/* Copy above the tub on all breakpoints */}
+          <div className="max-w-2xl mx-auto text-center space-y-2.5 md:space-y-3">
+            <motion.p
+              initial={{ opacity: 0, y: 10 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true, amount: 0.4 }}
+              transition={{ duration: 0.4 }}
+              className={`${NATION_STORY_TYPE.eyebrow} ${NATION_STORY_TEXT.eyebrow}`}
+            >
+              {t("nation.story.bathtub.eyebrow")}
+            </motion.p>
             <motion.p
               initial={{ opacity: 0, y: 12 }}
-              animate={{ opacity: 1, y: 0 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true, amount: 0.4 }}
               transition={{ duration: 0.45 }}
               className={`${NATION_STORY_TYPE.body} ${NATION_STORY_TEXT.body}`}
             >
@@ -239,46 +359,42 @@ export function NationBathtub({ data }: NationBathtubProps) {
             </motion.p>
             <motion.p
               initial={{ opacity: 0, y: 10 }}
-              animate={{ opacity: 1, y: 0 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true, amount: 0.4 }}
               transition={{ duration: 0.45, delay: 0.1 }}
               className={`${NATION_STORY_TYPE.emphasis} text-white`}
             >
               {t("nation.story.bathtub.question")}
             </motion.p>
           </div>
-        </div>
 
-        {/* Desktop: wide tub with copy inside translucent water. */}
-        <div className="hidden md:block w-full max-w-4xl mx-auto">
-          <div className="relative mx-auto w-full">
-            <TubGraphic
-              waterClipId={`${waterClipId}-desktop`}
-              waterClipUrl={svgLocalUrl(`${waterClipId}-desktop`)}
-              chunks={chunks}
-              maxCumulative={maxCumulative}
-              waterTop={waterTop}
-              className="w-full h-auto"
-            />
-            <div className="pointer-events-none absolute inset-x-[12%] top-[28%] bottom-[26%] flex flex-col items-center justify-center gap-4 text-center px-6">
-              <motion.p
-                initial={{ opacity: 0, y: 12 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.45 }}
-                className="text-lg leading-relaxed text-white [text-shadow:0_1px_10px_rgba(0,0,0,0.55)]"
-              >
-                {t("nation.story.bathtub.text")}
-              </motion.p>
-              <motion.p
-                initial={{ opacity: 0, y: 10 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.45, delay: 0.1 }}
-                className="text-xl font-medium text-white [text-shadow:0_1px_10px_rgba(0,0,0,0.55)]"
-              >
-                {t("nation.story.bathtub.question")}
-              </motion.p>
-            </div>
+          <TubGraphic
+            idPrefix={idPrefix}
+            waterTop={waterTop}
+            className="w-56 md:w-full max-w-lg mx-auto h-auto"
+          />
+
+          {/* Milestone captions below the tub */}
+          <div className="text-center space-y-0.5 md:space-y-1 min-h-[3.5rem] md:min-h-[4.5rem]">
+            <motion.p
+              key={current.year}
+              initial={{ opacity: 0, y: 6 }}
+              animate={{ opacity: 1, y: 0 }}
+              className={NATION_STORY_TYPE.stat}
+            >
+              {current.year}
+            </motion.p>
+            <p className={`${NATION_STORY_TYPE.meta} ${NATION_STORY_TEXT.body}`}>
+              {t("nation.story.bathtub.levelCaption", {
+                value: formatMton(current.cumulativeMton, currentLanguage, 0),
+              })}
+            </p>
+            <p
+              className={`${NATION_STORY_TYPE.meta} ${NATION_STORY_TEXT.secondary}`}
+            >
+              {chunkCaption}
+            </p>
           </div>
-          <div className="mt-4">{yearBlock}</div>
         </div>
       </div>
     </section>

--- a/src/components/nation/story/NationBathtub.tsx
+++ b/src/components/nation/story/NationBathtub.tsx
@@ -384,7 +384,9 @@ export function NationBathtub({ data }: NationBathtubProps) {
             >
               {current.year}
             </motion.p>
-            <p className={`${NATION_STORY_TYPE.meta} ${NATION_STORY_TEXT.body}`}>
+            <p
+              className={`${NATION_STORY_TYPE.meta} ${NATION_STORY_TEXT.body}`}
+            >
               {t("nation.story.bathtub.levelCaption", {
                 value: formatMton(current.cumulativeMton, currentLanguage, 0),
               })}

--- a/src/components/nation/story/NationBathtub.tsx
+++ b/src/components/nation/story/NationBathtub.tsx
@@ -27,19 +27,24 @@ function sampleBathtubYears(
   return sampled;
 }
 
-/** Cumulative level interpolated continuously across the full yearly series. */
-function levelAtProgress(
-  data: NationBathtubDataPoint[],
+/** Cumulative level interpolated between milestone steps for the current scroll segment. */
+function levelAtStepProgress(
+  steps: NationBathtubDataPoint[],
+  step: number,
   progress: number,
+  stepCount: number,
 ): number {
-  if (data.length === 0) return 0;
-  const position = progress * (data.length - 1);
-  const index = Math.floor(position);
-  const fraction = position - index;
-  const from = data[index];
-  const to = data[Math.min(index + 1, data.length - 1)];
+  if (steps.length === 0) return 0;
+  const current = steps[step];
+  if (!current) return 0;
+
+  const stepProgress = Math.min(Math.max(progress * stepCount - step, 0), 1);
+  const previousCumulative =
+    step === 0 ? 0 : (steps[step - 1]?.cumulativeMton ?? 0);
+
   return (
-    from.cumulativeMton + (to.cumulativeMton - from.cumulativeMton) * fraction
+    previousCumulative +
+    stepProgress * (current.cumulativeMton - previousCumulative)
   );
 }
 
@@ -203,18 +208,18 @@ function TubGraphic({ idPrefix, waterTop, className }: TubGraphicProps) {
           transition={waterTransition}
           fill={svgLocalUrl(gradientId)}
         />
-        {/* Elliptical surface gives the water a 3D lens matching the rim */}
-        <motion.ellipse
-          cx={260}
-          fill="var(--blue-2)"
-          fillOpacity={0.32}
-          stroke="var(--blue-2)"
-          strokeWidth="2"
-          initial={false}
-          animate={{ cy: waterTop, rx: surfaceRx, ry: surfaceRy }}
-          transition={waterTransition}
-        />
       </g>
+      {/* Surface sits above the fill and outside the clip so it stays visible when full */}
+      <motion.ellipse
+        cx={260}
+        fill="var(--blue-2)"
+        fillOpacity={0.32}
+        stroke="var(--blue-2)"
+        strokeWidth="2"
+        initial={false}
+        animate={{ cy: waterTop, rx: surfaceRx, ry: surfaceRy }}
+        transition={waterTransition}
+      />
 
       {/* Basin walls and rounded floor */}
       <path
@@ -288,18 +293,19 @@ export function NationBathtub({ data }: NationBathtubProps) {
   // useId can include ":" which is awkward in url(#…) fragments
   const idPrefix = `tub-${useId().replace(/:/g, "")}`;
   const steps = useMemo(() => sampleBathtubYears(data), [data]);
+  const stepCount = Math.max(steps.length, 1);
   const maxCumulative = data.at(-1)?.cumulativeMton ?? 1;
 
   const { ref, step, progress, sectionVh, stageStyle } = usePinnedSteps(
-    Math.max(steps.length, 1),
+    stepCount,
     70,
   );
 
   const current = steps[step] ?? steps[0];
   if (!current) return null;
 
-  // Water rises continuously with scroll; captions advance in milestones.
-  const level = levelAtProgress(data, progress);
+  // Water rises smoothly within each milestone segment so fill matches captions.
+  const level = levelAtStepProgress(steps, step, progress, stepCount);
   const fillRatio = Math.min(level / maxCumulative, 1);
   const waterTop = TUB_INNER_BOTTOM - fillRatio * TUB_WATER_HEIGHT;
 

--- a/src/components/nation/story/NationConclusion.tsx
+++ b/src/components/nation/story/NationConclusion.tsx
@@ -1,6 +1,10 @@
+import { useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { motion } from "framer-motion";
+import { ArrowRight } from "lucide-react";
+import { animate, motion, useInView, useReducedMotion } from "framer-motion";
+import { Button } from "@/components/ui/button";
+import { LocalizedLink } from "@/components/LocalizedLink";
 import {
   formatMton,
   type NationStoryMetrics,
@@ -16,16 +20,149 @@ type NationConclusionProps = {
   metrics: NationStoryMetrics;
 };
 
+/** Counts up from zero when scrolled into view, so the final numbers land. */
+function CountUpMton({ value }: { value: number }) {
+  const { currentLanguage } = useLanguage();
+  const reducedMotion = useReducedMotion();
+  const ref = useRef<HTMLSpanElement>(null);
+  const inView = useInView(ref, { once: true, amount: 0.6 });
+  const [display, setDisplay] = useState(() =>
+    formatMton(0, currentLanguage, 0),
+  );
+
+  useEffect(() => {
+    if (!inView) return;
+    if (reducedMotion) {
+      setDisplay(formatMton(value, currentLanguage, 0));
+      return;
+    }
+    const controls = animate(0, value, {
+      duration: 1.4,
+      ease: "easeOut",
+      onUpdate: (v) => setDisplay(formatMton(v, currentLanguage, 0)),
+    });
+    return () => controls.stop();
+  }, [inView, value, currentLanguage, reducedMotion]);
+
+  return <span ref={ref}>{display}</span>;
+}
+
+/** Site-standard sweep-fill CTA button (same treatment as the landing sections). */
+function StoryCtaButton({
+  to,
+  children,
+}: {
+  to: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <LocalizedLink to={to} className="w-fit">
+      <Button
+        variant="outline"
+        size="lg"
+        className="group relative w-auto h-12 rounded-md overflow-hidden font-medium border-white group-hover:border-blue-3 hover:opacity-100 active:opacity-100"
+      >
+        <span
+          className="absolute inset-0 origin-left scale-x-0 bg-white transition-transform duration-500 ease-out group-hover:scale-x-100"
+          aria-hidden="true"
+        />
+        <span className="relative z-10 inline-flex items-center text-white transition-colors duration-500 group-hover:text-black">
+          {children}
+          <ArrowRight className="w-5 h-5 ml-2" aria-hidden="true" />
+        </span>
+      </Button>
+    </LocalizedLink>
+  );
+}
+
+type ConclusionStatProps = {
+  labelKey: string;
+  value: number;
+  changePercent: number;
+  /** value / max — drives the proportional scale bar */
+  share: number;
+  colorClass: string;
+  barColor: string;
+  delay: number;
+};
+
+function ConclusionStat({
+  labelKey,
+  value,
+  changePercent,
+  share,
+  colorClass,
+  barColor,
+  delay,
+}: ConclusionStatProps) {
+  const { t } = useTranslation();
+  const { currentLanguage } = useLanguage();
+  const reducedMotion = useReducedMotion();
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, amount: 0.5 }}
+      transition={{ duration: 0.5, delay }}
+      className="px-4 sm:px-8 md:px-12"
+    >
+      <p
+        className={`${NATION_STORY_TYPE.eyebrow} ${NATION_STORY_TEXT.secondary} mb-3 md:mb-4`}
+      >
+        {t(labelKey)}
+      </p>
+      <p
+        className={`text-6xl md:text-display font-light tabular-nums leading-none ${colorClass}`}
+      >
+        <CountUpMton value={value} />
+      </p>
+      <p
+        className={`${NATION_STORY_TYPE.body} ${NATION_STORY_TEXT.body} mt-2 md:mt-3`}
+      >
+        {t("nation.story.unit.millionTco2e")}
+      </p>
+
+      {/* Proportional scale bar – same fill metaphor as the hero and bathtub */}
+      <div className="mt-5 md:mt-6 h-1.5 w-full max-w-56 mx-auto rounded-full bg-white/10 overflow-hidden">
+        <motion.div
+          className="h-full rounded-full"
+          style={{ backgroundColor: barColor }}
+          initial={{ width: 0 }}
+          whileInView={{ width: `${share * 100}%` }}
+          viewport={{ once: true, amount: 0.6 }}
+          transition={
+            reducedMotion
+              ? { duration: 0 }
+              : { duration: 1.2, ease: "easeOut", delay: delay + 0.3 }
+          }
+        />
+      </div>
+
+      <p
+        className={`mt-4 md:mt-5 ${NATION_STORY_TYPE.emphasis} ${colorClass} tabular-nums`}
+      >
+        {formatPercentChange(changePercent, currentLanguage)}{" "}
+        <span
+          className={`font-normal ${NATION_STORY_TYPE.meta} ${NATION_STORY_TEXT.secondary}`}
+        >
+          {t("nation.story.conclusion.since1990")}
+        </span>
+      </p>
+    </motion.div>
+  );
+}
+
 export function NationConclusion({ metrics }: NationConclusionProps) {
   const { t } = useTranslation();
-  const { currentLanguage, getLocalizedPath } = useLanguage();
+  const { getLocalizedPath } = useLanguage();
 
   return (
     <div className="max-w-3xl mx-auto text-center space-y-5 md:space-y-8">
       <motion.p
         initial={{ opacity: 0, y: 12 }}
         whileInView={{ opacity: 1, y: 0 }}
-        viewport={{ once: false, amount: 0.5 }}
+        viewport={{ once: true, amount: 0.5 }}
         transition={{ duration: 0.4 }}
         className={`${NATION_STORY_TYPE.eyebrow} ${NATION_STORY_TEXT.eyebrow}`}
       >
@@ -35,83 +172,40 @@ export function NationConclusion({ metrics }: NationConclusionProps) {
       <motion.h2
         initial={{ opacity: 0, y: 16 }}
         whileInView={{ opacity: 1, y: 0 }}
-        viewport={{ once: false, amount: 0.5 }}
+        viewport={{ once: true, amount: 0.5 }}
         transition={{ duration: 0.45, delay: 0.05 }}
         className={`${NATION_STORY_TYPE.title} leading-tight`}
       >
         {t("nation.story.conclusion.title")}
       </motion.h2>
 
-      <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        whileInView={{ opacity: 1, y: 0 }}
-        viewport={{ once: false, amount: 0.5 }}
-        transition={{ duration: 0.5, delay: 0.15 }}
-        className="grid grid-cols-1 sm:grid-cols-2 gap-6 md:gap-12 py-2 md:py-4"
-      >
-        <div className="p-1 md:p-2">
-          <p
-            className={`${NATION_STORY_TYPE.eyebrow} ${NATION_STORY_TEXT.secondary} mb-2 md:mb-3`}
-          >
-            {t("nation.story.conclusion.usualLabel")}
-          </p>
-          <p className={`${NATION_STORY_TYPE.display} text-blue-2`}>
-            {formatMton(metrics.territorialLatestMton, currentLanguage, 0)}
-          </p>
-          <p
-            className={`${NATION_STORY_TYPE.body} ${NATION_STORY_TEXT.body} mt-1.5 md:mt-2`}
-          >
-            {t("nation.story.unit.millionTco2e")}
-          </p>
-          <p
-            className={`mt-3 md:mt-4 ${NATION_STORY_TYPE.emphasis} text-blue-2 tabular-nums`}
-          >
-            {formatPercentChange(
-              metrics.territorialChangePercent,
-              currentLanguage,
-            )}{" "}
-            <span
-              className={`font-normal ${NATION_STORY_TYPE.meta} ${NATION_STORY_TEXT.secondary}`}
-            >
-              {t("nation.story.conclusion.since1990")}
-            </span>
-          </p>
-        </div>
-
-        <div className="p-1 md:p-2">
-          <p
-            className={`${NATION_STORY_TYPE.eyebrow} ${NATION_STORY_TEXT.secondary} mb-2 md:mb-3`}
-          >
-            {t("nation.story.conclusion.fullLabel")}
-          </p>
-          <p className={`${NATION_STORY_TYPE.display} text-pink-3`}>
-            {formatMton(metrics.combinedLatestMton, currentLanguage, 0)}
-          </p>
-          <p
-            className={`${NATION_STORY_TYPE.body} ${NATION_STORY_TEXT.body} mt-1.5 md:mt-2`}
-          >
-            {t("nation.story.unit.millionTco2e")}
-          </p>
-          <p
-            className={`mt-3 md:mt-4 ${NATION_STORY_TYPE.emphasis} text-pink-3 tabular-nums`}
-          >
-            {formatPercentChange(
-              metrics.combinedChangePercent,
-              currentLanguage,
-            )}{" "}
-            <span
-              className={`font-normal ${NATION_STORY_TYPE.meta} ${NATION_STORY_TEXT.secondary}`}
-            >
-              {t("nation.story.conclusion.since1990")}
-            </span>
-          </p>
-        </div>
-      </motion.div>
+      {/* Open two-column finale: stats stand directly on the backdrop,
+          separated by a hairline on desktop */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-8 sm:gap-0 sm:divide-x sm:divide-white/10 py-4 md:py-6">
+        <ConclusionStat
+          labelKey="nation.story.conclusion.usualLabel"
+          value={metrics.territorialLatestMton}
+          changePercent={metrics.territorialChangePercent}
+          share={metrics.territorialLatestMton / metrics.combinedLatestMton}
+          colorClass="text-orange-3"
+          barColor="var(--orange-3)"
+          delay={0.15}
+        />
+        <ConclusionStat
+          labelKey="nation.story.conclusion.fullLabel"
+          value={metrics.combinedLatestMton}
+          changePercent={metrics.combinedChangePercent}
+          share={1}
+          colorClass="text-pink-3"
+          barColor="var(--pink-3)"
+          delay={0.3}
+        />
+      </div>
 
       <motion.p
         initial={{ opacity: 0, y: 12 }}
         whileInView={{ opacity: 1, y: 0 }}
-        viewport={{ once: false, amount: 0.4 }}
+        viewport={{ once: true, amount: 0.4 }}
         transition={{ duration: 0.4, delay: 0.2 }}
         className={`${NATION_STORY_TYPE.meta} ${NATION_STORY_TEXT.secondary}`}
       >
@@ -122,6 +216,27 @@ export function NationConclusion({ metrics }: NationConclusionProps) {
           {t("nation.story.conclusion.methodologyLink")}
         </Link>
       </motion.p>
+
+      {/* Closing CTA: the story hands the reader on to the data */}
+      <motion.div
+        initial={{ opacity: 0, y: 14 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true, amount: 0.4 }}
+        transition={{ duration: 0.45, delay: 0.25 }}
+        className="pt-4 md:pt-6 space-y-4 md:space-y-5"
+      >
+        <p className={`${NATION_STORY_TYPE.body} ${NATION_STORY_TEXT.body}`}>
+          {t("nation.story.conclusion.ctaLead")}
+        </p>
+        <div className="flex flex-col sm:flex-row items-center justify-center gap-3 md:gap-4">
+          <StoryCtaButton to="/nation">
+            {t("nation.story.conclusion.ctaNation")}
+          </StoryCtaButton>
+          <StoryCtaButton to="/municipalities">
+            {t("nation.story.conclusion.ctaMunicipalities")}
+          </StoryCtaButton>
+        </div>
+      </motion.div>
     </div>
   );
 }

--- a/src/components/nation/story/NationEmissionsJourney.tsx
+++ b/src/components/nation/story/NationEmissionsJourney.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next";
-import { motion } from "framer-motion";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import {
   formatMton,
   type NationStoryMetrics,
@@ -26,12 +26,11 @@ type JourneyStep = {
   layer: boolean;
   /** small extra addition drawn as a dashed ring (private e-commerce) */
   ring?: boolean;
-  badgeKey?: string;
 };
 
 /** Desktop onion diameter; mobile scales down so text + bubble fit one screen. */
 const DESKTOP_MAX_DIAMETER = 300;
-const MOBILE_MAX_DIAMETER = 168;
+const MOBILE_MAX_DIAMETER = 148;
 /** Scroll distance per journey step – higher = more time to watch each layer grow. */
 const JOURNEY_STEP_VH = 115;
 /** Gentle spring so each new onion layer visibly expands. */
@@ -85,7 +84,6 @@ function buildSteps(metrics: NationStoryMetrics): JourneyStep[] {
       delta: 0,
       layer: false,
       ring: true,
-      badgeKey: "nation.story.journey.step4.badge",
     },
     {
       key: "step5",
@@ -109,6 +107,7 @@ export function NationEmissionsJourney({
   const { t } = useTranslation();
   const { currentLanguage } = useLanguage();
   const { isMobile } = useScreenSize();
+  const reducedMotion = useReducedMotion();
 
   const steps = buildSteps(metrics);
   const maxTotal = steps[steps.length - 1].total;
@@ -139,6 +138,11 @@ export function NationEmissionsJourney({
   const diameterFor = (total: number) =>
     Math.sqrt(total / maxTotal) * maxDiameter;
 
+  // Distance from the bubble center to just outside the current circle's
+  // edge along the 45° upper-right diagonal.
+  const deltaChipOffset =
+    diameterFor(current.total) / 2 / Math.SQRT2 + (isMobile ? 8 : 12);
+
   return (
     <section
       ref={ref}
@@ -150,16 +154,41 @@ export function NationEmissionsJourney({
       style={{ height: `${sectionVh}vh` }}
     >
       <div
-        className="h-[100svh] flex items-center px-4 md:px-8 py-3 md:py-0"
+        className="h-[100svh] flex items-center px-4 md:px-8 py-3 md:py-0 overflow-hidden"
         style={stageStyle}
       >
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-12 items-center w-full max-w-5xl mx-auto">
+        {/* Same subtle depth backdrop as the hero, tying the chapter to the intro */}
+        <div
+          aria-hidden
+          className="absolute inset-0 bg-[radial-gradient(ellipse_70%_55%_at_50%_45%,var(--black-2)_0%,var(--black-3)_78%)]"
+        />
+        <div className="relative grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-12 items-center w-full max-w-5xl mx-auto">
           {/* Bubble = accumulating colored layers */}
           <div className="flex flex-col items-center gap-2 md:gap-4 order-1">
             <div
               className="relative"
               style={{ width: maxDiameter, height: maxDiameter }}
             >
+              {/* Soft glow behind the bubble in the current step's color */}
+              <AnimatePresence>
+                <motion.div
+                  key={`glow-${current.color}`}
+                  aria-hidden
+                  className="absolute left-1/2 top-1/2 rounded-full blur-3xl"
+                  style={{
+                    width: maxDiameter * 1.3,
+                    height: maxDiameter * 1.3,
+                    x: "-50%",
+                    y: "-50%",
+                    backgroundColor: current.color,
+                  }}
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 0.18 }}
+                  exit={{ opacity: 0 }}
+                  transition={{ duration: reducedMotion ? 0 : 0.8 }}
+                />
+              </AnimatePresence>
+
               {revealedLayers.map((layer) => {
                 const d = diameterFor(layer.total);
                 const isGrowingLayer = layer.key === newestLayerKey;
@@ -169,13 +198,15 @@ export function NationEmissionsJourney({
                     className="absolute left-1/2 top-1/2 rounded-full"
                     style={{ backgroundColor: layer.color, opacity: 1 }}
                     initial={
-                      isGrowingLayer
+                      isGrowingLayer && !reducedMotion
                         ? { width: 0, height: 0, x: "-50%", y: "-50%" }
                         : { width: d, height: d, x: "-50%", y: "-50%" }
                     }
                     animate={{ width: d, height: d, x: "-50%", y: "-50%" }}
                     transition={
-                      isGrowingLayer ? LAYER_GROW_TRANSITION : { duration: 0 }
+                      isGrowingLayer && !reducedMotion
+                        ? LAYER_GROW_TRANSITION
+                        : { duration: 0 }
                     }
                   />
                 );
@@ -192,25 +223,61 @@ export function NationEmissionsJourney({
                     y: "-50%",
                     borderColor: NATION_STORY_COLORS.eCommerceRing,
                   }}
-                  initial={{ opacity: 0, scale: 0.85 }}
+                  initial={reducedMotion ? false : { opacity: 0, scale: 0.85 }}
                   animate={{ opacity: 1, scale: 1 }}
-                  transition={{ duration: 0.9, ease: [0.22, 1, 0.36, 1] }}
+                  transition={
+                    reducedMotion
+                      ? { duration: 0 }
+                      : { duration: 0.9, ease: [0.22, 1, 0.36, 1] }
+                  }
                 />
               )}
 
               {/* Running total on top */}
               <div className="absolute inset-0 flex items-center justify-center">
                 <span
-                  className={`${NATION_STORY_TYPE.stat} text-black font-bold select-none leading-none text-center`}
+                  className={`${NATION_STORY_TYPE.stat} text-black font-medium select-none leading-none text-center`}
                 >
                   {formatMton(current.total, currentLanguage, 0)}
                   <span
-                    className={`block ${NATION_STORY_TYPE.meta} font-semibold mt-0.5 md:mt-1`}
+                    className={`block ${NATION_STORY_TYPE.meta} font-medium mt-0.5 md:mt-1`}
                   >
                     {t("nation.story.unit.mton")}
                   </span>
                 </span>
               </div>
+
+              {/* The step's own contribution sits just off the current circle's
+                  upper-right edge, riding outward with the same spring as the
+                  growing layer so it follows the circle smoothly. */}
+              {step > 0 && current.delta > 0 && (
+                <motion.span
+                  className="absolute left-1/2 top-1/2 pointer-events-none"
+                  initial={false}
+                  animate={{ x: deltaChipOffset, y: -deltaChipOffset }}
+                  transition={
+                    reducedMotion ? { duration: 0 } : LAYER_GROW_TRANSITION
+                  }
+                >
+                  <span className="block -translate-y-full">
+                    <motion.p
+                      key={`delta-${current.key}`}
+                      initial={
+                        reducedMotion
+                          ? false
+                          : { opacity: 0, y: 8, scale: 0.92 }
+                      }
+                      animate={{ opacity: 1, y: 0, scale: 1 }}
+                      transition={{ duration: 0.45, delay: 0.2 }}
+                      className={`${NATION_STORY_TYPE.emphasis} tabular-nums whitespace-nowrap`}
+                      style={{ color: current.color }}
+                    >
+                      +{formatMton(current.delta, currentLanguage, 0)}{" "}
+                      {t("nation.story.unit.mton")}
+                    </motion.p>
+                  </span>
+                </motion.span>
+              )}
             </div>
 
             <p
@@ -230,6 +297,14 @@ export function NationEmissionsJourney({
               className="space-y-2 md:space-y-3"
             >
               <p
+                className={`${NATION_STORY_TYPE.eyebrow} ${NATION_STORY_TEXT.eyebrow}`}
+              >
+                {t("nation.story.journey.stepCounter", {
+                  current: step + 1,
+                  total: steps.length,
+                })}
+              </p>
+              <p
                 className={`flex items-center gap-2.5 md:gap-3 ${NATION_STORY_TYPE.emphasis} text-white`}
               >
                 <span
@@ -243,38 +318,53 @@ export function NationEmissionsJourney({
               >
                 {t(current.textKey)}
               </p>
-              {current.badgeKey && (
-                <p className={`${NATION_STORY_TYPE.emphasis} text-pink-1`}>
-                  {t(current.badgeKey)}
-                </p>
-              )}
             </motion.div>
 
-            {/* Legend: each type and what it adds to the total */}
-            <div className="space-y-1 border-t border-white/10 pt-2 md:pt-3">
-              {steps
-                .slice(0, step + 1)
-                .filter((s) => s.layer)
-                .map((s, i) => (
-                  <div
-                    key={s.key}
-                    className={`flex items-center gap-2 md:gap-2.5 ${NATION_STORY_TYPE.meta}`}
-                  >
-                    <span
-                      className="w-2.5 h-2.5 md:w-3.5 md:h-3.5 rounded-full shrink-0"
-                      style={{ backgroundColor: s.color }}
-                    />
-                    <span className={`${NATION_STORY_TEXT.secondary} flex-1`}>
-                      {t(s.labelKey)}
-                    </span>
-                    <span className="text-white tabular-nums shrink-0">
-                      {i === 0 ? "" : "+"}
-                      {formatMton(s.delta, currentLanguage, 0)}{" "}
-                      {t("nation.story.unit.mton")}
-                    </span>
-                  </div>
-                ))}
-            </div>
+            {/* Running tally: builds up row by row, with a summed total line.
+                Hidden while there is only one layer (it would just repeat the header). */}
+            {revealedLayers.length >= 2 && (
+              <div className="space-y-1 border-t border-white/10 pt-2 md:pt-3">
+                {steps
+                  .slice(0, step + 1)
+                  .filter((s) => s.layer)
+                  .map((s, i) => (
+                    <motion.div
+                      key={s.key}
+                      initial={{ opacity: 0, x: -10 }}
+                      animate={{ opacity: 1, x: 0 }}
+                      transition={{ duration: 0.35, delay: 0.1 }}
+                      className={`flex items-center gap-2 md:gap-2.5 ${NATION_STORY_TYPE.meta}`}
+                    >
+                      <span
+                        className="w-2.5 h-2.5 md:w-3.5 md:h-3.5 rounded-full shrink-0"
+                        style={{ backgroundColor: s.color }}
+                      />
+                      <span className={`${NATION_STORY_TEXT.secondary} flex-1`}>
+                        {t(s.labelKey)}
+                      </span>
+                      <span
+                        className={`${NATION_STORY_TEXT.secondary} tabular-nums shrink-0`}
+                      >
+                        {i === 0 ? "" : "+"}
+                        {formatMton(s.delta, currentLanguage, 0)}{" "}
+                        {t("nation.story.unit.mton")}
+                      </span>
+                    </motion.div>
+                  ))}
+                <div
+                  className={`flex items-center gap-2 md:gap-2.5 border-t border-white/10 pt-1.5 mt-1.5 ${NATION_STORY_TYPE.meta} text-white font-medium`}
+                >
+                  <span className="w-2.5 md:w-3.5 shrink-0" aria-hidden />
+                  <span className="flex-1">
+                    {t("nation.story.journey.totalLabel")}
+                  </span>
+                  <span className="tabular-nums shrink-0">
+                    {formatMton(current.total, currentLanguage, 0)}{" "}
+                    {t("nation.story.unit.mton")}
+                  </span>
+                </div>
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/nation/story/NationIntroPunch.tsx
+++ b/src/components/nation/story/NationIntroPunch.tsx
@@ -60,7 +60,9 @@ function StatCallout({
       transition={{ duration: 0.5, delay }}
       className="text-center md:text-left"
     >
-      <p className={`${NATION_STORY_TYPE.meta} ${NATION_STORY_TEXT.secondary} mb-1`}>
+      <p
+        className={`${NATION_STORY_TYPE.meta} ${NATION_STORY_TEXT.secondary} mb-1`}
+      >
         {label}
       </p>
       <p className={`${NATION_STORY_TYPE.display} ${colorClass}`}>
@@ -145,7 +147,11 @@ export function NationIntroPunch({ metrics }: NationIntroPunchProps) {
                 height: OUTLINE_BOTTOM - fillTop + 6,
               }}
               viewport={{ once: true, amount: 0.35 }}
-              transition={reducedMotion ? { duration: 0 } : { ...FILL_SPRING, delay: 0.35 }}
+              transition={
+                reducedMotion
+                  ? { duration: 0 }
+                  : { ...FILL_SPRING, delay: 0.35 }
+              }
             />
             <motion.line
               x1={0}
@@ -160,7 +166,11 @@ export function NationIntroPunch({ metrics }: NationIntroPunchProps) {
               }
               whileInView={{ y1: fillTop, y2: fillTop, opacity: 1 }}
               viewport={{ once: true, amount: 0.35 }}
-              transition={reducedMotion ? { duration: 0 } : { ...FILL_SPRING, delay: 0.35 }}
+              transition={
+                reducedMotion
+                  ? { duration: 0 }
+                  : { ...FILL_SPRING, delay: 0.35 }
+              }
             />
           </g>
         </svg>

--- a/src/components/nation/story/NationIntroPunch.tsx
+++ b/src/components/nation/story/NationIntroPunch.tsx
@@ -1,11 +1,17 @@
+import { useId } from "react";
 import { useTranslation } from "react-i18next";
-import { motion } from "framer-motion";
+import { motion, useReducedMotion } from "framer-motion";
 import {
   formatMton,
   type NationStoryMetrics,
 } from "@/utils/data/nationStoryMetrics";
 import { useLanguage } from "@/components/LanguageProvider";
-import { NATION_STORY_COLORS } from "@/components/nation/story/nationStoryColors";
+import {
+  NATION_STORY_COLORS,
+  NATION_STORY_TEXT,
+  NATION_STORY_TYPE,
+} from "@/components/nation/story/nationStoryColors";
+import { svgLocalUrl } from "@/components/nation/story/svgLocalUrl";
 import {
   SWEDEN_OUTLINE_PATH,
   SWEDEN_OUTLINE_VIEWBOX,
@@ -15,15 +21,83 @@ type NationIntroPunchProps = {
   metrics: NationStoryMetrics;
 };
 
+/** Silhouette vertical extents inside the 0 0 100 220 viewBox. */
+const OUTLINE_TOP = 6;
+const OUTLINE_BOTTOM = 214;
+const OUTLINE_HEIGHT = OUTLINE_BOTTOM - OUTLINE_TOP;
+
+const FILL_SPRING = {
+  type: "spring" as const,
+  stiffness: 50,
+  damping: 18,
+  mass: 1,
+};
+
+type StatCalloutProps = {
+  label: string;
+  value: string;
+  /** Compact unit for mobile (e.g. "Mton") */
+  unitShort: string;
+  /** Written-out unit for desktop (e.g. "miljoner ton") */
+  unitLong: string;
+  colorClass: string;
+  delay: number;
+};
+
+function StatCallout({
+  label,
+  value,
+  unitShort,
+  unitLong,
+  colorClass,
+  delay,
+}: StatCalloutProps) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, x: 12 }}
+      whileInView={{ opacity: 1, x: 0 }}
+      viewport={{ once: true, amount: 0.4 }}
+      transition={{ duration: 0.5, delay }}
+      className="text-center md:text-left"
+    >
+      <p className={`${NATION_STORY_TYPE.meta} ${NATION_STORY_TEXT.secondary} mb-1`}>
+        {label}
+      </p>
+      <p className={`${NATION_STORY_TYPE.display} ${colorClass}`}>
+        {value}{" "}
+        <span
+          className={`${NATION_STORY_TYPE.meta} ${NATION_STORY_TEXT.secondary} font-normal align-baseline`}
+        >
+          <span className="md:hidden">{unitShort}</span>
+          <span className="hidden md:inline">{unitLong}</span>
+        </span>
+      </p>
+    </motion.div>
+  );
+}
+
+/**
+ * Hero visual: the Sweden silhouette in the full-emissions colour, with the
+ * officially reported share shown as a liquid fill rising from the bottom —
+ * foreshadowing the bathtub metaphor later in the story.
+ *
+ * The fill is height-proportional (standard infographic convention); the
+ * exact figures live in the callouts beside the silhouette.
+ */
 export function NationIntroPunch({ metrics }: NationIntroPunchProps) {
   const { t } = useTranslation();
   const { currentLanguage } = useLanguage();
+  const reducedMotion = useReducedMotion();
+  const clipId = `sweden-fill-clip-${useId().replace(/:/g, "")}`;
 
   const reportedValue = metrics.territorialLatestMton;
   const fullValue = Math.max(metrics.combinedLatestMton, reportedValue);
   const reported = formatMton(reportedValue, currentLanguage, 0);
   const full = formatMton(fullValue, currentLanguage, 0);
-  const innerScale = Math.sqrt(reportedValue / fullValue);
+  const fillRatio = reportedValue / fullValue;
+  const fillTop = OUTLINE_BOTTOM - fillRatio * OUTLINE_HEIGHT;
+  const unitShort = t("nation.story.unit.mton");
+  const unitLong = t("nation.story.unit.millionTon");
 
   return (
     <motion.div
@@ -31,18 +105,21 @@ export function NationIntroPunch({ metrics }: NationIntroPunchProps) {
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true, amount: 0.35 }}
       transition={{ duration: 0.45 }}
+      className="flex flex-col md:flex-row items-center justify-center gap-5 md:gap-10 lg:gap-14"
     >
-      {/*
-        Fluid height: small phones stay compact, short laptops shrink,
-        large desktops can grow toward the original silhouette size.
-      */}
-      <div className="relative mx-auto h-[clamp(120px,26svh,180px)] md:h-[clamp(180px,30svh,340px)] w-auto aspect-[100/220]">
+      <div className="relative h-[clamp(180px,32svh,300px)] md:h-[clamp(240px,40svh,420px)] aspect-[100/220]">
         <svg
           viewBox={SWEDEN_OUTLINE_VIEWBOX}
           className="h-full w-auto max-w-full mx-auto"
           role="img"
-          aria-label={`${reported}–${full} ${t("nation.story.unit.mton")}`}
+          aria-label={`${reported}–${full} ${unitLong}`}
         >
+          <defs>
+            <clipPath id={clipId}>
+              <path d={SWEDEN_OUTLINE_PATH} />
+            </clipPath>
+          </defs>
+
           <motion.path
             d={SWEDEN_OUTLINE_PATH}
             fill={NATION_STORY_COLORS.consumption}
@@ -51,60 +128,62 @@ export function NationIntroPunch({ metrics }: NationIntroPunchProps) {
             transition={{ duration: 0.5, ease: [0.22, 1, 0.36, 1] }}
             style={{ transformOrigin: "50% 50%" }}
           />
-          <motion.g
-            initial={{ opacity: 0, scale: 0.5 }}
-            animate={{ opacity: 1, scale: innerScale }}
-            transition={{
-              duration: 0.5,
-              delay: 0.1,
-              ease: [0.22, 1, 0.36, 1],
-            }}
-            style={{ transformOrigin: "50% 45%" }}
-          >
-            <path
-              d={SWEDEN_OUTLINE_PATH}
+
+          {/* Reported share rises like water inside the silhouette */}
+          <g clipPath={svgLocalUrl(clipId)}>
+            <motion.rect
+              x={0}
+              width={100}
               fill={NATION_STORY_COLORS.territorial}
+              initial={
+                reducedMotion
+                  ? { y: fillTop, height: OUTLINE_BOTTOM - fillTop + 6 }
+                  : { y: OUTLINE_BOTTOM, height: 0 }
+              }
+              whileInView={{
+                y: fillTop,
+                height: OUTLINE_BOTTOM - fillTop + 6,
+              }}
+              viewport={{ once: true, amount: 0.35 }}
+              transition={reducedMotion ? { duration: 0 } : { ...FILL_SPRING, delay: 0.35 }}
             />
-          </motion.g>
-
-          <text
-            x="50"
-            y="96"
-            textAnchor="middle"
-            className="fill-black font-semibold"
-            style={{ fontSize: 18 }}
-          >
-            {reported}
-          </text>
-          <text
-            x="50"
-            y="110"
-            textAnchor="middle"
-            className="fill-black/70 font-medium"
-            style={{ fontSize: 9 }}
-          >
-            {t("nation.story.unit.mton")}
-          </text>
-
-          <text
-            x="72"
-            y="168"
-            textAnchor="middle"
-            className="fill-white font-semibold"
-            style={{ fontSize: 15 }}
-          >
-            {full}
-          </text>
-          <text
-            x="72"
-            y="180"
-            textAnchor="middle"
-            className="fill-white/85 font-medium"
-            style={{ fontSize: 8 }}
-          >
-            {t("nation.story.unit.mton")}
-          </text>
+            <motion.line
+              x1={0}
+              x2={100}
+              stroke="var(--orange-1)"
+              strokeWidth="1"
+              strokeOpacity="0.8"
+              initial={
+                reducedMotion
+                  ? { y1: fillTop, y2: fillTop, opacity: 1 }
+                  : { y1: OUTLINE_BOTTOM, y2: OUTLINE_BOTTOM, opacity: 0 }
+              }
+              whileInView={{ y1: fillTop, y2: fillTop, opacity: 1 }}
+              viewport={{ once: true, amount: 0.35 }}
+              transition={reducedMotion ? { duration: 0 } : { ...FILL_SPRING, delay: 0.35 }}
+            />
+          </g>
         </svg>
+      </div>
+
+      {/* Full/pink callout beside the upper region, reported/orange beside the fill */}
+      <div className="flex flex-row md:flex-col items-center md:items-start justify-center gap-8 md:gap-10">
+        <StatCallout
+          label={t("nation.story.conclusion.fullLabel")}
+          value={full}
+          unitShort={unitShort}
+          unitLong={unitLong}
+          colorClass="text-pink-3"
+          delay={0.15}
+        />
+        <StatCallout
+          label={t("nation.story.conclusion.usualLabel")}
+          value={reported}
+          unitShort={unitShort}
+          unitLong={unitLong}
+          colorClass="text-orange-3"
+          delay={0.3}
+        />
       </div>
     </motion.div>
   );

--- a/src/components/nation/story/NationStackedChart.tsx
+++ b/src/components/nation/story/NationStackedChart.tsx
@@ -138,71 +138,71 @@ export const NationStackedChart: FC<NationStackedChartProps> = ({
           </div>
 
           <div style={{ width: "100%", height: chartHeight }}>
-              <ResponsiveContainer width="100%" height="100%">
-                <AreaChart data={data} margin={getStoryChartMargin(isMobile)}>
-                  <XAxis
-                    {...getXAxisProps(
-                      "year",
-                      [NATION_BASELINE_YEAR, latestYear],
-                      xAxisTicks,
-                    )}
-                  />
-                  <YAxis
-                    stroke="var(--grey)"
-                    tickLine={false}
-                    axisLine={false}
-                    width={isMobile ? 36 : 56}
-                    tick={{ fill: "var(--grey)", fontSize: isMobile ? 10 : 12 }}
-                    tickFormatter={(value: number) =>
-                      formatMton(value, currentLanguage, 0)
-                    }
-                    domain={[0, "auto"]}
-                    {...(!isMobile
-                      ? {
-                          label: {
-                            value: t("nation.story.unit.mton"),
-                            angle: -90,
-                            position: "insideLeft" as const,
-                            style: {
-                              fill: "var(--grey)",
-                              fontSize: 12,
-                              textAnchor: "middle",
-                            },
+            <ResponsiveContainer width="100%" height="100%">
+              <AreaChart data={data} margin={getStoryChartMargin(isMobile)}>
+                <XAxis
+                  {...getXAxisProps(
+                    "year",
+                    [NATION_BASELINE_YEAR, latestYear],
+                    xAxisTicks,
+                  )}
+                />
+                <YAxis
+                  stroke="var(--grey)"
+                  tickLine={false}
+                  axisLine={false}
+                  width={isMobile ? 36 : 56}
+                  tick={{ fill: "var(--grey)", fontSize: isMobile ? 10 : 12 }}
+                  tickFormatter={(value: number) =>
+                    formatMton(value, currentLanguage, 0)
+                  }
+                  domain={[0, "auto"]}
+                  {...(!isMobile
+                    ? {
+                        label: {
+                          value: t("nation.story.unit.mton"),
+                          angle: -90,
+                          position: "insideLeft" as const,
+                          style: {
+                            fill: "var(--grey)",
+                            fontSize: 12,
+                            textAnchor: "middle",
                           },
-                        }
-                      : {})}
-                  />
-                  <Tooltip
-                    content={
-                      <ChartTooltip
-                        unit={t("nation.story.unit.mton")}
-                        customFormatter={(value) =>
-                          formatMton(value, currentLanguage, 1)
-                        }
-                      />
-                    }
-                    wrapperStyle={{ outline: "none", zIndex: 60 }}
-                  />
-                  {LAYERS.slice(0, visibleLayers).map((layer) => (
-                    <Area
-                      key={layer.dataKey}
-                      type="monotone"
-                      dataKey={layer.dataKey}
-                      stackId="emissions"
-                      stroke={layer.color}
-                      strokeWidth={NATION_STORY_CHART.strokeWidth}
-                      fill={layer.color}
-                      fillOpacity={NATION_STORY_CHART.fillOpacity}
-                      name={t(layer.translationKey)}
-                      connectNulls={false}
-                      isAnimationActive
-                      animationDuration={1000}
-                      animationEasing="ease-out"
+                        },
+                      }
+                    : {})}
+                />
+                <Tooltip
+                  content={
+                    <ChartTooltip
+                      unit={t("nation.story.unit.mton")}
+                      customFormatter={(value) =>
+                        formatMton(value, currentLanguage, 1)
+                      }
                     />
-                  ))}
-                </AreaChart>
-              </ResponsiveContainer>
-            </div>
+                  }
+                  wrapperStyle={{ outline: "none", zIndex: 60 }}
+                />
+                {LAYERS.slice(0, visibleLayers).map((layer) => (
+                  <Area
+                    key={layer.dataKey}
+                    type="monotone"
+                    dataKey={layer.dataKey}
+                    stackId="emissions"
+                    stroke={layer.color}
+                    strokeWidth={NATION_STORY_CHART.strokeWidth}
+                    fill={layer.color}
+                    fillOpacity={NATION_STORY_CHART.fillOpacity}
+                    name={t(layer.translationKey)}
+                    connectNulls={false}
+                    isAnimationActive
+                    animationDuration={1000}
+                    animationEasing="ease-out"
+                  />
+                ))}
+              </AreaChart>
+            </ResponsiveContainer>
+          </div>
 
           {/* Legend in the story's own styling: revealed layers inline,
               each with its latest-year contribution */}

--- a/src/components/nation/story/NationStackedChart.tsx
+++ b/src/components/nation/story/NationStackedChart.tsx
@@ -16,18 +16,11 @@ import {
 } from "@/utils/data/nationStoryMetrics";
 import { useLanguage } from "@/components/LanguageProvider";
 import { useScreenSize } from "@/hooks/useScreenSize";
-import {
-  ChartFooter,
-  ChartTooltip,
-  EnhancedLegend,
-  getXAxisProps,
-  type LegendItem,
-} from "@/components/charts";
-import { SectionWithHelp } from "@/data-guide/SectionWithHelp";
-import { cn } from "@/lib/utils";
+import { ChartTooltip, getXAxisProps } from "@/components/charts";
 import {
   NATION_STORY_CHART,
   NATION_STORY_COLORS,
+  NATION_STORY_TEXT,
   NATION_STORY_TYPE,
 } from "@/components/nation/story/nationStoryColors";
 import { usePinnedSteps } from "@/components/nation/story/usePinnedSteps";
@@ -92,19 +85,8 @@ export const NationStackedChart: FC<NationStackedChartProps> = ({
   const { ref, step, sectionVh, stageStyle } = usePinnedSteps(LAYERS.length);
   const visibleLayers = step + 1;
 
-  const visibleLegendItems: LegendItem[] = useMemo(
-    () =>
-      LAYERS.slice(0, visibleLayers).map((layer) => ({
-        name: t(layer.translationKey),
-        color: layer.color,
-        isClickable: false,
-        isHidden: false,
-        isDashed: false,
-      })),
-    [t, visibleLayers],
-  );
-
-  const chartHeight = isMobile ? 180 : 320;
+  const latestPoint = data.at(-1);
+  const chartHeight = isMobile ? 190 : 330;
 
   return (
     <section
@@ -117,41 +99,45 @@ export const NationStackedChart: FC<NationStackedChartProps> = ({
       style={{ height: `${sectionVh}vh` }}
     >
       <div
-        className="h-[100svh] flex items-center px-4 md:px-8 py-3 md:py-0"
+        className="h-[100svh] flex items-center px-4 md:px-8 py-3 md:py-0 overflow-hidden"
         style={stageStyle}
       >
-        <div className="w-full max-w-4xl mx-auto">
-          <SectionWithHelp
-            helpItems={[]}
-            className={cn(
-              className,
-              "pb-1 md:pb-3 [&>div]:pb-1 [&>div]:mb-0 md:[&>div]:mb-2",
-            )}
+        {/* Same depth backdrop as the hero and journey chapters */}
+        <div
+          aria-hidden
+          className="absolute inset-0 bg-[radial-gradient(ellipse_70%_55%_at_50%_45%,var(--black-2)_0%,var(--black-3)_78%)]"
+        />
+        <div className={`relative w-full max-w-4xl mx-auto ${className ?? ""}`}>
+          <p
+            className={`${NATION_STORY_TYPE.eyebrow} ${NATION_STORY_TEXT.eyebrow} mb-2 md:mb-3`}
           >
-            <h2
-              className={`${NATION_STORY_TYPE.title} text-white mb-2 md:mb-4`}
+            {t("nation.story.stacked.layerCounter", {
+              current: visibleLayers,
+              total: LAYERS.length,
+            })}
+          </p>
+          <h2 className={`${NATION_STORY_TYPE.title} text-white mb-2 md:mb-4`}>
+            {t("nation.story.stacked.title")}
+          </h2>
+
+          {/* Caption explaining the layer currently being drawn */}
+          <div className="min-h-[2rem] md:min-h-[2.5rem] mb-2 md:mb-4">
+            <motion.p
+              key={visibleLayers}
+              initial={{ opacity: 0, y: 6 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.4 }}
+              className={`flex items-center gap-2 md:gap-3 ${NATION_STORY_TYPE.emphasis} text-white`}
             >
-              {t("nation.story.stacked.title")}
-            </h2>
+              <span
+                className="w-3 h-3 md:w-4 md:h-4 rounded-full shrink-0"
+                style={{ backgroundColor: LAYERS[visibleLayers - 1].color }}
+              />
+              {t(LAYERS[visibleLayers - 1].captionKey)}
+            </motion.p>
+          </div>
 
-            {/* Caption explaining the layer currently being drawn */}
-            <div className="min-h-[2rem] md:min-h-[2.5rem] mb-1 md:mb-2">
-              <motion.p
-                key={visibleLayers}
-                initial={{ opacity: 0, y: 6 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.4 }}
-                className={`flex items-center gap-2 md:gap-3 ${NATION_STORY_TYPE.emphasis} text-white`}
-              >
-                <span
-                  className="w-3 h-3 md:w-4 md:h-4 rounded-full shrink-0"
-                  style={{ backgroundColor: LAYERS[visibleLayers - 1].color }}
-                />
-                {t(LAYERS[visibleLayers - 1].captionKey)}
-              </motion.p>
-            </div>
-
-            <div style={{ width: "100%", height: chartHeight }}>
+          <div style={{ width: "100%", height: chartHeight }}>
               <ResponsiveContainer width="100%" height="100%">
                 <AreaChart data={data} margin={getStoryChartMargin(isMobile)}>
                   <XAxis
@@ -218,13 +204,42 @@ export const NationStackedChart: FC<NationStackedChartProps> = ({
               </ResponsiveContainer>
             </div>
 
-            <ChartFooter className="mt-1 mb-0 space-y-2">
-              <EnhancedLegend
-                items={visibleLegendItems}
-                className="gap-1.5 md:gap-3 [&_span]:text-sm md:[&_span]:text-base"
-              />
-            </ChartFooter>
-          </SectionWithHelp>
+          {/* Legend in the story's own styling: revealed layers inline,
+              each with its latest-year contribution */}
+          <div className="mt-3 md:mt-5 border-t border-white/10 pt-2.5 md:pt-3 space-y-1.5 md:space-y-2">
+            <div className="flex flex-wrap items-center gap-x-5 md:gap-x-8 gap-y-1.5">
+              {LAYERS.slice(0, visibleLayers).map((layer) => (
+                <motion.span
+                  key={layer.dataKey}
+                  initial={{ opacity: 0, y: 6 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.35, delay: 0.1 }}
+                  className={`flex items-center gap-2 md:gap-2.5 ${NATION_STORY_TYPE.meta}`}
+                >
+                  <span
+                    className="w-2.5 h-2.5 md:w-3.5 md:h-3.5 rounded-full shrink-0"
+                    style={{ backgroundColor: layer.color }}
+                  />
+                  <span className={NATION_STORY_TEXT.secondary}>
+                    {t(layer.translationKey)}
+                  </span>
+                  <span className="text-white tabular-nums">
+                    {formatMton(
+                      latestPoint?.[layer.dataKey] ?? 0,
+                      currentLanguage,
+                      0,
+                    )}{" "}
+                    {t("nation.story.unit.mton")}
+                  </span>
+                </motion.span>
+              ))}
+            </div>
+            <p
+              className={`${NATION_STORY_TYPE.meta} ${NATION_STORY_TEXT.secondary}`}
+            >
+              {t("nation.story.journey.dataYear", { year: latestYear })}
+            </p>
+          </div>
         </div>
       </div>
     </section>

--- a/src/components/nation/story/NationStoryPage.tsx
+++ b/src/components/nation/story/NationStoryPage.tsx
@@ -1,6 +1,6 @@
 import { useRef } from "react";
 import { useTranslation } from "react-i18next";
-import { motion } from "framer-motion";
+import { motion, useScroll } from "framer-motion";
 import { NationBathtub } from "@/components/nation/story/NationBathtub";
 import { NationConclusion } from "@/components/nation/story/NationConclusion";
 import { NationEmissionsJourney } from "@/components/nation/story/NationEmissionsJourney";
@@ -18,6 +18,18 @@ type NationStoryPageProps = {
   nation: NationStoryDetails;
   metrics: NationStoryMetrics;
 };
+
+/** Thin reading-progress bar just below the fixed site header. */
+function StoryProgressBar() {
+  const { scrollYProgress } = useScroll();
+  return (
+    <motion.div
+      aria-hidden
+      className="fixed top-12 left-0 right-0 z-40 h-0.5 origin-left bg-gradient-to-r from-orange-3 to-pink-3"
+      style={{ scaleX: scrollYProgress }}
+    />
+  );
+}
 
 function FullScreenSection({ children }: { children: React.ReactNode }) {
   return (
@@ -39,30 +51,60 @@ export function NationStoryPage({
 
   return (
     <div className="bg-black text-white pb-16 md:pb-24">
-      {/* Intro */}
+      <StoryProgressBar />
+
+      {/* Intro hero – exactly one viewport: eyebrow, headline, lede, silhouette */}
       <section
         data-story-section
-        className="relative flex items-start justify-center min-h-[100svh] px-4 md:px-8 pt-1 md:pt-2 pb-12 md:pb-14"
+        className="relative min-h-[100svh] md:h-[100svh] flex flex-col items-center justify-center px-4 md:px-8 pt-8 md:pt-10 pb-16 md:pb-20 overflow-hidden"
       >
-        <div className="max-w-3xl mx-auto text-center space-y-2 md:space-y-3">
-          <img
-            src="https://upload.wikimedia.org/wikipedia/commons/4/4c/Flag_of_Sweden.svg"
-            alt=""
-            className="h-7 w-10 md:h-10 md:w-16 mx-auto object-contain opacity-90 rounded-sm"
-          />
-          <h1 className={`${NATION_STORY_TYPE.title} text-white`}>
+        {/* Subtle depth behind the hero, using existing surface colors only */}
+        <div
+          aria-hidden
+          className="absolute inset-0 bg-[radial-gradient(ellipse_70%_55%_at_50%_38%,var(--black-2)_0%,var(--black-3)_78%)]"
+        />
+        <div className="relative max-w-5xl mx-auto text-center space-y-4 md:space-y-6">
+          <p
+            className={`${NATION_STORY_TYPE.eyebrow} ${NATION_STORY_TEXT.eyebrow}`}
+          >
+            {t("nation.story.intro.eyebrow")}
+          </p>
+          <h1 className="text-4xl md:text-6xl font-light tracking-tight text-white">
             {t("nation.story.intro.title")}
           </h1>
-          <p className={`${NATION_STORY_TYPE.body} ${NATION_STORY_TEXT.body}`}>
+          <p
+            className={`${NATION_STORY_TYPE.body} ${NATION_STORY_TEXT.body} max-w-2xl mx-auto`}
+          >
             {t("nation.story.intro.paragraph1")}
           </p>
           <NationIntroPunch metrics={metrics} />
-          <p className={`${NATION_STORY_TYPE.body} ${NATION_STORY_TEXT.body}`}>
+        </div>
+      </section>
+
+      {/* Short transition: the explanation that follows the hero's punch */}
+      <section
+        data-story-section
+        className="relative min-h-[50vh] md:min-h-[60vh] flex items-center justify-center px-4 md:px-8 py-12 md:py-16"
+      >
+        <div className="max-w-2xl mx-auto text-center space-y-5 md:space-y-6">
+          <motion.p
+            initial={{ opacity: 0, y: 16 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true, amount: 0.5 }}
+            transition={{ duration: 0.5 }}
+            className={`${NATION_STORY_TYPE.body} ${NATION_STORY_TEXT.body}`}
+          >
             {t("nation.story.intro.paragraph2")}
-          </p>
-          <p className={`${NATION_STORY_TYPE.body} text-white font-medium`}>
+          </motion.p>
+          <motion.p
+            initial={{ opacity: 0, y: 16 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true, amount: 0.5 }}
+            transition={{ duration: 0.5, delay: 0.1 }}
+            className={`${NATION_STORY_TYPE.emphasis} text-white`}
+          >
             {t("nation.story.intro.paragraph3")}
-          </p>
+          </motion.p>
         </div>
       </section>
 
@@ -78,7 +120,7 @@ export function NationStoryPage({
           <motion.p
             initial={{ opacity: 0, y: 12 }}
             whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: false, amount: 0.5 }}
+            viewport={{ once: true, amount: 0.5 }}
             transition={{ duration: 0.4 }}
             className={`${NATION_STORY_TYPE.eyebrow} ${NATION_STORY_TEXT.eyebrow}`}
           >
@@ -87,7 +129,7 @@ export function NationStoryPage({
           <motion.h2
             initial={{ opacity: 0, y: 16 }}
             whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: false, amount: 0.5 }}
+            viewport={{ once: true, amount: 0.5 }}
             transition={{ duration: 0.45, delay: 0.05 }}
             className={`${NATION_STORY_TYPE.title} leading-tight`}
           >
@@ -96,7 +138,7 @@ export function NationStoryPage({
           <motion.p
             initial={{ opacity: 0, y: 16 }}
             whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: false, amount: 0.5 }}
+            viewport={{ once: true, amount: 0.5 }}
             transition={{ duration: 0.5, delay: 0.15 }}
             className={`${NATION_STORY_TYPE.body} ${NATION_STORY_TEXT.body}`}
           >
@@ -112,9 +154,14 @@ export function NationStoryPage({
       <section
         ref={conclusionRef}
         data-story-section
-        className="relative min-h-[80vh] flex items-center justify-center px-4 md:px-8 py-10"
+        className="relative min-h-[80vh] flex items-center justify-center px-4 md:px-8 py-10 overflow-hidden"
       >
-        <div className="w-full max-w-4xl mx-auto">
+        {/* Same depth backdrop as the hero – the story ends where it began */}
+        <div
+          aria-hidden
+          className="absolute inset-0 bg-[radial-gradient(ellipse_70%_55%_at_50%_45%,var(--black-2)_0%,var(--black-3)_78%)]"
+        />
+        <div className="relative w-full max-w-4xl mx-auto">
           <NationConclusion metrics={metrics} />
         </div>
       </section>

--- a/src/components/nation/story/StoryScrollHint.tsx
+++ b/src/components/nation/story/StoryScrollHint.tsx
@@ -89,7 +89,7 @@ export function StoryScrollHint({ endRef }: StoryScrollHintProps) {
             }
           : { duration: 0.35 }
       }
-      className={`fixed inset-x-0 bottom-6 md:bottom-10 z-50 mx-auto flex w-fit items-center justify-center text-white/90 transition-colors hover:text-white ${visible ? "" : "pointer-events-none"}`}
+      className={`fixed inset-x-0 bottom-6 md:bottom-10 z-50 mx-auto flex w-fit items-center justify-center text-grey transition-colors hover:text-white ${visible ? "" : "pointer-events-none"}`}
     >
       <ChevronDown className="h-9 w-9" strokeWidth={2.25} aria-hidden />
     </motion.button>

--- a/src/components/nation/story/nationStoryColors.ts
+++ b/src/components/nation/story/nationStoryColors.ts
@@ -12,30 +12,34 @@ export const NATION_STORY_CHART = {
   strokeWidth: 2.5,
 } as const;
 
-/** Shared typography for readable body copy on black backgrounds. */
+/**
+ * Text colors matching the site-wide convention: white for primary copy,
+ * grey (#878787) for secondary copy — no white-opacity variants.
+ */
 export const NATION_STORY_TEXT = {
-  body: "text-white/90",
-  secondary: "text-white/75",
-  eyebrow: "text-white/70",
+  /** Narrative copy — grey like `.prose` body text on the rest of the site */
+  body: "text-grey",
+  secondary: "text-grey",
+  eyebrow: "text-grey",
 } as const;
 
 /**
- * Tight type scale for the story so each viewport uses a few sizes,
- * not a unique size per line. Mobile and desktop still step independently.
+ * Type scale mapped onto the site's design tokens (DM Sans light,
+ * tight tracking, `.prose`-style body copy, `text-display` for stats).
  */
 export const NATION_STORY_TYPE = {
   /** Section titles (intro, interlude, conclusion, stacked chart) */
-  title: "text-2xl md:text-5xl font-light",
+  title: "text-3xl md:text-5xl font-light tracking-tight",
   /** Narrative paragraphs and step body copy */
-  body: "text-base md:text-xl leading-snug md:leading-relaxed",
+  body: "text-base md:text-lg leading-relaxed",
   /** Step/layer headers with color dots – same size as body, heavier weight */
-  emphasis: "text-base md:text-xl font-medium",
+  emphasis: "text-base md:text-lg font-medium",
   /** Eyebrows like “Conclusion” */
-  eyebrow: "text-sm md:text-lg uppercase tracking-widest",
+  eyebrow: "text-sm md:text-base",
   /** Legend rows, data-year, bathtub captions */
   meta: "text-sm md:text-base",
-  /** Large stats (conclusion totals) */
-  display: "text-4xl md:text-8xl font-light tabular-nums leading-none",
+  /** Large stats (conclusion totals, hero callouts) */
+  display: "text-4xl md:text-display font-light tabular-nums leading-none",
   /** Mid stats (bathtub year, onion total) */
-  stat: "text-2xl md:text-5xl font-light tabular-nums",
+  stat: "text-2xl md:text-5xl font-light tabular-nums tracking-tight",
 } as const;

--- a/src/components/nation/story/svgLocalUrl.ts
+++ b/src/components/nation/story/svgLocalUrl.ts
@@ -1,0 +1,9 @@
+/**
+ * Absolute fragment URL so SVG clipPath/gradient refs work with <base href="/">.
+ * Bare url(#id) resolves against the base and breaks on locale routes.
+ */
+export function svgLocalUrl(elementId: string): string {
+  if (typeof window === "undefined") return `url(#${elementId})`;
+  const { origin, pathname, search } = window.location;
+  return `url(${origin}${pathname}${search}#${elementId})`;
+}

--- a/src/components/nation/story/usePinnedSteps.ts
+++ b/src/components/nation/story/usePinnedSteps.ts
@@ -16,6 +16,7 @@ export type PinMode = "before" | "pinned" | "after";
 export function usePinnedSteps(stepCount: number, stepVh = 90) {
   const ref = useRef<HTMLElement>(null);
   const [step, setStep] = useState(0);
+  const [progress, setProgress] = useState(0);
   const [mode, setMode] = useState<PinMode>("before");
   const [stageBounds, setStageBounds] = useState({ left: 0, width: 0 });
   const sectionVh = stepCount * stepVh;
@@ -33,15 +34,16 @@ export function usePinnedSteps(stepCount: number, stepVh = 90) {
       if (rect.top > 0) nextMode = "before";
       else if (scrolled >= pinDistance) nextMode = "after";
 
-      const progress =
+      const nextProgress =
         pinDistance > 0 ? Math.min(Math.max(scrolled / pinDistance, 0), 1) : 0;
       const nextStep = Math.min(
-        Math.max(Math.floor(progress * stepCount), 0),
+        Math.max(Math.floor(nextProgress * stepCount), 0),
         stepCount - 1,
       );
 
       setStageBounds({ left: rect.left, width: rect.width });
       setMode(nextMode);
+      setProgress(nextProgress);
       setStep(nextStep);
     };
 
@@ -71,5 +73,5 @@ export function usePinnedSteps(stepCount: number, stepVh = 90) {
             right: 0,
           };
 
-  return { ref, step, mode, sectionVh, stageStyle };
+  return { ref, step, progress, mode, sectionVh, stageStyle };
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1532,12 +1532,14 @@
     "story": {
       "unit": {
         "mton": "Mt",
+        "millionTon": "million tonnes",
         "millionTco2e": "million tonnes CO₂e"
       },
       "intro": {
+        "eyebrow": "Election 2026",
         "title": "Sweden's emissions",
         "paragraph1": "We often hear that Sweden's emissions have fallen by a third while the economy has doubled. But is that really true?",
-        "paragraph2": "What we usually hear about are territorial emissions – fossil greenhouse gas emissions within Sweden's borders. That is the measure used to track Sweden's climate goals.",
+        "paragraph2": "What we usually hear about are territorial emissions – fossil greenhouse gas emissions within Sweden's borders. That measure is used to track Sweden's climate goals.",
         "paragraph3": "But Sweden's emissions are actually larger than that. Let's look at it, step by step.",
         "previewRatio": "larger than what we usually talk about"
       },
@@ -1547,6 +1549,8 @@
       },
       "journey": {
         "dataYear": "Figures refer to {{year}}.",
+        "stepCounter": "Step {{current}} of {{total}}",
+        "totalLabel": "Total",
         "step1": {
           "label": "Territorial emissions",
           "text": "First, we have emissions within Sweden's borders. This includes emissions from industry, domestic transport, agriculture, heating and waste, among other sources."
@@ -1561,8 +1565,7 @@
         },
         "step4": {
           "label": "Private e-commerce",
-          "text": "We have also quantified emissions from private e-commerce imports – for example when we order goods from Amazon and Shein. These emissions are not included in official statistics today. They amount to an additional 326,000 tonnes, comparable to Gävle's emissions in 2024 (328,000 tonnes).",
-          "badge": "+326,000 t ≈ Gävle"
+          "text": "We have also quantified emissions from private e-commerce imports – for example when we order goods from Amazon and Shein. These emissions are not included in official statistics today. They amount to an additional 326,000 tonnes, comparable to Gävle's emissions in 2024 (328,000 tonnes)."
         },
         "step5": {
           "label": "Biogenic emissions",
@@ -1570,6 +1573,7 @@
         }
       },
       "bathtub": {
+        "eyebrow": "The bathtub effect",
         "text": "The atmosphere responds to the total amount of greenhouse gases – and they stay and accumulate over time. A bit like a bathtub with the tap running: until the tap is fully closed, the water level will keep rising. And the atmosphere has already passed the threshold for 1.5°C of warming. That is why how quickly we cut emissions toward zero is critically important.",
         "question": "How has that gone since 1990?",
         "levelCaption": "{{value}} Mt accumulated since 1990",
@@ -1584,11 +1588,12 @@
         "consumptionAbroad": "Consumption-based emissions abroad"
       },
       "interlude": {
-        "eyebrow": "Conclusion",
+        "eyebrow": "Insight",
         "title": "We only discuss part of Sweden's emissions",
         "body": "The usual figure we hear about gives an overly positive picture. When we also include other emissions that Sweden can influence, we get a more complete picture – one that tells a different story."
       },
       "stacked": {
+        "layerCounter": "Layer {{current}} of {{total}}",
         "title": "Sweden's emissions since 1990",
         "layerCaption1": "First we have territorial emissions – fossil emissions within Sweden's borders.",
         "layerCaption2": "Now we add emissions from Swedish shipping and airlines outside the country's borders.",
@@ -1597,11 +1602,14 @@
       },
       "conclusion": {
         "eyebrow": "Conclusion",
-        "title": "Sweden's emissions are larger than we think and have not fallen as much as we think",
+        "title": "Sweden's emissions are larger than we think and have fallen less than we think",
         "usualLabel": "What we usually discuss",
         "fullLabel": "Sweden's actual emissions",
         "since1990": "since 1990",
-        "methodologyLink": "Read more about how we calculate Sweden’s emissions"
+        "methodologyLink": "Read more about how we calculate Sweden’s emissions",
+        "ctaLead": "Want to dig deeper into the numbers?",
+        "ctaNation": "Explore Sweden's data",
+        "ctaMunicipalities": "How does your municipality compare?"
       }
     }
   },

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -1582,12 +1582,14 @@
     "story": {
       "unit": {
         "mton": "Mton",
+        "millionTon": "miljoner ton",
         "millionTco2e": "miljoner ton CO₂e"
       },
       "intro": {
+        "eyebrow": "Valet 2026",
         "title": "Sveriges utsläpp",
         "paragraph1": "Vi får ofta höra att Sveriges utsläpp minskat med en tredjedel samtidigt som ekonomin har fördubblats. Men stämmer det verkligen?",
-        "paragraph2": "Det vi oftast hör om är territoriella utsläpp, det vill säga fossila växthusgasutsläpp inom Sveriges gränser. Det är det måttet som används för att följa upp Sveriges klimatmål.",
+        "paragraph2": "Det vi oftast hör om är territoriella utsläpp, det vill säga fossila växthusgasutsläpp inom Sveriges gränser. Det måttet används för att följa upp Sveriges klimatmål.",
         "paragraph3": "Men Sveriges utsläpp är egentligen större än så. Låt oss titta på det, steg för steg.",
         "previewRatio": "större än det vi brukar prata om"
       },
@@ -1597,6 +1599,8 @@
       },
       "journey": {
         "dataYear": "Siffrorna avser {{year}}.",
+        "stepCounter": "Steg {{current}} av {{total}}",
+        "totalLabel": "Totalt",
         "step1": {
           "label": "Territoriella utsläpp",
           "text": "Först har vi alltså utsläpp innanför Sveriges gränser. Här ingår bland annat utsläpp från industrin, inrikestransporter, jordbruk, uppvärmning och avfall."
@@ -1607,12 +1611,11 @@
         },
         "step3": {
           "label": "Konsumtion utomlands",
-          "text": "Men svenskar orsakar också utsläpp genom vår konsumtion utomlands. Här inkluderas utsläpp från tillverkning och transport av importerade varor till svensk hushållskonsumtion, offentlig verksamhet och investeringar. Svenskarnas utrikesflyg ingår här, men utsläpp från varor som produceras i Sverige men exporteras till andra länder räknas bort."
+          "text": "Men svenskar orsakar också utsläpp genom vår konsumtion utomlands. Här inkluderas utsläpp från tillverkning och transport av importerade varor till svensk hushållskonsumtion, offentlig verksamhet och investeringar. Svenskarnas utrikesflyg ingår här, men utsläpp från varor som produceras i Sverige och exporteras till andra länder räknas bort."
         },
         "step4": {
           "label": "Privat e-handel",
-          "text": "Vi har också satt siffror på utsläppen från privat e-handelsimport, exempelvis när vi klickar hem prylar från Amazon och Shein. Dessa utsläpp ingår idag inte i den offentliga statistiken. Det handlar om ytterligare 326 000 ton, motsvarande utsläppen i Gävle 2024 (328 000 ton).",
-          "badge": "+326 000 ton ≈ Gävle"
+          "text": "Vi har också satt siffror på utsläppen från privat e-handelsimport, exempelvis när vi klickar hem prylar från Amazon och Shein. Dessa utsläpp ingår idag inte i den offentliga statistiken. Det handlar om ytterligare 326 000 ton, motsvarande utsläppen i Gävle 2024 (328 000 ton)."
         },
         "step5": {
           "label": "Biogena utsläpp",
@@ -1620,6 +1623,7 @@
         }
       },
       "bathtub": {
+        "eyebrow": "Badkarseffekten",
         "text": "Atmosfären reagerar på mängden växthusgaser totalt – och de stannar kvar och ansamlas över tid. Lite som ett badkar, där kranen står på. Innan kranen dras åt helt, kommer vattennivån att fortsätta stiga. Och atmosfären har redan passerat gränsen för 1,5 graders uppvärmning. Därför är det avgörande viktigt hur snabbt vi minskar utsläppen ner mot noll.",
         "question": "Hur har det gått med det sedan 1990?",
         "levelCaption": "{{value}} Mton ansamlat sedan 1990",
@@ -1634,11 +1638,12 @@
         "consumptionAbroad": "Konsumtionsbaserade utomlands"
       },
       "interlude": {
-        "eyebrow": "Slutsats",
+        "eyebrow": "Insikt",
         "title": "Vi diskuterar bara en del av Sveriges utsläpp",
         "body": "Den vanliga siffran vi hör om ger en överdrivet positiv bild. Om vi räknar in även andra utsläpp som Sverige kan påverka får vi en mer heltäckande bild – som berättar en annan historia."
       },
       "stacked": {
+        "layerCounter": "Lager {{current}} av {{total}}",
         "title": "Sveriges utsläpp sedan 1990",
         "layerCaption1": "Först har vi de territoriella utsläppen – fossila utsläpp inom Sveriges gränser.",
         "layerCaption2": "Nu lägger vi till utsläpp från svenska rederier och flygbolag utanför landets gränser.",
@@ -1647,11 +1652,14 @@
       },
       "conclusion": {
         "eyebrow": "Slutsats",
-        "title": "Sveriges utsläpp är större än vad vi tror och har inte minskat så mycket som vi tror",
+        "title": "Sveriges utsläpp är större än vi tror och har minskat mindre än vi tror",
         "usualLabel": "Det vi vanligtvis diskuterar",
         "fullLabel": "Sveriges egentliga utsläpp",
         "since1990": "sedan 1990",
-        "methodologyLink": "Läs mer om hur vi räknar på Sveriges utsläpp"
+        "methodologyLink": "Läs mer om hur vi räknar på Sveriges utsläpp",
+        "ctaLead": "Vill du gräva vidare i siffrorna?",
+        "ctaNation": "Utforska Sveriges data",
+        "ctaMunicipalities": "Hur ser det ut där du bor?"
       }
     }
   },


### PR DESCRIPTION
## Summary

Design overhaul of the Valet 2026 nation story page (`/sv/valet-2026`) to unify it with the rest of the site and make the scroll story more engaging:

- **Typography & colors**: all story sections now use a shared type scale (`nationStoryColors.ts`) mapped to the site's design tokens — DM Sans light titles, grey/white text convention, `text-display` for large stats — with a responsive mobile pass (smaller titles/body on small screens).
- **Hero**: replaced the flag with a Sweden silhouette that fills like liquid to the reported share of emissions, flanked by stat callouts (with "miljoner ton"/"million tonnes" written out on desktop).
- **Bathtub**: redrawn claw-foot tub with enamel body, detailed faucet, elliptical water surface, and an animated drip; copy moved outside the tub with a chapter eyebrow ("Badkarseffekten"/"The bathtub effect").
- **Emissions journey**: now a narrative chapter with step counter, growing glow, animated delta chips that track the bubble, and a receipt-style running tally. Redundant "+326 000 ton = Gävle" badge removed.
- **Stacked chart**: full-bleed layout with chapter framing (layer counter) and a horizontal legend tally, replacing the generic embedded chart component.
- **Conclusion**: open two-column layout with count-up numbers, proportional scale bars, and CTA buttons linking to the nation and municipality data pages.
- **Page-level**: fixed top scroll progress bar, radial gradient backdrops for section continuity, `useReducedMotion` support across all animations.
- **Copy (SV/EN)**: senior-dev copy edits (horunge fix, "men" → "och", shorter conclusion title) and new translation keys for eyebrows, counters, units, and CTAs.

## Test plan

- [ ] Review `/sv/valet-2026` and `/en/valet-2026` on staging: hero fill, bathtub drip, journey steps, stacked chart, conclusion count-up
- [ ] Verify mobile layout (no cramping, hero fits viewport)
- [ ] Verify reduced-motion behavior (OS setting)
- [ ] `npm run lint`, `npm run test`, `tsc --noEmit` pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes to story components and translations; metrics still come from existing hooks with no auth or API changes.
> 
> **Overview**
> Redesigns the **Valet 2026** nation scroll story (`NationStoryPage` and chapter components) so typography, grey/white text, and stat sizing align with the site design tokens in `nationStoryColors.ts`, replacing ad-hoc white-opacity styles.
> 
> The **hero** drops the flag for a Sweden silhouette with a height-proportional “liquid” fill of reported vs full emissions, plus side **stat callouts**; intro copy is split into a full-viewport hero and a follow-on transition section. Page chrome adds a **fixed scroll progress bar**, shared **radial backdrops**, and **`viewport={{ once: true }}`** on in-view animations.
> 
> **Scroll chapters** gain polish: the bathtub is a new claw-foot SVG with continuous water (interpolated via `usePinnedSteps` **`progress`**), copy above/below the tub, and **`svgLocalUrl`** for locale-safe SVG refs; the emissions journey adds step counter, glow, **delta chips**, and a receipt-style tally (e-commerce badge removed); the stacked chart uses story-native framing/legend instead of `SectionWithHelp` / `EnhancedLegend`.
> 
> The **conclusion** uses count-up stats, proportional bars, and **LocalizedLink** CTAs to nation/municipality data. **`useReducedMotion`** is wired across animations; **SV/EN** strings add eyebrows, counters, units, and CTA keys with light copy edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51f3f746c5fa3c82a785961221e12d4e7df87063. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->