### PR TITLE
Election 2026 story: feedback round 2, scene morphs and updated copy

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -15,6 +15,9 @@ export function Layout({ children }: LayoutProps) {
   const location = useLocation();
   const params = useParams();
   const isLandingPage = /^\/(sv|en)\/?$/.test(location.pathname);
+  // The Valet 2026 story pins full-screen scenes with captions near the bottom
+  // edge; on mobile the floating corner buttons cover them, so hide them there.
+  const isStoryPage = /^\/(sv|en)\/valet-2026\/?$/.test(location.pathname);
 
   const isStagingHost =
     typeof window !== "undefined" && window.location.hostname.includes("stage");
@@ -45,8 +48,10 @@ export function Layout({ children }: LayoutProps) {
         }
       >
         {children}
-        <ScrollToTop />
-        <SuggestEdit />
+        <div className={isStoryPage ? "hidden md:block" : undefined}>
+          <ScrollToTop />
+          <SuggestEdit />
+        </div>
       </main>
       <Footer />
     </div>

--- a/src/components/nation/story/NationBathtub.tsx
+++ b/src/components/nation/story/NationBathtub.tsx
@@ -6,6 +6,7 @@ import {
   type NationBathtubDataPoint,
 } from "@/utils/data/nationStoryMetrics";
 import { useLanguage } from "@/components/LanguageProvider";
+import { useScreenSize } from "@/hooks/useScreenSize";
 import {
   NATION_STORY_TEXT,
   NATION_STORY_TYPE,
@@ -13,16 +14,20 @@ import {
 import { svgLocalUrl } from "@/components/nation/story/svgLocalUrl";
 import { usePinnedSteps } from "@/components/nation/story/usePinnedSteps";
 
-/** Sample years so the caption advances in readable 5-year milestones. */
+/**
+ * Sample years so the caption advances in decade milestones
+ * (1990, 2000, 2010, 2020 + the latest year) – four scrolls to the end.
+ */
 function sampleBathtubYears(
   data: NationBathtubDataPoint[],
 ): NationBathtubDataPoint[] {
   if (data.length === 0) return [];
   const sampled: NationBathtubDataPoint[] = [];
   for (const point of data) {
-    const isMilestone = (point.year - data[0].year) % 5 === 0;
+    const isMilestone = (point.year - data[0].year) % 10 === 0;
     const isLast = point === data.at(-1);
-    if (isMilestone || isLast) sampled.push(point);
+    if ((isMilestone || isLast) && !sampled.includes(point))
+      sampled.push(point);
   }
   return sampled;
 }
@@ -108,14 +113,45 @@ const WATER_SPRING = {
   mass: 0.8,
 };
 
+/** Scroll distance per bathtub milestone step. */
+const BATHTUB_STEP_VH = 70;
+/**
+ * Extra pinned scroll before the steps: the tub eases in while the faucet
+ * drip (the droplet handed over from the onion scene) is already falling.
+ * The onion scene's auto-scroll ride ends exactly at the end of this zone.
+ */
+export const BATHTUB_ENTER_VH = 70;
+
+const clamp01 = (value: number) => Math.min(Math.max(value, 0), 1);
+const smoothstep = (t: number) => t * t * (3 - 2 * t);
+
+type TubCaption = {
+  /** small line above the figure, e.g. "Sverige har totalt släppt ut" */
+  prefix: string;
+  /** the accumulated figure incl. unit, e.g. "4 712 Mton CO₂e" */
+  value: string;
+  /** small line below the figure, e.g. "sedan 1990" */
+  suffix: string;
+};
+
 type TubGraphicProps = {
   idPrefix: string;
   /** SVG y coordinate of the current water surface. */
   waterTop: number;
+  /** Accumulated-total caption rendered inside the basin. */
+  caption: TubCaption;
+  /** Larger relative type on small screens where the whole SVG shrinks. */
+  compact?: boolean;
   className?: string;
 };
 
-function TubGraphic({ idPrefix, waterTop, className }: TubGraphicProps) {
+function TubGraphic({
+  idPrefix,
+  waterTop,
+  caption,
+  compact = false,
+  className,
+}: TubGraphicProps) {
   const reducedMotion = useReducedMotion();
   const clipId = `${idPrefix}-clip`;
   const gradientId = `${idPrefix}-gradient`;
@@ -221,6 +257,39 @@ function TubGraphic({ idPrefix, waterTop, className }: TubGraphicProps) {
         transition={waterTransition}
       />
 
+      {/* Accumulated total inside the basin – the screenshot-friendly figure */}
+      <g style={{ fontFamily: "inherit" }}>
+        <text
+          x={260}
+          y={compact ? 122 : 126}
+          textAnchor="middle"
+          fill="rgba(255,255,255,0.9)"
+          fontSize={compact ? 21 : 15}
+        >
+          {caption.prefix}
+        </text>
+        <text
+          x={260}
+          y={compact ? 162 : 164}
+          textAnchor="middle"
+          fill="#ffffff"
+          fontSize={compact ? 42 : 32}
+          fontWeight={500}
+          style={{ fontVariantNumeric: "tabular-nums" }}
+        >
+          {caption.value}
+        </text>
+        <text
+          x={260}
+          y={compact ? 192 : 190}
+          textAnchor="middle"
+          fill="rgba(255,255,255,0.9)"
+          fontSize={compact ? 21 : 15}
+        >
+          {caption.suffix}
+        </text>
+      </g>
+
       {/* Basin walls and rounded floor */}
       <path
         d={TUB_BODY_PATH}
@@ -290,19 +359,29 @@ function TubGraphic({ idPrefix, waterTop, className }: TubGraphicProps) {
 export function NationBathtub({ data }: NationBathtubProps) {
   const { t } = useTranslation();
   const { currentLanguage } = useLanguage();
+  const { isMobile } = useScreenSize();
+  const reducedMotion = useReducedMotion();
   // useId can include ":" which is awkward in url(#…) fragments
   const idPrefix = `tub-${useId().replace(/:/g, "")}`;
   const steps = useMemo(() => sampleBathtubYears(data), [data]);
   const stepCount = Math.max(steps.length, 1);
   const maxCumulative = data.at(-1)?.cumulativeMton ?? 1;
 
-  const { ref, step, progress, sectionVh, stageStyle } = usePinnedSteps(
-    stepCount,
-    70,
-  );
+  const { ref, step, progress, enterProgress, sectionVh, stageStyle } =
+    usePinnedSteps(stepCount, BATHTUB_STEP_VH, {
+      enterVh: BATHTUB_ENTER_VH,
+    });
 
   const current = steps[step] ?? steps[0];
   if (!current) return null;
+
+  // Enter morph (scroll-lerped): the tub and copy ease in from below while
+  // the faucet drip carries over the droplet from the onion scene. `progress`
+  // covers the steps span only, so the water stays at zero until this is done.
+  // Opacity completes early in the zone to keep the black gap after the
+  // falling droplet short.
+  const enterT = reducedMotion ? 1 : smoothstep(clamp01(enterProgress));
+  const enterOpacity = reducedMotion ? 1 : clamp01(enterT / 0.65);
 
   // Water rises smoothly within each milestone segment so fill matches captions.
   const level = levelAtStepProgress(steps, step, progress, stepCount);
@@ -328,32 +407,46 @@ export function NationBathtub({ data }: NationBathtubProps) {
           toYear: chunkToYear,
         });
 
+  // Accumulated-total caption drawn inside the tub water.
+  const tubCaption: TubCaption = {
+    prefix: t("nation.story.bathtub.waterCaptionPrefix"),
+    value: `${formatMton(current.cumulativeMton, currentLanguage, 0)} ${t("nation.story.unit.mtonCo2e")}`,
+    suffix: t("nation.story.bathtub.waterCaptionSuffix"),
+  };
+
   return (
     <section
       ref={ref}
       data-story-section
       data-story-step={step}
       data-story-steps={steps.length}
-      data-story-step-vh={70}
+      data-story-step-vh={BATHTUB_STEP_VH}
       className="relative"
       style={{ height: `${sectionVh}vh` }}
     >
       <div
-        className="h-[100svh] flex items-center px-4 md:px-8 py-3 md:py-0"
+        className="h-[100svh] flex items-center px-4 md:px-8 pt-14 pb-6 md:pt-0 md:pb-28"
         style={stageStyle}
       >
-        <div className="w-full max-w-3xl mx-auto space-y-4 md:space-y-6">
+        <div
+          className="w-full max-w-3xl mx-auto space-y-4 md:space-y-6"
+          style={{
+            opacity: enterOpacity,
+            transform: `translateY(${(1 - enterT) * 24}px) scale(${0.94 + 0.06 * enterT})`,
+            transformOrigin: "50% 40%",
+          }}
+        >
           {/* Copy above the tub on all breakpoints */}
           <div className="max-w-2xl mx-auto text-center space-y-2.5 md:space-y-3">
-            <motion.p
+            <motion.h2
               initial={{ opacity: 0, y: 10 }}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true, amount: 0.4 }}
               transition={{ duration: 0.4 }}
-              className={`${NATION_STORY_TYPE.eyebrow} ${NATION_STORY_TEXT.eyebrow}`}
+              className="text-2xl md:text-3xl font-light tracking-tight text-white"
             >
               {t("nation.story.bathtub.eyebrow")}
-            </motion.p>
+            </motion.h2>
             <motion.p
               initial={{ opacity: 0, y: 12 }}
               whileInView={{ opacity: 1, y: 0 }}
@@ -377,11 +470,17 @@ export function NationBathtub({ data }: NationBathtubProps) {
           <TubGraphic
             idPrefix={idPrefix}
             waterTop={waterTop}
-            className="w-56 md:w-full max-w-lg mx-auto h-auto"
+            caption={tubCaption}
+            compact={isMobile}
+            className="w-64 md:w-full max-w-lg mx-auto h-auto"
           />
 
-          {/* Milestone captions below the tub */}
+          {/* Milestone captions below the tub: the year and this decade's addition.
+              The accumulated total lives inside the tub water. */}
           <div className="text-center space-y-0.5 md:space-y-1 min-h-[3.5rem] md:min-h-[4.5rem]">
+            <p className="sr-only">
+              {`${tubCaption.prefix} ${tubCaption.value} ${tubCaption.suffix}`}
+            </p>
             <motion.p
               key={current.year}
               initial={{ opacity: 0, y: 6 }}
@@ -390,13 +489,6 @@ export function NationBathtub({ data }: NationBathtubProps) {
             >
               {current.year}
             </motion.p>
-            <p
-              className={`${NATION_STORY_TYPE.meta} ${NATION_STORY_TEXT.body}`}
-            >
-              {t("nation.story.bathtub.levelCaption", {
-                value: formatMton(current.cumulativeMton, currentLanguage, 0),
-              })}
-            </p>
             <p
               className={`${NATION_STORY_TYPE.meta} ${NATION_STORY_TEXT.secondary}`}
             >

--- a/src/components/nation/story/NationBathtub.tsx
+++ b/src/components/nation/story/NationBathtub.tsx
@@ -421,6 +421,7 @@ export function NationBathtub({ data }: NationBathtubProps) {
       data-story-step={step}
       data-story-steps={steps.length}
       data-story-step-vh={BATHTUB_STEP_VH}
+      data-story-enter-vh={BATHTUB_ENTER_VH}
       className="relative"
       style={{ height: `${sectionVh}vh` }}
     >

--- a/src/components/nation/story/NationEmissionsJourney.tsx
+++ b/src/components/nation/story/NationEmissionsJourney.tsx
@@ -171,7 +171,11 @@ export function NationEmissionsJourney({
     prevExitRef.current = exitProgress;
 
     if (exitProgress === 0) {
+      // Back above the zone: re-arm and make sure no stale ride keeps
+      // driving the scroll (e.g. after a scrollbar drag fought it upward).
       rideDoneRef.current = false;
+      rideControlsRef.current?.stop();
+      rideControlsRef.current = null;
       return;
     }
     if (reducedMotion || rideDoneRef.current) return;
@@ -183,6 +187,8 @@ export function NationEmissionsJourney({
     const tubSection = ref.current?.nextElementSibling;
     if (!(tubSection instanceof HTMLElement)) return;
     rideDoneRef.current = true;
+    // Single flight: never let two rides drive the scroll at once.
+    rideControlsRef.current?.stop();
 
     // Land where the tub has fully entered: tub top + its enter zone.
     const target =
@@ -200,17 +206,21 @@ export function NationEmissionsJourney({
     const cancelIfUpward = (event: WheelEvent) => {
       if (event.deltaY < 0) controls.stop();
     };
-    const cancelOnTouch = () => controls.stop();
+    // Any new pointer contact (touch, click, scrollbar grab) hands control back.
+    const cancelOnPointer = () => controls.stop();
     const cancelIfUpwardKey = (event: KeyboardEvent) => {
       if (["ArrowUp", "PageUp", "Home"].includes(event.key)) controls.stop();
     };
     window.addEventListener("wheel", cancelIfUpward, { passive: true });
-    window.addEventListener("touchstart", cancelOnTouch, { passive: true });
+    window.addEventListener("touchstart", cancelOnPointer, { passive: true });
+    window.addEventListener("pointerdown", cancelOnPointer, { passive: true });
     window.addEventListener("keydown", cancelIfUpwardKey);
     const cleanup = () => {
       window.removeEventListener("wheel", cancelIfUpward);
-      window.removeEventListener("touchstart", cancelOnTouch);
+      window.removeEventListener("touchstart", cancelOnPointer);
+      window.removeEventListener("pointerdown", cancelOnPointer);
       window.removeEventListener("keydown", cancelIfUpwardKey);
+      if (rideControlsRef.current === controls) rideControlsRef.current = null;
     };
     controls.then(cleanup, cleanup);
   }, [exitProgress, reducedMotion, ref]);

--- a/src/components/nation/story/NationEmissionsJourney.tsx
+++ b/src/components/nation/story/NationEmissionsJourney.tsx
@@ -1,5 +1,13 @@
+import { useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
-import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import {
+  AnimatePresence,
+  animate,
+  motion,
+  useReducedMotion,
+  type AnimationPlaybackControls,
+} from "framer-motion";
+import { BATHTUB_ENTER_VH } from "@/components/nation/story/NationBathtub";
 import {
   formatMton,
   type NationStoryMetrics,
@@ -28,17 +36,45 @@ type JourneyStep = {
   ring?: boolean;
 };
 
+/**
+ * Private e-commerce estimate (~326 000 t CO₂e). Shown as its own tally row,
+ * but excluded from the running total: the amount is too small to move the
+ * rounded 159 Mton figure and is presented as an addition outside official
+ * statistics.
+ */
+const E_COMMERCE_MTON = 0.326;
+
+/** Small additions like e-commerce need a decimal to not round to zero. */
+function deltaDecimals(delta: number): number {
+  return delta > 0 && delta < 1 ? 1 : 0;
+}
+
 /** Desktop onion diameter; mobile scales down so text + bubble fit one screen. */
 const DESKTOP_MAX_DIAMETER = 300;
 const MOBILE_MAX_DIAMETER = 148;
 /** Scroll distance per journey step – higher = more time to watch each layer grow. */
 const JOURNEY_STEP_VH = 115;
-/** Gentle spring so each new onion layer visibly expands. */
+/**
+ * Extra pinned scroll after the last step for the exit morph: the finished
+ * bubble compresses into a water drop and falls toward the bathtub scene.
+ * Entering this zone triggers an auto-scroll ride through the whole hand-off,
+ * so the zone mainly sets the morph's pacing during that ride.
+ */
+const JOURNEY_EXIT_VH = 90;
+/** Size the bubble shrinks to before falling – matches the tub's faucet drip. */
+const DROPLET_DIAMETER = 14;
+
+const clamp01 = (value: number) => Math.min(Math.max(value, 0), 1);
+const smoothstep = (t: number) => t * t * (3 - 2 * t);
+/**
+ * Layer diameters are lerped from scroll progress; this spring only smooths
+ * between scroll events, so it tracks tighter than the old step-change spring.
+ */
 const LAYER_GROW_TRANSITION = {
   type: "spring" as const,
-  stiffness: 48,
-  damping: 16,
-  mass: 1.6,
+  stiffness: 90,
+  damping: 22,
+  mass: 0.8,
 };
 
 function buildSteps(metrics: NationStoryMetrics): JourneyStep[] {
@@ -81,7 +117,7 @@ function buildSteps(metrics: NationStoryMetrics): JourneyStep[] {
       textKey: "nation.story.journey.step4.text",
       color: NATION_STORY_COLORS.eCommerceRing,
       total: production + consumption,
-      delta: 0,
+      delta: E_COMMERCE_MTON,
       layer: false,
       ring: true,
     },
@@ -113,16 +149,82 @@ export function NationEmissionsJourney({
   const maxTotal = steps[steps.length - 1].total;
   const maxDiameter = isMobile ? MOBILE_MAX_DIAMETER : DESKTOP_MAX_DIAMETER;
 
-  const { ref, step, sectionVh, stageStyle } = usePinnedSteps(
-    steps.length,
-    JOURNEY_STEP_VH,
-  );
+  const { ref, step, progress, exitProgress, sectionVh, stageStyle } =
+    usePinnedSteps(steps.length, JOURNEY_STEP_VH, {
+      exitVh: JOURNEY_EXIT_VH,
+    });
+
+  // Auto-scroll ride: scrolling into the exit zone takes over and carries the
+  // page through the droplet morph and the bathtub's enter fade in one
+  // continuous motion, so a slow swipe can't strand the reader in the gap
+  // between the falling drop and the tub. Scrolling up (or a new touch)
+  // cancels the ride; it re-arms once the reader is back above the zone.
+  const prevExitRef = useRef(0);
+  const rideDoneRef = useRef(false);
+  const rideControlsRef = useRef<AnimationPlaybackControls | null>(null);
+
+  useEffect(() => {
+    const prevExit = prevExitRef.current;
+    prevExitRef.current = exitProgress;
+
+    if (exitProgress === 0) {
+      rideDoneRef.current = false;
+      return;
+    }
+    if (reducedMotion || rideDoneRef.current) return;
+    // Only trigger on a downward crossing into the zone, not when arriving
+    // from the bathtub side or after a programmatic jump deep into the zone.
+    if (!(prevExit <= 0.02 && exitProgress > 0.02 && exitProgress < 0.5))
+      return;
+
+    const tubSection = ref.current?.nextElementSibling;
+    if (!(tubSection instanceof HTMLElement)) return;
+    rideDoneRef.current = true;
+
+    // Land where the tub has fully entered: tub top + its enter zone.
+    const target =
+      window.scrollY +
+      tubSection.getBoundingClientRect().top +
+      (BATHTUB_ENTER_VH / 100) * window.innerHeight;
+
+    const controls = animate(window.scrollY, target, {
+      duration: 2,
+      ease: [0.45, 0, 0.25, 1],
+      onUpdate: (value) => window.scrollTo(0, value),
+    });
+    rideControlsRef.current = controls;
+
+    const cancelIfUpward = (event: WheelEvent) => {
+      if (event.deltaY < 0) controls.stop();
+    };
+    const cancelOnTouch = () => controls.stop();
+    window.addEventListener("wheel", cancelIfUpward, { passive: true });
+    window.addEventListener("touchstart", cancelOnTouch, { passive: true });
+    const cleanup = () => {
+      window.removeEventListener("wheel", cancelIfUpward);
+      window.removeEventListener("touchstart", cancelOnTouch);
+    };
+    controls.then(cleanup, cleanup);
+  }, [exitProgress, reducedMotion, ref]);
+
+  // Stop a running ride if the story unmounts mid-flight.
+  useEffect(() => () => rideControlsRef.current?.stop(), []);
 
   const current = steps[step];
+  // Scroll position within the current step (0–1), smoothstepped so layers
+  // grow gently with the scroll instead of jumping per step.
+  const rawStepProgress = clamp01(progress * steps.length - step);
+  const stepProgress = smoothstep(rawStepProgress);
   const newestLayerKey = steps
     .slice(0, step + 1)
     .filter((s) => s.layer)
     .at(-1)?.key;
+  // Total of the layer beneath the one currently growing – its start diameter.
+  const previousLayerTotal =
+    steps
+      .slice(0, step)
+      .filter((s) => s.layer)
+      .at(-1)?.total ?? 0;
 
   // All layer-circles revealed so far, largest drawn first (behind) so each
   // colour shows as a ring around the previous – i.e. the types stacked up.
@@ -138,10 +240,44 @@ export function NationEmissionsJourney({
   const diameterFor = (total: number) =>
     Math.sqrt(total / maxTotal) * maxDiameter;
 
+  // Diameter of the circle as currently drawn: lerped while the current
+  // step's layer is growing, full-size otherwise.
+  const currentStartDiameter =
+    previousLayerTotal > 0 ? diameterFor(previousLayerTotal) : 0;
+  const currentDrawnDiameter =
+    current.layer && !reducedMotion
+      ? currentStartDiameter +
+        (diameterFor(current.total) - currentStartDiameter) * stepProgress
+      : diameterFor(current.total);
+
   // Distance from the bubble center to just outside the current circle's
-  // edge along the 45° upper-right diagonal.
+  // edge along the 45° upper-right diagonal (past the dashed ring when shown).
   const deltaChipOffset =
-    diameterFor(current.total) / 2 / Math.SQRT2 + (isMobile ? 8 : 12);
+    (currentDrawnDiameter + (current.ring ? (isMobile ? 16 : 26) : 0)) /
+      2 /
+      Math.SQRT2 +
+    (isMobile ? 8 : 12);
+
+  // The running total sits on the smallest (innermost) circle – territorial,
+  // which only grows during the first step. Until that circle is big enough
+  // to sit behind the text, render the number white on the dark backdrop.
+  const smallestDrawnDiameter =
+    step === 0 ? currentDrawnDiameter : diameterFor(steps[0].total);
+  const totalOnLayer = smallestDrawnDiameter >= (isMobile ? 64 : 116);
+
+  // Exit morph (scroll-lerped): captions fade first, then the bubble
+  // compresses into a blue droplet that sinks and finally falls off-stage
+  // toward the bathtub scene. With reduced motion the stage simply fades.
+  const exitFade = reducedMotion ? 1 : 1 - Math.min(exitProgress / 0.3, 1);
+  const shrinkT = reducedMotion
+    ? 0
+    : smoothstep(clamp01((exitProgress - 0.1) / 0.7));
+  const fallT = reducedMotion ? 0 : clamp01((exitProgress - 0.8) / 0.2);
+  const viewportH = typeof window === "undefined" ? 800 : window.innerHeight;
+  const bubbleScale = 1 + (DROPLET_DIAMETER / maxDiameter - 1) * shrinkT;
+  const bubbleY = viewportH * (0.22 * shrinkT + 0.9 * fallT * fallT);
+  const bubbleOpacity = 1 - fallT;
+  const stageOpacity = reducedMotion ? 1 - clamp01(exitProgress / 0.5) : 1;
 
   return (
     <section
@@ -154,7 +290,7 @@ export function NationEmissionsJourney({
       style={{ height: `${sectionVh}vh` }}
     >
       <div
-        className="h-[100svh] flex items-center px-4 md:px-8 py-3 md:py-0 overflow-hidden"
+        className="h-[100svh] flex items-center px-4 md:px-8 pt-14 pb-6 md:py-0 overflow-hidden"
         style={stageStyle}
       >
         {/* Same subtle depth backdrop as the hero, tying the chapter to the intro */}
@@ -162,12 +298,21 @@ export function NationEmissionsJourney({
           aria-hidden
           className="absolute inset-0 bg-[radial-gradient(ellipse_70%_55%_at_50%_45%,var(--black-2)_0%,var(--black-3)_78%)]"
         />
-        <div className="relative grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-12 items-center w-full max-w-5xl mx-auto">
+        <div
+          className="relative grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-12 items-center w-full max-w-5xl mx-auto"
+          style={{ opacity: stageOpacity }}
+        >
           {/* Bubble = accumulating colored layers */}
           <div className="flex flex-col items-center gap-2 md:gap-4 order-1">
             <div
               className="relative"
-              style={{ width: maxDiameter, height: maxDiameter }}
+              style={{
+                width: maxDiameter,
+                height: maxDiameter,
+                transform: `translateY(${bubbleY}px) scale(${bubbleScale})`,
+                transformOrigin: "50% 50%",
+                opacity: bubbleOpacity,
+              }}
             >
               {/* Soft glow behind the bubble in the current step's color */}
               <AnimatePresence>
@@ -190,23 +335,30 @@ export function NationEmissionsJourney({
               </AnimatePresence>
 
               {revealedLayers.map((layer) => {
-                const d = diameterFor(layer.total);
-                const isGrowingLayer = layer.key === newestLayerKey;
+                const fullDiameter = diameterFor(layer.total);
+                // The newest layer grows with scroll (lerp) during its own
+                // step, starting from the previous layer's edge; scrolling
+                // back shrinks it the same way. Older layers stay full-size.
+                const isGrowingLayer =
+                  !reducedMotion &&
+                  current.layer &&
+                  layer.key === newestLayerKey &&
+                  layer.key === current.key;
+                const startDiameter =
+                  previousLayerTotal > 0 ? diameterFor(previousLayerTotal) : 0;
+                const d = isGrowingLayer
+                  ? startDiameter +
+                    (fullDiameter - startDiameter) * stepProgress
+                  : fullDiameter;
                 return (
                   <motion.div
                     key={layer.key}
                     className="absolute left-1/2 top-1/2 rounded-full"
                     style={{ backgroundColor: layer.color, opacity: 1 }}
-                    initial={
-                      isGrowingLayer && !reducedMotion
-                        ? { width: 0, height: 0, x: "-50%", y: "-50%" }
-                        : { width: d, height: d, x: "-50%", y: "-50%" }
-                    }
+                    initial={false}
                     animate={{ width: d, height: d, x: "-50%", y: "-50%" }}
                     transition={
-                      isGrowingLayer && !reducedMotion
-                        ? LAYER_GROW_TRANSITION
-                        : { duration: 0 }
+                      reducedMotion ? { duration: 0 } : LAYER_GROW_TRANSITION
                     }
                   />
                 );
@@ -214,29 +366,55 @@ export function NationEmissionsJourney({
 
               {/* Private e-commerce: thin dashed ring around the current total */}
               {showRing && ringStep && (
-                <motion.span
-                  className="absolute left-1/2 top-1/2 rounded-full border-2 border-dashed"
+                <div style={{ opacity: exitFade }}>
+                  <motion.span
+                    className="absolute left-1/2 top-1/2 rounded-full border-2 border-dashed"
+                    style={{
+                      width: diameterFor(ringTotal) + (isMobile ? 16 : 26),
+                      height: diameterFor(ringTotal) + (isMobile ? 16 : 26),
+                      x: "-50%",
+                      y: "-50%",
+                      borderColor: NATION_STORY_COLORS.eCommerceRing,
+                    }}
+                    initial={
+                      reducedMotion ? false : { opacity: 0, scale: 0.85 }
+                    }
+                    animate={{ opacity: 1, scale: 1 }}
+                    transition={
+                      reducedMotion
+                        ? { duration: 0 }
+                        : { duration: 0.9, ease: [0.22, 1, 0.36, 1] }
+                    }
+                  />
+                </div>
+              )}
+
+              {/* Exit morph: the stack crossfades to water-blue while it
+                  shrinks, so the droplet matches the tub's faucet drip */}
+              {shrinkT > 0 && (
+                <div
+                  aria-hidden
+                  className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full"
                   style={{
-                    width: diameterFor(ringTotal) + (isMobile ? 16 : 26),
-                    height: diameterFor(ringTotal) + (isMobile ? 16 : 26),
-                    x: "-50%",
-                    y: "-50%",
-                    borderColor: NATION_STORY_COLORS.eCommerceRing,
+                    width: maxDiameter,
+                    height: maxDiameter,
+                    backgroundColor: "var(--blue-2)",
+                    opacity: shrinkT,
                   }}
-                  initial={reducedMotion ? false : { opacity: 0, scale: 0.85 }}
-                  animate={{ opacity: 1, scale: 1 }}
-                  transition={
-                    reducedMotion
-                      ? { duration: 0 }
-                      : { duration: 0.9, ease: [0.22, 1, 0.36, 1] }
-                  }
                 />
               )}
 
-              {/* Running total on top */}
-              <div className="absolute inset-0 flex items-center justify-center">
-                <span
-                  className={`${NATION_STORY_TYPE.stat} text-black font-medium select-none leading-none text-center`}
+              {/* Running total on top – white on the dark backdrop until the
+                  innermost circle has grown large enough to sit behind it */}
+              <div
+                className="absolute inset-0 flex items-center justify-center"
+                style={{ opacity: exitFade }}
+              >
+                <motion.span
+                  initial={false}
+                  animate={{ color: totalOnLayer ? "#000000" : "#ffffff" }}
+                  transition={{ duration: 0.3 }}
+                  className={`${NATION_STORY_TYPE.stat} font-medium select-none leading-none text-center`}
                 >
                   {formatMton(current.total, currentLanguage, 0)}
                   <span
@@ -244,7 +422,7 @@ export function NationEmissionsJourney({
                   >
                     {t("nation.story.unit.mton")}
                   </span>
-                </span>
+                </motion.span>
               </div>
 
               {/* The step's own contribution sits just off the current circle's
@@ -253,6 +431,7 @@ export function NationEmissionsJourney({
               {step > 0 && current.delta > 0 && (
                 <motion.span
                   className="absolute left-1/2 top-1/2 pointer-events-none"
+                  style={{ opacity: exitFade }}
                   initial={false}
                   animate={{ x: deltaChipOffset, y: -deltaChipOffset }}
                   transition={
@@ -272,7 +451,12 @@ export function NationEmissionsJourney({
                       className={`${NATION_STORY_TYPE.emphasis} tabular-nums whitespace-nowrap`}
                       style={{ color: current.color }}
                     >
-                      +{formatMton(current.delta, currentLanguage, 0)}{" "}
+                      +
+                      {formatMton(
+                        current.delta,
+                        currentLanguage,
+                        deltaDecimals(current.delta),
+                      )}{" "}
                       {t("nation.story.unit.mton")}
                     </motion.p>
                   </span>
@@ -282,13 +466,17 @@ export function NationEmissionsJourney({
 
             <p
               className={`${NATION_STORY_TYPE.meta} ${NATION_STORY_TEXT.secondary} mt-1 md:mt-10`}
+              style={{ opacity: exitFade }}
             >
               {t("nation.story.journey.dataYear", { year: metrics.latestYear })}
             </p>
           </div>
 
           {/* Caption + legend of layers added so far */}
-          <div className="space-y-2.5 md:space-y-4 order-2 min-h-0">
+          <div
+            className="space-y-2.5 md:space-y-4 order-2 min-h-0"
+            style={{ opacity: exitFade }}
+          >
             <motion.div
               key={current.key}
               initial={{ opacity: 0, y: 12 }}
@@ -326,7 +514,7 @@ export function NationEmissionsJourney({
               <div className="space-y-1 border-t border-white/10 pt-2 md:pt-3">
                 {steps
                   .slice(0, step + 1)
-                  .filter((s) => s.layer)
+                  .filter((s) => s.layer || s.ring)
                   .map((s, i) => (
                     <motion.div
                       key={s.key}
@@ -337,7 +525,9 @@ export function NationEmissionsJourney({
                     >
                       <span
                         className="w-2.5 h-2.5 md:w-3.5 md:h-3.5 rounded-full shrink-0"
-                        style={{ backgroundColor: s.color }}
+                        style={{
+                          backgroundColor: s.ring ? "#ffffff" : s.color,
+                        }}
                       />
                       <span className={`${NATION_STORY_TEXT.secondary} flex-1`}>
                         {t(s.labelKey)}
@@ -346,7 +536,11 @@ export function NationEmissionsJourney({
                         className={`${NATION_STORY_TEXT.secondary} tabular-nums shrink-0`}
                       >
                         {i === 0 ? "" : "+"}
-                        {formatMton(s.delta, currentLanguage, 0)}{" "}
+                        {formatMton(
+                          s.delta,
+                          currentLanguage,
+                          deltaDecimals(s.delta),
+                        )}{" "}
                         {t("nation.story.unit.mton")}
                       </span>
                     </motion.div>

--- a/src/components/nation/story/NationEmissionsJourney.tsx
+++ b/src/components/nation/story/NationEmissionsJourney.tsx
@@ -44,9 +44,12 @@ type JourneyStep = {
  */
 const E_COMMERCE_MTON = 0.326;
 
-/** Small additions like e-commerce need a decimal to not round to zero. */
+/**
+ * Small additions need decimals to not round to zero – three of them, so the
+ * e-commerce delta (0.326 Mton) matches the 326 000 tonnes cited in the copy.
+ */
 function deltaDecimals(delta: number): number {
-  return delta > 0 && delta < 1 ? 1 : 0;
+  return delta > 0 && delta < 1 ? 3 : 0;
 }
 
 /** Desktop onion diameter; mobile scales down so text + bubble fit one screen. */
@@ -198,11 +201,16 @@ export function NationEmissionsJourney({
       if (event.deltaY < 0) controls.stop();
     };
     const cancelOnTouch = () => controls.stop();
+    const cancelIfUpwardKey = (event: KeyboardEvent) => {
+      if (["ArrowUp", "PageUp", "Home"].includes(event.key)) controls.stop();
+    };
     window.addEventListener("wheel", cancelIfUpward, { passive: true });
     window.addEventListener("touchstart", cancelOnTouch, { passive: true });
+    window.addEventListener("keydown", cancelIfUpwardKey);
     const cleanup = () => {
       window.removeEventListener("wheel", cancelIfUpward);
       window.removeEventListener("touchstart", cancelOnTouch);
+      window.removeEventListener("keydown", cancelIfUpwardKey);
     };
     controls.then(cleanup, cleanup);
   }, [exitProgress, reducedMotion, ref]);

--- a/src/components/nation/story/NationIntroPunch.tsx
+++ b/src/components/nation/story/NationIntroPunch.tsx
@@ -1,6 +1,11 @@
-import { useId } from "react";
+import { useId, useRef } from "react";
 import { useTranslation } from "react-i18next";
-import { motion, useReducedMotion } from "framer-motion";
+import {
+  motion,
+  useReducedMotion,
+  useScroll,
+  useTransform,
+} from "framer-motion";
 import {
   formatMton,
   type NationStoryMetrics,
@@ -42,6 +47,7 @@ type StatCalloutProps = {
   unitLong: string;
   colorClass: string;
   delay: number;
+  className?: string;
 };
 
 function StatCallout({
@@ -51,6 +57,7 @@ function StatCallout({
   unitLong,
   colorClass,
   delay,
+  className,
 }: StatCalloutProps) {
   return (
     <motion.div
@@ -58,7 +65,7 @@ function StatCallout({
       whileInView={{ opacity: 1, x: 0 }}
       viewport={{ once: true, amount: 0.4 }}
       transition={{ duration: 0.5, delay }}
-      className="text-center md:text-left"
+      className={`text-center md:text-left ${className ?? ""}`}
     >
       <p
         className={`${NATION_STORY_TYPE.meta} ${NATION_STORY_TEXT.secondary} mb-1`}
@@ -90,6 +97,7 @@ export function NationIntroPunch({ metrics }: NationIntroPunchProps) {
   const { t } = useTranslation();
   const { currentLanguage } = useLanguage();
   const reducedMotion = useReducedMotion();
+  const rootRef = useRef<HTMLDivElement>(null);
   const clipId = `sweden-fill-clip-${useId().replace(/:/g, "")}`;
 
   const reportedValue = metrics.territorialLatestMton;
@@ -98,11 +106,29 @@ export function NationIntroPunch({ metrics }: NationIntroPunchProps) {
   const full = formatMton(fullValue, currentLanguage, 0);
   const fillRatio = reportedValue / fullValue;
   const fillTop = OUTLINE_BOTTOM - fillRatio * OUTLINE_HEIGHT;
-  const unitShort = t("nation.story.unit.mton");
-  const unitLong = t("nation.story.unit.millionTon");
+  const unitShort = t("nation.story.unit.mtonCo2e");
+  const unitLong = t("nation.story.unit.millionTco2e");
+
+  // Scroll-lerped drain: as the hero scrolls out, the orange fill sinks back
+  // down and empties – one scroll later the onion's first orange circle grows
+  // from zero, so the reported share visually pours from the map into it.
+  // Pushing the clipped fill group down reads as the level draining; it
+  // composes with the one-shot rise (attribute animation vs transform) and
+  // refills when scrolling back up.
+  const { scrollYProgress: drainProgress } = useScroll({
+    target: rootRef,
+    offset: ["end 85%", "end 25%"],
+  });
+  const drainDistance = OUTLINE_BOTTOM - fillTop + 6;
+  const drainY = useTransform(
+    drainProgress,
+    [0, 1],
+    reducedMotion ? [0, 0] : [0, drainDistance],
+  );
 
   return (
     <motion.div
+      ref={rootRef}
       initial={{ opacity: 0, y: 12 }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true, amount: 0.35 }}
@@ -133,45 +159,47 @@ export function NationIntroPunch({ metrics }: NationIntroPunchProps) {
 
           {/* Reported share rises like water inside the silhouette */}
           <g clipPath={svgLocalUrl(clipId)}>
-            <motion.rect
-              x={0}
-              width={100}
-              fill={NATION_STORY_COLORS.territorial}
-              initial={
-                reducedMotion
-                  ? { y: fillTop, height: OUTLINE_BOTTOM - fillTop + 6 }
-                  : { y: OUTLINE_BOTTOM, height: 0 }
-              }
-              whileInView={{
-                y: fillTop,
-                height: OUTLINE_BOTTOM - fillTop + 6,
-              }}
-              viewport={{ once: true, amount: 0.35 }}
-              transition={
-                reducedMotion
-                  ? { duration: 0 }
-                  : { ...FILL_SPRING, delay: 0.35 }
-              }
-            />
-            <motion.line
-              x1={0}
-              x2={100}
-              stroke="var(--orange-1)"
-              strokeWidth="1"
-              strokeOpacity="0.8"
-              initial={
-                reducedMotion
-                  ? { y1: fillTop, y2: fillTop, opacity: 1 }
-                  : { y1: OUTLINE_BOTTOM, y2: OUTLINE_BOTTOM, opacity: 0 }
-              }
-              whileInView={{ y1: fillTop, y2: fillTop, opacity: 1 }}
-              viewport={{ once: true, amount: 0.35 }}
-              transition={
-                reducedMotion
-                  ? { duration: 0 }
-                  : { ...FILL_SPRING, delay: 0.35 }
-              }
-            />
+            <motion.g style={{ y: drainY }}>
+              <motion.rect
+                x={0}
+                width={100}
+                fill={NATION_STORY_COLORS.territorial}
+                initial={
+                  reducedMotion
+                    ? { y: fillTop, height: OUTLINE_BOTTOM - fillTop + 6 }
+                    : { y: OUTLINE_BOTTOM, height: 0 }
+                }
+                whileInView={{
+                  y: fillTop,
+                  height: OUTLINE_BOTTOM - fillTop + 6,
+                }}
+                viewport={{ once: true, amount: 0.35 }}
+                transition={
+                  reducedMotion
+                    ? { duration: 0 }
+                    : { ...FILL_SPRING, delay: 0.35 }
+                }
+              />
+              <motion.line
+                x1={0}
+                x2={100}
+                stroke="var(--orange-1)"
+                strokeWidth="1"
+                strokeOpacity="0.8"
+                initial={
+                  reducedMotion
+                    ? { y1: fillTop, y2: fillTop, opacity: 1 }
+                    : { y1: OUTLINE_BOTTOM, y2: OUTLINE_BOTTOM, opacity: 0 }
+                }
+                whileInView={{ y1: fillTop, y2: fillTop, opacity: 1 }}
+                viewport={{ once: true, amount: 0.35 }}
+                transition={
+                  reducedMotion
+                    ? { duration: 0 }
+                    : { ...FILL_SPRING, delay: 0.35 }
+                }
+              />
+            </motion.g>
           </g>
         </svg>
       </div>
@@ -185,6 +213,7 @@ export function NationIntroPunch({ metrics }: NationIntroPunchProps) {
           unitLong={unitLong}
           colorClass="text-pink-3"
           delay={0.15}
+          className="order-2 md:order-1"
         />
         <StatCallout
           label={t("nation.story.conclusion.usualLabel")}
@@ -193,6 +222,7 @@ export function NationIntroPunch({ metrics }: NationIntroPunchProps) {
           unitLong={unitLong}
           colorClass="text-orange-3"
           delay={0.3}
+          className="order-1 md:order-2"
         />
       </div>
     </motion.div>

--- a/src/components/nation/story/NationStackedChart.tsx
+++ b/src/components/nation/story/NationStackedChart.tsx
@@ -99,7 +99,7 @@ export const NationStackedChart: FC<NationStackedChartProps> = ({
       style={{ height: `${sectionVh}vh` }}
     >
       <div
-        className="h-[100svh] flex items-center px-4 md:px-8 py-3 md:py-0 overflow-hidden"
+        className="h-[100svh] flex items-center px-4 md:px-8 pt-14 pb-6 md:py-0 overflow-hidden"
         style={stageStyle}
       >
         {/* Same depth backdrop as the hero and journey chapters */}
@@ -234,11 +234,6 @@ export const NationStackedChart: FC<NationStackedChartProps> = ({
                 </motion.span>
               ))}
             </div>
-            <p
-              className={`${NATION_STORY_TYPE.meta} ${NATION_STORY_TEXT.secondary}`}
-            >
-              {t("nation.story.journey.dataYear", { year: latestYear })}
-            </p>
           </div>
         </div>
       </div>

--- a/src/components/nation/story/NationStoryPage.tsx
+++ b/src/components/nation/story/NationStoryPage.tsx
@@ -1,6 +1,7 @@
-import { useRef } from "react";
+import { useEffect, useRef, useState, type RefObject } from "react";
 import { useTranslation } from "react-i18next";
 import { motion, useScroll } from "framer-motion";
+import { useStoryEndReached } from "@/components/nation/story/useStoryEndReached";
 import { NationBathtub } from "@/components/nation/story/NationBathtub";
 import { NationConclusion } from "@/components/nation/story/NationConclusion";
 import { NationEmissionsJourney } from "@/components/nation/story/NationEmissionsJourney";
@@ -19,15 +20,120 @@ type NationStoryPageProps = {
   metrics: NationStoryMetrics;
 };
 
-/** Thin reading-progress bar just below the fixed site header. */
+/**
+ * Thin reading-progress bar just below the fixed site header.
+ * Desktop only – on mobile the step-dots timeline is the single progress cue.
+ */
 function StoryProgressBar() {
   const { scrollYProgress } = useScroll();
   return (
     <motion.div
       aria-hidden
-      className="fixed top-12 left-0 right-0 z-40 h-0.5 origin-left bg-gradient-to-r from-orange-3 to-pink-3"
+      className="hidden md:block fixed top-12 left-0 right-0 z-40 h-0.5 origin-left bg-gradient-to-r from-orange-3 to-pink-3"
       style={{ scaleX: scrollYProgress }}
     />
+  );
+}
+
+type StorySectionState = {
+  /** index of the section currently at the probe line */
+  active: number;
+  /** per-section state: number of pin-steps and the current step */
+  sections: Array<{ steps: number; step: number }>;
+};
+
+/**
+ * Fixed right-edge timeline: one dot per story chapter, so readers see the
+ * story is a sequence of scenes that advance on scroll. Multi-step chapters
+ * (onion, bathtub, stacked chart) show their inner steps as a segmented bar
+ * while active. Reads the `data-story-*` attributes the sections already
+ * expose; hides once the conclusion is in view.
+ */
+function StoryStepDots({ endRef }: { endRef: RefObject<HTMLElement | null> }) {
+  const endReached = useStoryEndReached(endRef);
+  const [state, setState] = useState<StorySectionState>({
+    active: 0,
+    sections: [],
+  });
+
+  useEffect(() => {
+    const update = () => {
+      const sections = Array.from(
+        document.querySelectorAll<HTMLElement>("[data-story-section]"),
+      );
+      const probeY = window.innerHeight * 0.45;
+      let active = 0;
+      sections.forEach((section, index) => {
+        const rect = section.getBoundingClientRect();
+        if (rect.top <= probeY) active = index;
+      });
+      setState({
+        active,
+        sections: sections.map((section) => ({
+          steps: Number(section.dataset.storySteps ?? "1"),
+          step: Number(section.dataset.storyStep ?? "0"),
+        })),
+      });
+    };
+
+    update();
+    window.addEventListener("scroll", update, { passive: true });
+    window.addEventListener("resize", update);
+    return () => {
+      window.removeEventListener("scroll", update);
+      window.removeEventListener("resize", update);
+    };
+  }, []);
+
+  const visible = !endReached && state.sections.length > 0;
+
+  return (
+    <motion.div
+      aria-hidden
+      initial={false}
+      animate={{ opacity: visible ? 1 : 0 }}
+      transition={{ duration: 0.35 }}
+      className={`fixed right-2 md:right-5 top-1/2 -translate-y-1/2 z-40 flex flex-col items-center gap-2 md:gap-2.5 ${visible ? "" : "pointer-events-none"}`}
+    >
+      {state.sections.map((section, index) => {
+        const isActive = index === state.active;
+        if (isActive && section.steps > 1) {
+          // Active multi-step chapter: segmented bar showing the inner steps
+          return (
+            <span key={index} className="flex flex-col items-center gap-1">
+              {Array.from({ length: section.steps }, (_, stepIndex) => (
+                <span
+                  key={stepIndex}
+                  className="w-1.5 rounded-full transition-colors duration-300"
+                  style={{
+                    height: 10,
+                    backgroundColor:
+                      stepIndex <= section.step
+                        ? "var(--blue-2)"
+                        : "rgba(255,255,255,0.2)",
+                  }}
+                />
+              ))}
+            </span>
+          );
+        }
+        return (
+          <span
+            key={index}
+            className="rounded-full transition-all duration-300"
+            style={{
+              width: isActive ? 10 : 6,
+              height: isActive ? 10 : 6,
+              backgroundColor: isActive
+                ? "var(--blue-2)"
+                : index < state.active
+                  ? "rgba(153,207,255,0.45)"
+                  : "rgba(255,255,255,0.2)",
+            }}
+          />
+        );
+      })}
+    </motion.div>
   );
 }
 
@@ -35,7 +141,7 @@ function FullScreenSection({ children }: { children: React.ReactNode }) {
   return (
     <section
       data-story-section
-      className="relative min-h-[70vh] md:min-h-[80vh] flex items-center justify-center px-4 md:px-8 py-8 md:py-10"
+      className="relative min-h-[42vh] md:min-h-[80vh] flex items-center justify-center px-4 md:px-8 py-12 md:py-16"
     >
       <div className="w-full max-w-4xl mx-auto">{children}</div>
     </section>
@@ -50,13 +156,13 @@ export function NationStoryPage({
   const conclusionRef = useRef<HTMLElement>(null);
 
   return (
-    <div className="bg-black text-white pb-16 md:pb-24">
+    <div className="bg-black text-white pb-10 md:pb-24">
       <StoryProgressBar />
 
       {/* Intro hero – exactly one viewport: eyebrow, headline, lede, silhouette */}
       <section
         data-story-section
-        className="relative min-h-[100svh] md:h-[100svh] flex flex-col items-center justify-center px-4 md:px-8 pt-8 md:pt-10 pb-16 md:pb-20 overflow-hidden"
+        className="relative min-h-[100svh] md:h-[100svh] flex flex-col items-center justify-center px-4 md:px-8 pt-6 md:pt-10 pb-28 md:pb-20 overflow-hidden"
       >
         {/* Subtle depth behind the hero, using existing surface colors only */}
         <div
@@ -81,10 +187,11 @@ export function NationStoryPage({
         </div>
       </section>
 
-      {/* Short transition: the explanation that follows the hero's punch */}
+      {/* Short transition: the explanation that follows the hero's punch.
+          Mobile keeps this tight – big min-heights read as empty black. */}
       <section
         data-story-section
-        className="relative min-h-[50vh] md:min-h-[60vh] flex items-center justify-center px-4 md:px-8 py-12 md:py-16"
+        className="relative min-h-[35vh] md:min-h-[70vh] flex items-center justify-center px-4 md:px-8 py-12 md:py-16"
       >
         <div className="max-w-2xl mx-auto text-center space-y-5 md:space-y-6">
           <motion.p
@@ -154,7 +261,7 @@ export function NationStoryPage({
       <section
         ref={conclusionRef}
         data-story-section
-        className="relative min-h-[80vh] flex items-center justify-center px-4 md:px-8 py-10 overflow-hidden"
+        className="relative min-h-[50vh] md:min-h-[80vh] flex items-center justify-center px-4 md:px-8 py-12 md:py-16 overflow-hidden"
       >
         {/* Same depth backdrop as the hero – the story ends where it began */}
         <div
@@ -167,6 +274,7 @@ export function NationStoryPage({
       </section>
 
       <StoryScrollHint endRef={conclusionRef} />
+      <StoryStepDots endRef={conclusionRef} />
     </div>
   );
 }

--- a/src/components/nation/story/NationStoryPage.tsx
+++ b/src/components/nation/story/NationStoryPage.tsx
@@ -47,7 +47,8 @@ type StorySectionState = {
  * story is a sequence of scenes that advance on scroll. Multi-step chapters
  * (onion, bathtub, stacked chart) show their inner steps as a segmented bar
  * while active. Reads the `data-story-*` attributes the sections already
- * expose; hides once the conclusion is in view.
+ * expose; hides once the conclusion is in view. Mobile only – desktop uses
+ * the top reading-progress bar instead.
  */
 function StoryStepDots({ endRef }: { endRef: RefObject<HTMLElement | null> }) {
   const endReached = useStoryEndReached(endRef);
@@ -93,7 +94,7 @@ function StoryStepDots({ endRef }: { endRef: RefObject<HTMLElement | null> }) {
       initial={false}
       animate={{ opacity: visible ? 1 : 0 }}
       transition={{ duration: 0.35 }}
-      className={`fixed right-2 md:right-5 top-1/2 -translate-y-1/2 z-40 flex flex-col items-center gap-2 md:gap-2.5 ${visible ? "" : "pointer-events-none"}`}
+      className={`md:hidden fixed right-2 top-1/2 -translate-y-1/2 z-40 flex flex-col items-center gap-2 ${visible ? "" : "pointer-events-none"}`}
     >
       {state.sections.map((section, index) => {
         const isActive = index === state.active;

--- a/src/components/nation/story/StoryScrollHint.tsx
+++ b/src/components/nation/story/StoryScrollHint.tsx
@@ -10,6 +10,26 @@ type StoryScrollHintProps = {
 };
 
 /**
+ * Scroll to a section's start, past any enter zone it declares via
+ * `data-story-enter-vh`, so pinned scenes land fully visible instead of at
+ * the zone's opacity-0 beginning.
+ */
+function scrollToStorySectionStart(section: HTMLElement) {
+  const enterVh = Number(section.dataset.storyEnterVh ?? "0");
+  if (enterVh > 0) {
+    window.scrollTo({
+      top:
+        window.scrollY +
+        section.getBoundingClientRect().top +
+        (enterVh / 100) * window.innerHeight,
+      behavior: "smooth",
+    });
+    return;
+  }
+  section.scrollIntoView({ behavior: "smooth", block: "start" });
+}
+
+/**
  * Advance one pin-step inside a multi-step section, or jump to the next
  * `[data-story-section]` when on its last step. Avoids the “black gap”
  * that a fixed scrollBy leaves at the end of tall pinned sections.
@@ -45,7 +65,7 @@ function scrollToNextStoryBeat() {
 
     const next = sections[currentIndex + 1];
     if (next) {
-      next.scrollIntoView({ behavior: "smooth", block: "start" });
+      scrollToStorySectionStart(next);
       return;
     }
   }
@@ -54,7 +74,7 @@ function scrollToNextStoryBeat() {
     (section) => section.getBoundingClientRect().top > probeY,
   );
   if (nextBelow) {
-    nextBelow.scrollIntoView({ behavior: "smooth", block: "start" });
+    scrollToStorySectionStart(nextBelow);
     return;
   }
 

--- a/src/components/nation/story/StoryScrollHint.tsx
+++ b/src/components/nation/story/StoryScrollHint.tsx
@@ -1,7 +1,8 @@
 import { useRef, type RefObject } from "react";
 import { ChevronDown } from "lucide-react";
-import { motion, useInView } from "framer-motion";
+import { motion } from "framer-motion";
 import { useTranslation } from "react-i18next";
+import { useStoryEndReached } from "@/components/nation/story/useStoryEndReached";
 
 type StoryScrollHintProps = {
   /** Hide the hint once this element (typically the conclusion) enters the viewport. */
@@ -64,7 +65,7 @@ function scrollToNextStoryBeat() {
 export function StoryScrollHint({ endRef }: StoryScrollHintProps) {
   const { t } = useTranslation();
   const ref = useRef<HTMLButtonElement>(null);
-  const endReached = useInView(endRef, { amount: 0.35 });
+  const endReached = useStoryEndReached(endRef);
   const visible = !endReached;
 
   return (
@@ -78,20 +79,24 @@ export function StoryScrollHint({ endRef }: StoryScrollHintProps) {
       initial={false}
       animate={
         visible
-          ? { opacity: [0.55, 1, 0.55], y: [0, 10, 0] }
+          ? { opacity: [0.4, 1, 0.4], y: [0, 12, 0] }
           : { opacity: 0, y: 0 }
       }
       transition={
         visible
           ? {
-              opacity: { repeat: Infinity, duration: 1.4, ease: "easeInOut" },
-              y: { repeat: Infinity, duration: 1.4, ease: "easeInOut" },
+              opacity: { repeat: Infinity, duration: 1.2, ease: "easeInOut" },
+              y: { repeat: Infinity, duration: 1.2, ease: "easeInOut" },
             }
           : { duration: 0.35 }
       }
-      className={`fixed inset-x-0 bottom-6 md:bottom-10 z-50 mx-auto flex w-fit items-center justify-center text-grey transition-colors hover:text-white ${visible ? "" : "pointer-events-none"}`}
+      className={`fixed inset-x-0 bottom-5 md:bottom-8 z-50 mx-auto flex w-fit items-center justify-center text-white drop-shadow-[0_2px_8px_rgba(0,0,0,0.9)] transition-colors hover:text-blue-2 ${visible ? "" : "pointer-events-none"}`}
     >
-      <ChevronDown className="h-9 w-9" strokeWidth={2.25} aria-hidden />
+      <ChevronDown
+        className="h-10 w-10 md:h-11 md:w-11"
+        strokeWidth={2.5}
+        aria-hidden
+      />
     </motion.button>
   );
 }

--- a/src/components/nation/story/usePinnedSteps.ts
+++ b/src/components/nation/story/usePinnedSteps.ts
@@ -2,24 +2,45 @@ import { useEffect, useRef, useState } from "react";
 
 export type PinMode = "before" | "pinned" | "after";
 
+export type PinnedStepsOptions = {
+  /** Extra pinned scroll (in vh) before the steps – drives `enterProgress`. */
+  enterVh?: number;
+  /** Extra pinned scroll (in vh) after the steps – drives `exitProgress`. */
+  exitVh?: number;
+};
+
+const clamp01 = (value: number) => Math.min(Math.max(value, 0), 1);
+
 /**
  * Scroll-driven pinning used by the nation story sections.
  *
- * Renders a tall section (`stepCount * stepVh`) and reports the current step
- * derived from scroll position. The visual "stage" should be positioned with
- * the returned `stageStyle`: absolute at the top before pinning, fixed while
- * the section fully covers the viewport, absolute at the bottom afterwards.
- * This keeps the pinned content inside the section bounds (no overlap with
- * neighbouring sections) and works regardless of the scroll container – the
- * layout's `overflow-x-hidden` breaks `position: sticky`, so we avoid it.
+ * Renders a tall section (`enterVh + stepCount * stepVh + exitVh`) and reports
+ * the current step derived from scroll position. The visual "stage" should be
+ * positioned with the returned `stageStyle`: absolute at the top before
+ * pinning, fixed while the section fully covers the viewport, absolute at the
+ * bottom afterwards. This keeps the pinned content inside the section bounds
+ * (no overlap with neighbouring sections) and works regardless of the scroll
+ * container – the layout's `overflow-x-hidden` breaks `position: sticky`, so
+ * we avoid it.
+ *
+ * Optional enter/exit zones reserve pinned scroll around the steps for
+ * scene-transition morphs: `enterProgress` runs 0→1 across the enter zone,
+ * `exitProgress` 0→1 across the exit zone, and `step`/`progress` cover the
+ * steps span only, so per-step lerp math is unaffected by the zones.
  */
-export function usePinnedSteps(stepCount: number, stepVh = 90) {
+export function usePinnedSteps(
+  stepCount: number,
+  stepVh = 90,
+  { enterVh = 0, exitVh = 0 }: PinnedStepsOptions = {},
+) {
   const ref = useRef<HTMLElement>(null);
   const [step, setStep] = useState(0);
   const [progress, setProgress] = useState(0);
+  const [enterProgress, setEnterProgress] = useState(enterVh > 0 ? 0 : 1);
+  const [exitProgress, setExitProgress] = useState(0);
   const [mode, setMode] = useState<PinMode>("before");
   const [stageBounds, setStageBounds] = useState({ left: 0, width: 0 });
-  const sectionVh = stepCount * stepVh;
+  const sectionVh = enterVh + stepCount * stepVh + exitVh;
 
   useEffect(() => {
     const update = () => {
@@ -34,8 +55,18 @@ export function usePinnedSteps(stepCount: number, stepVh = 90) {
       if (rect.top > 0) nextMode = "before";
       else if (scrolled >= pinDistance) nextMode = "after";
 
+      // Split the pin travel into enter / steps / exit spans (px), keeping
+      // the zone sizes exact so morphs get precisely enterVh/exitVh of scroll.
+      const vhPx = viewport / 100;
+      const enterPx = enterVh * vhPx;
+      const exitPx = exitVh * vhPx;
+      const stepsPx = Math.max(pinDistance - enterPx - exitPx, 0);
+
+      const nextEnter = enterPx > 0 ? clamp01(scrolled / enterPx) : 1;
       const nextProgress =
-        pinDistance > 0 ? Math.min(Math.max(scrolled / pinDistance, 0), 1) : 0;
+        stepsPx > 0 ? clamp01((scrolled - enterPx) / stepsPx) : 0;
+      const nextExit =
+        exitPx > 0 ? clamp01((scrolled - enterPx - stepsPx) / exitPx) : 0;
       const nextStep = Math.min(
         Math.max(Math.floor(nextProgress * stepCount), 0),
         stepCount - 1,
@@ -43,7 +74,9 @@ export function usePinnedSteps(stepCount: number, stepVh = 90) {
 
       setStageBounds({ left: rect.left, width: rect.width });
       setMode(nextMode);
+      setEnterProgress(nextEnter);
       setProgress(nextProgress);
+      setExitProgress(nextExit);
       setStep(nextStep);
     };
 
@@ -54,7 +87,7 @@ export function usePinnedSteps(stepCount: number, stepVh = 90) {
       window.removeEventListener("scroll", update);
       window.removeEventListener("resize", update);
     };
-  }, [stepCount, stepVh]);
+  }, [stepCount, stepVh, enterVh, exitVh]);
 
   const stageStyle: React.CSSProperties =
     mode === "pinned"
@@ -73,5 +106,14 @@ export function usePinnedSteps(stepCount: number, stepVh = 90) {
             right: 0,
           };
 
-  return { ref, step, progress, mode, sectionVh, stageStyle };
+  return {
+    ref,
+    step,
+    progress,
+    enterProgress,
+    exitProgress,
+    mode,
+    sectionVh,
+    stageStyle,
+  };
 }

--- a/src/components/nation/story/useStoryEndReached.ts
+++ b/src/components/nation/story/useStoryEndReached.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState, type RefObject } from "react";
+
+/**
+ * True while the conclusion section sits at or above the probe line – i.e.
+ * the reader has reached the end of the story content (or scrolled past it
+ * into the footer). Unlike `useInView`, this stays true below the conclusion,
+ * so end-of-story chrome doesn't reappear over the footer.
+ */
+export function useStoryEndReached(
+  endRef: RefObject<HTMLElement | null>,
+): boolean {
+  const [reached, setReached] = useState(false);
+
+  useEffect(() => {
+    const update = () => {
+      const el = endRef.current;
+      if (!el) return;
+      setReached(el.getBoundingClientRect().top <= window.innerHeight * 0.6);
+    };
+
+    update();
+    window.addEventListener("scroll", update, { passive: true });
+    window.addEventListener("resize", update);
+    return () => {
+      window.removeEventListener("scroll", update);
+      window.removeEventListener("resize", update);
+    };
+  }, [endRef]);
+
+  return reached;
+}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1532,6 +1532,7 @@
     "story": {
       "unit": {
         "mton": "Mt",
+        "mtonCo2e": "Mt CO₂e",
         "millionTon": "million tonnes",
         "millionTco2e": "million tonnes CO₂e"
       },
@@ -1539,7 +1540,7 @@
         "eyebrow": "Election 2026",
         "title": "Sweden's emissions",
         "paragraph1": "We often hear that Sweden's emissions have fallen by a third while the economy has doubled. But is that really true?",
-        "paragraph2": "What we usually hear about are territorial emissions – fossil greenhouse gas emissions within Sweden's borders. That measure is used to track Sweden's climate goals.",
+        "paragraph2": "What we usually hear about are territorial emissions – fossil greenhouse gas emissions within Sweden's borders. It is the measure used to track Sweden's climate goals.",
         "paragraph3": "But Sweden's emissions are actually larger than that. Let's look at it, step by step.",
         "previewRatio": "larger than what we usually talk about"
       },
@@ -1548,7 +1549,7 @@
         "label": "Scroll down to the next part of the story"
       },
       "journey": {
-        "dataYear": "Figures refer to {{year}}.",
+        "dataYear": "Figures refer to CO₂e and year {{year}}.",
         "stepCounter": "Step {{current}} of {{total}}",
         "totalLabel": "Total",
         "step1": {
@@ -1561,7 +1562,7 @@
         },
         "step3": {
           "label": "Consumption abroad",
-          "text": "Swedes also cause emissions through consumption abroad. This includes emissions from manufacturing and transport of imported goods for Swedish household consumption, public services and investments. Swedes' international flights are included here, but emissions from goods produced in Sweden and exported to other countries are excluded."
+          "text": "But Swedes also cause emissions through our consumption abroad. This includes emissions from manufacturing and transport of imported goods for Swedish household consumption, public services and investments. Swedes' international flights are included here, but emissions from goods produced in Sweden and exported to other countries are excluded."
         },
         "step4": {
           "label": "Private e-commerce",
@@ -1574,16 +1575,17 @@
       },
       "bathtub": {
         "eyebrow": "The bathtub effect",
-        "text": "The atmosphere responds to the total amount of greenhouse gases – and they stay and accumulate over time. A bit like a bathtub with the tap running: until the tap is fully closed, the water level will keep rising. And the atmosphere has already passed the threshold for 1.5°C of warming. That is why how quickly we cut emissions toward zero is critically important.",
+        "text": "The atmosphere responds to the total amount of greenhouse gases – and they stay and accumulate over time. A bit like a bathtub with the tap running: until the tap is fully closed, the water level will keep rising. And the atmosphere has already passed the threshold for 1.5°C of warming. That is why it is crucially important how quickly we cut emissions toward zero.",
         "question": "How has that gone since 1990?",
-        "levelCaption": "{{value}} Mt accumulated since 1990",
-        "chunkCaptionSingleYear": "+{{value}} Mt added in {{year}}",
-        "chunkCaptionYearRange": "+{{value}} Mt added {{fromYear}}–{{toYear}}"
+        "waterCaptionPrefix": "Sweden has emitted a total of",
+        "waterCaptionSuffix": "since 1990",
+        "chunkCaptionSingleYear": "+{{value}} Mt CO₂e added in {{year}}",
+        "chunkCaptionYearRange": "+{{value}} Mt CO₂e added {{fromYear}}–{{toYear}}"
       },
       "graph": {
         "territorialFossil": "Territorial emissions",
         "productionBased": "Production-based emissions",
-        "productionBeyondTerritorial": "Shipping and aviation abroad",
+        "productionBeyondTerritorial": "Swedish shipping and aviation abroad",
         "biogenic": "Biogenic emissions",
         "consumptionAbroad": "Consumption-based emissions abroad"
       },
@@ -1596,13 +1598,13 @@
         "layerCounter": "Layer {{current}} of {{total}}",
         "title": "Sweden's emissions since 1990",
         "layerCaption1": "First we have territorial emissions – fossil emissions within Sweden's borders.",
-        "layerCaption2": "Now we add emissions from Swedish shipping and airlines outside the country's borders.",
-        "layerCaption3": "Then we add consumption-based emissions abroad.",
+        "layerCaption2": "Now we add emissions from Swedish shipping and aviation abroad – together with the territorial emissions, this makes up the production-based emissions.",
+        "layerCaption3": "Then we add consumption-based emissions abroad, including private e-commerce imports.",
         "layerCaption4": "And finally the biogenic emissions to show the full picture."
       },
       "conclusion": {
         "eyebrow": "Conclusion",
-        "title": "Sweden's emissions are larger than we think and have fallen less than we think",
+        "title": "Sweden's emissions are larger than we think and have not fallen as much as we think",
         "usualLabel": "What we usually discuss",
         "fullLabel": "Sweden's actual emissions",
         "since1990": "since 1990",

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -1582,6 +1582,7 @@
     "story": {
       "unit": {
         "mton": "Mton",
+        "mtonCo2e": "Mton CO₂e",
         "millionTon": "miljoner ton",
         "millionTco2e": "miljoner ton CO₂e"
       },
@@ -1589,7 +1590,7 @@
         "eyebrow": "Valet 2026",
         "title": "Sveriges utsläpp",
         "paragraph1": "Vi får ofta höra att Sveriges utsläpp minskat med en tredjedel samtidigt som ekonomin har fördubblats. Men stämmer det verkligen?",
-        "paragraph2": "Det vi oftast hör om är territoriella utsläpp, det vill säga fossila växthusgasutsläpp inom Sveriges gränser. Det måttet används för att följa upp Sveriges klimatmål.",
+        "paragraph2": "Det vi oftast hör om är territoriella utsläpp, det vill säga fossila växthusgasutsläpp inom Sveriges gränser. Det är det måttet som används för att följa upp Sveriges klimatmål.",
         "paragraph3": "Men Sveriges utsläpp är egentligen större än så. Låt oss titta på det, steg för steg.",
         "previewRatio": "större än det vi brukar prata om"
       },
@@ -1598,7 +1599,7 @@
         "label": "Scrolla nedåt till nästa del av berättelsen"
       },
       "journey": {
-        "dataYear": "Siffrorna avser {{year}}.",
+        "dataYear": "Siffrorna avser CO₂e och år {{year}}.",
         "stepCounter": "Steg {{current}} av {{total}}",
         "totalLabel": "Totalt",
         "step1": {
@@ -1611,7 +1612,7 @@
         },
         "step3": {
           "label": "Konsumtion utomlands",
-          "text": "Men svenskar orsakar också utsläpp genom vår konsumtion utomlands. Här inkluderas utsläpp från tillverkning och transport av importerade varor till svensk hushållskonsumtion, offentlig verksamhet och investeringar. Svenskarnas utrikesflyg ingår här, men utsläpp från varor som produceras i Sverige och exporteras till andra länder räknas bort."
+          "text": "Men svenskar orsakar också utsläpp genom vår konsumtion utomlands. Här inkluderas utsläpp från tillverkning och transport av importerade varor till svensk hushållskonsumtion, offentlig verksamhet och investeringar. Svenskarnas utrikesflyg ingår här, men utsläpp från varor som produceras i Sverige men exporteras till andra länder räknas bort."
         },
         "step4": {
           "label": "Privat e-handel",
@@ -1626,14 +1627,15 @@
         "eyebrow": "Badkarseffekten",
         "text": "Atmosfären reagerar på mängden växthusgaser totalt – och de stannar kvar och ansamlas över tid. Lite som ett badkar, där kranen står på. Innan kranen dras åt helt, kommer vattennivån att fortsätta stiga. Och atmosfären har redan passerat gränsen för 1,5 graders uppvärmning. Därför är det avgörande viktigt hur snabbt vi minskar utsläppen ner mot noll.",
         "question": "Hur har det gått med det sedan 1990?",
-        "levelCaption": "{{value}} Mton ansamlat sedan 1990",
-        "chunkCaptionSingleYear": "+{{value}} Mton tillkom {{year}}",
-        "chunkCaptionYearRange": "+{{value}} Mton tillkom {{fromYear}}–{{toYear}}"
+        "waterCaptionPrefix": "Sverige har totalt släppt ut",
+        "waterCaptionSuffix": "sedan 1990",
+        "chunkCaptionSingleYear": "+{{value}} Mton CO₂e tillkom {{year}}",
+        "chunkCaptionYearRange": "+{{value}} Mton CO₂e tillkom {{fromYear}}–{{toYear}}"
       },
       "graph": {
         "territorialFossil": "Territoriella utsläpp",
         "productionBased": "Produktionsbaserade utsläpp",
-        "productionBeyondTerritorial": "Rederier och flyg utanför gränserna",
+        "productionBeyondTerritorial": "Svensk sjöfart och flyg utomlands",
         "biogenic": "Biogena utsläpp",
         "consumptionAbroad": "Konsumtionsbaserade utomlands"
       },
@@ -1646,13 +1648,13 @@
         "layerCounter": "Lager {{current}} av {{total}}",
         "title": "Sveriges utsläpp sedan 1990",
         "layerCaption1": "Först har vi de territoriella utsläppen – fossila utsläpp inom Sveriges gränser.",
-        "layerCaption2": "Nu lägger vi till utsläpp från svenska rederier och flygbolag utanför landets gränser.",
-        "layerCaption3": "Sedan lägger vi till de konsumtionsbaserade utsläppen utomlands.",
+        "layerCaption2": "Nu lägger vi till utsläpp från svensk sjöfart och flyg utomlands – tillsammans med de territoriella blir det de produktionsbaserade utsläppen.",
+        "layerCaption3": "Sedan lägger vi till de konsumtionsbaserade utsläppen utomlands, inklusive privat e-handelsimport.",
         "layerCaption4": "Och slutligen de biogena utsläppen för att ge hela bilden."
       },
       "conclusion": {
         "eyebrow": "Slutsats",
-        "title": "Sveriges utsläpp är större än vi tror och har minskat mindre än vi tror",
+        "title": "Sveriges utsläpp är större än vad vi tror och har inte minskat så mycket som vi tror",
         "usualLabel": "Det vi vanligtvis diskuterar",
         "fullLabel": "Sveriges egentliga utsläpp",
         "since1990": "sedan 1990",


### PR DESCRIPTION
## Summary
- Implements the founders' feedback on the Valet 2026 story page: sleeker scroll chevron that hides past the conclusion, right-edge step-dot progress timeline (single progress cue on mobile), white e-commerce tally row, 10-year bathtub milestones with the accumulated total inside the tub water, and the onion running total starting white and turning black as the first layer grows in.
- Adds scroll-lerped scene-to-scene morphs: the intro silhouette's orange fill drains into the onion's first circle, and the finished onion bubble compresses into a blue drop that falls toward the bathtub, with an auto-scroll ride carrying the reader through the hand-off (cancellable, reduced-motion aware).
- Updates the story copy to the founders' new script in both Swedish and English, and trims empty black space between sections on mobile.

## Test plan
- [ ] Walk /sv/valet-2026 and /en/valet-2026 on desktop and mobile widths
- [ ] Scrub the onion-to-bathtub boundary up and down; confirm the auto-ride triggers, cancels on scroll-up/touch, and re-arms
- [ ] Check prefers-reduced-motion: no morphs or scroll hijacking, plain fades
- [ ] Verify step dots and scroll chevron hide at the conclusion and stay hidden over the footer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds programmatic auto-scroll during the onion→bathtub transition (mitigated by cancel listeners and reduced-motion bypass); otherwise presentation, copy, and scroll UX with no backend or auth changes.
> 
> **Overview**
> Second pass on the **Valet 2026** scroll story: tighter **mobile** layout (shorter section min-heights, extra hero/footer padding), **ScrollToTop** / **SuggestEdit** hidden on the story route on small screens, and split progress UI (**top bar on desktop**, **right-edge step dots** on mobile) that stays hidden after the conclusion via **`useStoryEndReached`**.
> 
> **Scroll-pinned scenes** gain optional **enter/exit** zones in **`usePinnedSteps`**: hero Sweden fill **drains on scroll** into the onion; onion layers **grow with scroll** (not step jumps); **e-commerce** shows as **+0.326 Mton** with a **white** legend dot, excluded from the running total; the running total is **white until the inner circle is large enough**; then the bubble **morphs to a droplet** with an **auto-scroll “ride”** into the bathtub enter zone (cancellable, disabled for reduced motion). Bathtub uses **decade milestones**, **accumulated CO₂e inside the water**, and an **enter fade** aligned with the droplet hand-off.
> 
> **Scroll chevron** is restyled and advances beats past **`data-story-enter-vh`**; **SV/EN copy** and units (**Mt CO₂e**) updated to the founders’ script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebaafe4b87224de3dd914c351839a461b9ff0e6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->