### PR TITLE
[Prod] Minor Version Bump v8.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "klimatkollen",
-  "version": "8.1.2-rc.29",
+  "version": "8.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "klimatkollen",
-      "version": "8.1.2-rc.29",
+      "version": "8.2.0",
       "dependencies": {
         "@fontsource/dm-sans": "^5.2.5",
         "@hookform/resolvers": "^3.9.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "klimatkollen",
   "private": true,
-  "version": "8.1.2-rc.29",
+  "version": "8.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
# 🚀 Production Release PR

> **Title format:** `[Prod] Major/Minor/Patch Version Bump vX.X.X`

## 📦 Release Type

- [ ] Major version bump
- [x] Minor version bump
- [ ] Patch version bump

### Rollback Version

v8.1.1

## 🔁 Environment Promotion

This release promotes changes **from `stage` to `production`**.

## 📋 What's Being Released

### Valet 2026 story page
- New scroll-driven nation story at `/sv/valet-2026` and `/en/valet-2026`: intro, onion layers, bathtub metaphor, stacked historic chart, and conclusion
- Scene-to-scene morph transitions (intro drain, onion-to-bathtub drop with auto-scroll ride)
- Founder copy updates in Swedish and English
- UX polish: scroll chevron, step dots (mobile), reduced black space on mobile, bathtub decade milestones

### Reports & content
- Updated Klimatkollen emissions reports and copy on About/Reports pages
- Fix report landing page lookup for locale PDFs and legacy route

### Other fixes & improvements
- Nation story data sourced from additional-nation-data endpoint
- Company overview memoization fix (#1607)
- Country filter badges on sector overview (#1609)
- Ranked list stretched rows fix (#1602)

## ✅ Checklist

- [x] Version number is updated correctly
- [ ] All relevant changes have been QA-tested in staging
- [x] Rollback version has been updated
- [x] Title follows the required format: `[Prod] Major/Minor/Patch Version Bump vX.X.X`

---

_This template is for versioned production releases only. For other PR types, please select a different template._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only metadata version fields change; no application code, dependencies, or runtime behavior in this diff.
> 
> **Overview**
> **Production release version bump** from `8.1.2-rc.29` to **`8.2.0`**.
> 
> Updates the root `version` in `package.json` and the matching root package entry in `package-lock.json` so the shipped app and lockfile align on the minor release being promoted from staging to production (rollback target noted in the PR: `v8.1.1`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e770271b9bb1e9c9b1d441c36c41e6d8953bd0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->