### PR TITLE
Election story: mobile polish, chart scrub readout and e-commerce layer

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -40,9 +40,11 @@ export function Layout({ children }: LayoutProps) {
     <div className="min-h-screen w-full overflow-x-hidden bg-black-3 flex flex-col">
       <Seo meta={seoMeta} />
       <Header />
+      {/* The story page is full-bleed like the landing page – its scenes
+          manage their own padding and start right below the fixed header */}
       <main
         className={
-          isLandingPage
+          isLandingPage || isStoryPage
             ? "flex-1 min-h-0"
             : "flex-1 container mx-auto px-4 pt-24 pb-12 min-h-0"
         }

--- a/src/components/nation/story/NationBathtub.tsx
+++ b/src/components/nation/story/NationBathtub.tsx
@@ -32,27 +32,6 @@ function sampleBathtubYears(
   return sampled;
 }
 
-/** Cumulative level interpolated between milestone steps for the current scroll segment. */
-function levelAtStepProgress(
-  steps: NationBathtubDataPoint[],
-  step: number,
-  progress: number,
-  stepCount: number,
-): number {
-  if (steps.length === 0) return 0;
-  const current = steps[step];
-  if (!current) return 0;
-
-  const stepProgress = Math.min(Math.max(progress * stepCount - step, 0), 1);
-  const previousCumulative =
-    step === 0 ? 0 : (steps[step - 1]?.cumulativeMton ?? 0);
-
-  return (
-    previousCumulative +
-    stepProgress * (current.cumulativeMton - previousCumulative)
-  );
-}
-
 type NationBathtubProps = {
   data: NationBathtubDataPoint[];
 };
@@ -79,6 +58,13 @@ const TUB_RIM_BAND_PATH =
   "M40 78 a220 16 0 1 0 440 0 a220 16 0 1 0 -440 0 " +
   "M58 80 a202 10 0 1 0 404 0 a202 10 0 1 0 -404 0";
 const TUB_STROKE = "rgba(255,255,255,0.4)";
+
+/**
+ * The tub artwork is scaled up around its centre while the caption text keeps
+ * its own size, giving the text more room inside the basin. Only the drawn
+ * shapes get this transform – text elements stay in unscaled coordinates.
+ */
+const TUB_ZOOM = "translate(260 150) scale(1.13 1.1) translate(-260 -150)";
 
 /**
  * Basin interior half-width sampled along the wall curve, so the water
@@ -113,25 +99,28 @@ const WATER_SPRING = {
   mass: 0.8,
 };
 
-/** Scroll distance per bathtub milestone step. */
-const BATHTUB_STEP_VH = 70;
+/**
+ * Scroll distance per bathtub milestone segment. The effective scroll per
+ * segment is smaller (the pin distance loses one viewport height: 55vh
+ * nominal ≈ 30vh real), so this mainly guards against a single lazy swipe
+ * skipping two decades at once – the water snaps per milestone regardless.
+ */
+const BATHTUB_STEP_VH = 55;
 /**
  * Extra pinned scroll before the steps: the tub eases in while the faucet
  * drip (the droplet handed over from the onion scene) is already falling.
  * The onion scene's auto-scroll ride ends exactly at the end of this zone.
  */
-export const BATHTUB_ENTER_VH = 70;
+export const BATHTUB_ENTER_VH = 55;
 
 const clamp01 = (value: number) => Math.min(Math.max(value, 0), 1);
 const smoothstep = (t: number) => t * t * (3 - 2 * t);
 
 type TubCaption = {
-  /** small line above the figure, e.g. "Sverige har totalt släppt ut" */
+  /** small line above the figure, e.g. "Sverige har sedan 1990 släppt" */
   prefix: string;
   /** the accumulated figure incl. unit, e.g. "4 712 Mton CO₂e" */
   value: string;
-  /** small line below the figure, e.g. "sedan 1990" */
-  suffix: string;
 };
 
 type TubGraphicProps = {
@@ -163,7 +152,7 @@ function TubGraphic({
   const surfaceRy = Math.max(surfaceRx * 0.055, 4);
 
   return (
-    <svg viewBox="0 0 520 260" className={className} aria-hidden>
+    <svg viewBox="0 0 520 262" className={className} aria-hidden>
       <defs>
         <clipPath id={clipId}>
           <path d={TUB_WATER_CLIP_PATH} />
@@ -178,90 +167,93 @@ function TubGraphic({
         </linearGradient>
       </defs>
 
-      {/* Rim-mounted faucet: riser with a cross handle, gooseneck spout */}
-      <path
-        d="M424 76 V42 Q424 26 408 26 H400 V30"
-        fill="none"
-        stroke={TUB_STROKE}
-        strokeWidth="2.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-      {/* Handle on the riser */}
-      <path
-        d="M429 48 h10"
-        stroke={TUB_STROKE}
-        strokeWidth="2"
-        strokeLinecap="round"
-      />
-      <circle
-        cx="441"
-        cy="48"
-        r="3"
-        fill="none"
-        stroke={TUB_STROKE}
-        strokeWidth="2"
-      />
-      {/* Spout mouth */}
-      <path d="M396 30 h8 v4 h-8 z" fill={TUB_STROKE} />
-      {/* Drip in brand blue – falls from the spout on a loop */}
-      {reducedMotion ? (
-        <circle cx="400" cy="46" r="3.2" fill="var(--blue-2)" />
-      ) : (
-        <motion.circle
-          cx={400}
-          r={3.2}
-          fill="var(--blue-2)"
-          initial={false}
-          animate={{ cy: [38, 74], opacity: [0, 1, 1, 0] }}
-          transition={{
-            cy: {
-              repeat: Infinity,
-              duration: 1.3,
-              ease: "easeIn",
-              repeatDelay: 0.5,
-            },
-            opacity: {
-              repeat: Infinity,
-              duration: 1.3,
-              times: [0, 0.15, 0.8, 1],
-              repeatDelay: 0.5,
-            },
-          }}
+      {/* Everything drawn below the text (water, enamel, faucet) – scaled up */}
+      <g transform={TUB_ZOOM}>
+        {/* Rim-mounted faucet: riser with a cross handle, gooseneck spout */}
+        <path
+          d="M424 76 V42 Q424 26 408 26 H400 V30"
+          fill="none"
+          stroke={TUB_STROKE}
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
         />
-      )}
+        {/* Handle on the riser */}
+        <path
+          d="M429 48 h10"
+          stroke={TUB_STROKE}
+          strokeWidth="2"
+          strokeLinecap="round"
+        />
+        <circle
+          cx="441"
+          cy="48"
+          r="3"
+          fill="none"
+          stroke={TUB_STROKE}
+          strokeWidth="2"
+        />
+        {/* Spout mouth */}
+        <path d="M396 30 h8 v4 h-8 z" fill={TUB_STROKE} />
+        {/* Drip in brand blue – falls from the spout on a loop */}
+        {reducedMotion ? (
+          <circle cx="400" cy="46" r="3.2" fill="var(--blue-2)" />
+        ) : (
+          <motion.circle
+            cx={400}
+            r={3.2}
+            fill="var(--blue-2)"
+            initial={false}
+            animate={{ cy: [38, 74], opacity: [0, 1, 1, 0] }}
+            transition={{
+              cy: {
+                repeat: Infinity,
+                duration: 1.3,
+                ease: "easeIn",
+                repeatDelay: 0.5,
+              },
+              opacity: {
+                repeat: Infinity,
+                duration: 1.3,
+                times: [0, 0.15, 0.8, 1],
+                repeatDelay: 0.5,
+              },
+            }}
+          />
+        )}
 
-      {/* Enamel body – a subtle fill so the tub reads as a solid object */}
-      <path d={TUB_BODY_FILL_PATH} fill={svgLocalUrl(enamelId)} />
+        {/* Enamel body – a subtle fill so the tub reads as a solid object */}
+        <path d={TUB_BODY_FILL_PATH} fill={svgLocalUrl(enamelId)} />
 
-      {/* Single continuous water body (behind the rim so the lip overlaps it) */}
-      <g clipPath={svgLocalUrl(clipId)}>
-        <motion.rect
-          x={TUB_WATER_LEFT}
-          width={TUB_WATER_WIDTH}
+        {/* Single continuous water body (behind the rim so the lip overlaps it) */}
+        <g clipPath={svgLocalUrl(clipId)}>
+          <motion.rect
+            x={TUB_WATER_LEFT}
+            width={TUB_WATER_WIDTH}
+            initial={false}
+            animate={{ y: waterTop, height: waterHeight }}
+            transition={waterTransition}
+            fill={svgLocalUrl(gradientId)}
+          />
+        </g>
+        {/* Surface sits above the fill and outside the clip so it stays visible when full */}
+        <motion.ellipse
+          cx={260}
+          fill="var(--blue-2)"
+          fillOpacity={0.32}
+          stroke="var(--blue-2)"
+          strokeWidth="2"
           initial={false}
-          animate={{ y: waterTop, height: waterHeight }}
+          animate={{ cy: waterTop, rx: surfaceRx, ry: surfaceRy }}
           transition={waterTransition}
-          fill={svgLocalUrl(gradientId)}
         />
       </g>
-      {/* Surface sits above the fill and outside the clip so it stays visible when full */}
-      <motion.ellipse
-        cx={260}
-        fill="var(--blue-2)"
-        fillOpacity={0.32}
-        stroke="var(--blue-2)"
-        strokeWidth="2"
-        initial={false}
-        animate={{ cy: waterTop, rx: surfaceRx, ry: surfaceRy }}
-        transition={waterTransition}
-      />
 
       {/* Accumulated total inside the basin – the screenshot-friendly figure */}
       <g style={{ fontFamily: "inherit" }}>
         <text
           x={260}
-          y={compact ? 122 : 126}
+          y={compact ? 134 : 138}
           textAnchor="middle"
           fill="rgba(255,255,255,0.9)"
           fontSize={compact ? 21 : 15}
@@ -270,7 +262,7 @@ function TubGraphic({
         </text>
         <text
           x={260}
-          y={compact ? 162 : 164}
+          y={compact ? 176 : 176}
           textAnchor="middle"
           fill="#ffffff"
           fontSize={compact ? 42 : 32}
@@ -279,79 +271,73 @@ function TubGraphic({
         >
           {caption.value}
         </text>
-        <text
-          x={260}
-          y={compact ? 192 : 190}
-          textAnchor="middle"
-          fill="rgba(255,255,255,0.9)"
-          fontSize={compact ? 21 : 15}
-        >
-          {caption.suffix}
-        </text>
       </g>
 
-      {/* Basin walls and rounded floor */}
-      <path
-        d={TUB_BODY_PATH}
-        fill="none"
-        stroke={TUB_STROKE}
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
+      {/* Tub outline drawn above the text – same zoom as the artwork below */}
+      <g transform={TUB_ZOOM}>
+        {/* Basin walls and rounded floor */}
+        <path
+          d={TUB_BODY_PATH}
+          fill="none"
+          stroke={TUB_STROKE}
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
 
-      {/* Rolled rim: filled band between outer lip and inner opening */}
-      <path
-        d={TUB_RIM_BAND_PATH}
-        fill="rgba(255,255,255,0.07)"
-        fillRule="evenodd"
-      />
-      <ellipse
-        cx="260"
-        cy="78"
-        rx="220"
-        ry="16"
-        fill="none"
-        stroke={TUB_STROKE}
-        strokeWidth="2"
-      />
-      <ellipse
-        cx="260"
-        cy="80"
-        rx="202"
-        ry="10"
-        fill="none"
-        stroke={TUB_STROKE}
-        strokeWidth="1"
-        strokeOpacity="0.6"
-      />
+        {/* Rolled rim: filled band between outer lip and inner opening */}
+        <path
+          d={TUB_RIM_BAND_PATH}
+          fill="rgba(255,255,255,0.07)"
+          fillRule="evenodd"
+        />
+        <ellipse
+          cx="260"
+          cy="78"
+          rx="220"
+          ry="16"
+          fill="none"
+          stroke={TUB_STROKE}
+          strokeWidth="2"
+        />
+        <ellipse
+          cx="260"
+          cy="80"
+          rx="202"
+          ry="10"
+          fill="none"
+          stroke={TUB_STROKE}
+          strokeWidth="1"
+          strokeOpacity="0.6"
+        />
 
-      {/* Sheen on the left enamel wall */}
-      <path
-        d="M76 100 C72 134 80 172 98 194"
-        fill="none"
-        stroke="rgba(255,255,255,0.09)"
-        strokeWidth="7"
-        strokeLinecap="round"
-      />
+        {/* Sheen on the left enamel wall */}
+        <path
+          d="M76 100 C72 134 80 172 98 194"
+          fill="none"
+          stroke="rgba(255,255,255,0.09)"
+          strokeWidth="7"
+          strokeLinecap="round"
+        />
 
-      {/* Ball-claw feet, curling outward */}
-      <path
-        d="M152 224 Q152 238 140 245"
-        fill="none"
-        stroke={TUB_STROKE}
-        strokeWidth="2.5"
-        strokeLinecap="round"
-      />
-      <circle cx="137" cy="247" r="3.5" fill={TUB_STROKE} />
-      <path
-        d="M368 224 Q368 238 380 245"
-        fill="none"
-        stroke={TUB_STROKE}
-        strokeWidth="2.5"
-        strokeLinecap="round"
-      />
-      <circle cx="383" cy="247" r="3.5" fill={TUB_STROKE} />
+        {/* Ball-claw feet, curling outward */}
+        <path
+          d="M152 224 Q152 238 140 245"
+          fill="none"
+          stroke={TUB_STROKE}
+          strokeWidth="2.5"
+          strokeLinecap="round"
+        />
+        <circle cx="137" cy="247" r="3.5" fill={TUB_STROKE} />
+        <path
+          d="M368 224 Q368 238 380 245"
+          fill="none"
+          stroke={TUB_STROKE}
+          strokeWidth="2.5"
+          strokeLinecap="round"
+        />
+        <circle cx="383" cy="247" r="3.5" fill={TUB_STROKE} />
+      </g>
     </svg>
   );
 }
@@ -363,32 +349,40 @@ export function NationBathtub({ data }: NationBathtubProps) {
   const reducedMotion = useReducedMotion();
   // useId can include ":" which is awkward in url(#…) fragments
   const idPrefix = `tub-${useId().replace(/:/g, "")}`;
-  const steps = useMemo(() => sampleBathtubYears(data), [data]);
-  const stepCount = Math.max(steps.length, 1);
+  const milestones = useMemo(() => sampleBathtubYears(data), [data]);
+  // 1990 is the resting start view (its water already in the tub), so only
+  // the decade jumps get scroll segments – four scrolls to full, not five.
+  const segmentCount = Math.max(milestones.length - 1, 1);
   const maxCumulative = data.at(-1)?.cumulativeMton ?? 1;
 
-  const { ref, step, progress, enterProgress, sectionVh, stageStyle } =
-    usePinnedSteps(stepCount, BATHTUB_STEP_VH, {
+  const { ref, progress, enterProgress, sectionVh, stageStyle } =
+    usePinnedSteps(segmentCount, BATHTUB_STEP_VH, {
       enterVh: BATHTUB_ENTER_VH,
     });
 
-  const current = steps[step] ?? steps[0];
+  // Water and captions move in lock-step: scroll only picks the active
+  // milestone (flipping at segment midpoints) and the water springs to that
+  // exact level – a swipe either bumps a whole decade or changes nothing,
+  // never a partial fill with a stale caption.
+  const displayedIndex = Math.min(
+    Math.round(progress * segmentCount),
+    milestones.length - 1,
+  );
+  const current = milestones[displayedIndex];
   if (!current) return null;
 
   // Enter morph (scroll-lerped): the tub and copy ease in from below while
   // the faucet drip carries over the droplet from the onion scene. `progress`
-  // covers the steps span only, so the water stays at zero until this is done.
-  // Opacity completes early in the zone to keep the black gap after the
-  // falling droplet short.
+  // covers the steps span only, so the water rests at the 1990 level until
+  // this is done. Opacity completes early in the zone to keep the black gap
+  // after the falling droplet short.
   const enterT = reducedMotion ? 1 : smoothstep(clamp01(enterProgress));
   const enterOpacity = reducedMotion ? 1 : clamp01(enterT / 0.65);
 
-  // Water rises smoothly within each milestone segment so fill matches captions.
-  const level = levelAtStepProgress(steps, step, progress, stepCount);
-  const fillRatio = Math.min(level / maxCumulative, 1);
+  const fillRatio = Math.min(current.cumulativeMton / maxCumulative, 1);
   const waterTop = TUB_INNER_BOTTOM - fillRatio * TUB_WATER_HEIGHT;
 
-  const previous = step === 0 ? null : steps[step - 1];
+  const previous = displayedIndex === 0 ? null : milestones[displayedIndex - 1];
   const previousCumulative = previous?.cumulativeMton ?? 0;
   const chunkMton = current.cumulativeMton - previousCumulative;
   // Milestone chunks cover the years after the previous sample through current.
@@ -411,26 +405,26 @@ export function NationBathtub({ data }: NationBathtubProps) {
   const tubCaption: TubCaption = {
     prefix: t("nation.story.bathtub.waterCaptionPrefix"),
     value: `${formatMton(current.cumulativeMton, currentLanguage, 0)} ${t("nation.story.unit.mtonCo2e")}`,
-    suffix: t("nation.story.bathtub.waterCaptionSuffix"),
   };
 
   return (
     <section
       ref={ref}
       data-story-section
-      data-story-step={step}
-      data-story-steps={steps.length}
+      data-story-step={displayedIndex}
+      data-story-steps={milestones.length}
+      data-story-snap="round"
       data-story-step-vh={BATHTUB_STEP_VH}
       data-story-enter-vh={BATHTUB_ENTER_VH}
       className="relative"
       style={{ height: `${sectionVh}vh` }}
     >
       <div
-        className="h-[100svh] flex items-center px-4 md:px-8 pt-14 pb-6 md:pt-0 md:pb-28"
+        className="h-[100svh] flex items-center px-4 md:px-8 pt-14 pb-6 md:pt-16 md:pb-16"
         style={stageStyle}
       >
         <div
-          className="w-full max-w-3xl mx-auto space-y-4 md:space-y-6"
+          className="w-full max-w-3xl mx-auto space-y-6 md:space-y-8"
           style={{
             opacity: enterOpacity,
             transform: `translateY(${(1 - enterT) * 24}px) scale(${0.94 + 0.06 * enterT})`,
@@ -438,13 +432,13 @@ export function NationBathtub({ data }: NationBathtubProps) {
           }}
         >
           {/* Copy above the tub on all breakpoints */}
-          <div className="max-w-2xl mx-auto text-center space-y-2.5 md:space-y-3">
+          <div className="max-w-2xl mx-auto text-center space-y-3.5 md:space-y-4">
             <motion.h2
               initial={{ opacity: 0, y: 10 }}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true, amount: 0.4 }}
               transition={{ duration: 0.4 }}
-              className="text-2xl md:text-3xl font-light tracking-tight text-white"
+              className={`${NATION_STORY_TYPE.title} text-white`}
             >
               {t("nation.story.bathtub.eyebrow")}
             </motion.h2>
@@ -473,14 +467,14 @@ export function NationBathtub({ data }: NationBathtubProps) {
             waterTop={waterTop}
             caption={tubCaption}
             compact={isMobile}
-            className="w-64 md:w-full max-w-lg mx-auto h-auto"
+            className="w-full max-w-sm md:max-w-2xl mx-auto h-auto max-h-[32svh] md:max-h-[38svh]"
           />
 
           {/* Milestone captions below the tub: the year and this decade's addition.
               The accumulated total lives inside the tub water. */}
           <div className="text-center space-y-0.5 md:space-y-1 min-h-[3.5rem] md:min-h-[4.5rem]">
             <p className="sr-only">
-              {`${tubCaption.prefix} ${tubCaption.value} ${tubCaption.suffix}`}
+              {`${tubCaption.prefix} ${tubCaption.value}`}
             </p>
             <motion.p
               key={current.year}

--- a/src/components/nation/story/NationConclusion.tsx
+++ b/src/components/nation/story/NationConclusion.tsx
@@ -159,22 +159,12 @@ export function NationConclusion({ metrics }: NationConclusionProps) {
 
   return (
     <div className="max-w-3xl mx-auto text-center space-y-5 md:space-y-8">
-      <motion.p
-        initial={{ opacity: 0, y: 12 }}
-        whileInView={{ opacity: 1, y: 0 }}
-        viewport={{ once: true, amount: 0.5 }}
-        transition={{ duration: 0.4 }}
-        className={`${NATION_STORY_TYPE.eyebrow} ${NATION_STORY_TEXT.eyebrow}`}
-      >
-        {t("nation.story.conclusion.eyebrow")}
-      </motion.p>
-
       <motion.h2
         initial={{ opacity: 0, y: 16 }}
         whileInView={{ opacity: 1, y: 0 }}
         viewport={{ once: true, amount: 0.5 }}
         transition={{ duration: 0.45, delay: 0.05 }}
-        className={`${NATION_STORY_TYPE.title} leading-tight`}
+        className={NATION_STORY_TYPE.title}
       >
         {t("nation.story.conclusion.title")}
       </motion.h2>

--- a/src/components/nation/story/NationEmissionsJourney.tsx
+++ b/src/components/nation/story/NationEmissionsJourney.tsx
@@ -257,10 +257,6 @@ export function NationEmissionsJourney({
   const deltaChipOffset =
     currentDiameter / 2 / Math.SQRT2 + (isMobile ? 8 : 12);
 
-  // The running total sits on the innermost circle – white on the dark
-  // backdrop until the first layer starts growing behind it.
-  const totalOnLayer = sectionStarted;
-
   // Exit morph (scroll-lerped): captions fade first, then the bubble
   // compresses into a blue droplet that sinks and finally falls off-stage
   // toward the bathtub scene. With reduced motion the stage simply fades.
@@ -395,9 +391,16 @@ export function NationEmissionsJourney({
               >
                 {sectionStarted ? (
                   <motion.span
-                    initial={false}
-                    animate={{ color: totalOnLayer ? "#000000" : "#ffffff" }}
-                    transition={{ duration: 0.3 }}
+                    // Mounts the moment the first layer starts springing from
+                    // zero, so it starts white on the dark backdrop and turns
+                    // black once the circle has grown up behind it
+                    initial={{ color: "#ffffff" }}
+                    animate={{ color: "#000000" }}
+                    transition={
+                      reducedMotion
+                        ? { duration: 0 }
+                        : { duration: 0.3, delay: 0.4 }
+                    }
                     className={`${NATION_STORY_TYPE.stat} font-medium select-none leading-none text-center`}
                   >
                     {formatMton(current.total, currentLanguage, 0)}

--- a/src/components/nation/story/NationEmissionsJourney.tsx
+++ b/src/components/nation/story/NationEmissionsJourney.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   AnimatePresence,
@@ -123,6 +123,39 @@ function buildSteps(metrics: NationStoryMetrics): JourneyStep[] {
       delta: biogenic,
     },
   ];
+}
+
+/**
+ * Rolls the running total between step values instead of snapping, roughly
+ * in step with the layer-growth spring. Renders the formatted value only.
+ */
+function AnimatedTotal({
+  value,
+  format,
+}: {
+  value: number;
+  format: (value: number) => string;
+}) {
+  const reducedMotion = useReducedMotion();
+  const [displayValue, setDisplayValue] = useState(value);
+  const previousRef = useRef(value);
+
+  useEffect(() => {
+    const from = previousRef.current;
+    previousRef.current = value;
+    if (reducedMotion || from === value) {
+      setDisplayValue(value);
+      return;
+    }
+    const controls = animate(from, value, {
+      duration: 0.7,
+      ease: [0.22, 1, 0.36, 1],
+      onUpdate: setDisplayValue,
+    });
+    return () => controls.stop();
+  }, [value, reducedMotion]);
+
+  return <>{format(displayValue)}</>;
 }
 
 type NationEmissionsJourneyProps = {
@@ -403,7 +436,10 @@ export function NationEmissionsJourney({
                     }
                     className={`${NATION_STORY_TYPE.stat} font-medium select-none leading-none text-center`}
                   >
-                    {formatMton(current.total, currentLanguage, 0)}
+                    <AnimatedTotal
+                      value={current.total}
+                      format={(v) => formatMton(v, currentLanguage, 0)}
+                    />
                     <span
                       className={`block ${NATION_STORY_TYPE.meta} font-medium mt-0.5 md:mt-1`}
                     >

--- a/src/components/nation/story/NationEmissionsJourney.tsx
+++ b/src/components/nation/story/NationEmissionsJourney.tsx
@@ -30,17 +30,12 @@ type JourneyStep = {
   total: number;
   /** this step's own contribution in Mton */
   delta: number;
-  /** drawn as an added colored circle layer (vs a thin ring for tiny additions) */
-  layer: boolean;
-  /** small extra addition drawn as a dashed ring (private e-commerce) */
-  ring?: boolean;
 };
 
 /**
- * Private e-commerce estimate (~326 000 t CO₂e). Shown as its own tally row,
- * but excluded from the running total: the amount is too small to move the
- * rounded 159 Mton figure and is presented as an addition outside official
- * statistics.
+ * Private e-commerce estimate (~326 000 t CO₂e). Included in the running
+ * total like every other layer, though it is far too small to move the
+ * rounded Mton figures.
  */
 const E_COMMERCE_MTON = 0.326;
 
@@ -54,16 +49,16 @@ function deltaDecimals(delta: number): number {
 
 /** Desktop onion diameter; mobile scales down so text + bubble fit one screen. */
 const DESKTOP_MAX_DIAMETER = 300;
-const MOBILE_MAX_DIAMETER = 148;
+const MOBILE_MAX_DIAMETER = 240;
 /** Scroll distance per journey step – higher = more time to watch each layer grow. */
-const JOURNEY_STEP_VH = 115;
+const JOURNEY_STEP_VH = 80;
 /**
  * Extra pinned scroll after the last step for the exit morph: the finished
  * bubble compresses into a water drop and falls toward the bathtub scene.
  * Entering this zone triggers an auto-scroll ride through the whole hand-off,
  * so the zone mainly sets the morph's pacing during that ride.
  */
-const JOURNEY_EXIT_VH = 90;
+const JOURNEY_EXIT_VH = 70;
 /** Size the bubble shrinks to before falling – matches the tub's faucet drip. */
 const DROPLET_DIAMETER = 14;
 
@@ -94,7 +89,6 @@ function buildSteps(metrics: NationStoryMetrics): JourneyStep[] {
       color: NATION_STORY_COLORS.territorial,
       total: territorial,
       delta: territorial,
-      layer: true,
     },
     {
       key: "step2",
@@ -103,7 +97,6 @@ function buildSteps(metrics: NationStoryMetrics): JourneyStep[] {
       color: NATION_STORY_COLORS.production,
       total: production,
       delta: production - territorial,
-      layer: true,
     },
     {
       key: "step3",
@@ -112,26 +105,22 @@ function buildSteps(metrics: NationStoryMetrics): JourneyStep[] {
       color: NATION_STORY_COLORS.consumption,
       total: production + consumption,
       delta: consumption,
-      layer: true,
     },
     {
       key: "step4",
       labelKey: "nation.story.journey.step4.label",
       textKey: "nation.story.journey.step4.text",
-      color: NATION_STORY_COLORS.eCommerceRing,
-      total: production + consumption,
+      color: NATION_STORY_COLORS.eCommerce,
+      total: production + consumption + E_COMMERCE_MTON,
       delta: E_COMMERCE_MTON,
-      layer: false,
-      ring: true,
     },
     {
       key: "step5",
       labelKey: "nation.story.journey.step5.label",
       textKey: "nation.story.journey.step5.text",
       color: NATION_STORY_COLORS.biogenic,
-      total: production + consumption + biogenic,
+      total: production + consumption + E_COMMERCE_MTON + biogenic,
       delta: biogenic,
-      layer: true,
     },
   ];
 }
@@ -152,7 +141,7 @@ export function NationEmissionsJourney({
   const maxTotal = steps[steps.length - 1].total;
   const maxDiameter = isMobile ? MOBILE_MAX_DIAMETER : DESKTOP_MAX_DIAMETER;
 
-  const { ref, step, progress, exitProgress, sectionVh, stageStyle } =
+  const { ref, step, exitProgress, mode, sectionVh, stageStyle } =
     usePinnedSteps(steps.length, JOURNEY_STEP_VH, {
       exitVh: JOURNEY_EXIT_VH,
     });
@@ -229,59 +218,48 @@ export function NationEmissionsJourney({
   useEffect(() => () => rideControlsRef.current?.stop(), []);
 
   const current = steps[step];
-  // Scroll position within the current step (0–1), smoothstepped so layers
-  // grow gently with the scroll instead of jumping per step.
-  const rawStepProgress = clamp01(progress * steps.length - step);
-  const stepProgress = smoothstep(rawStepProgress);
-  const newestLayerKey = steps
-    .slice(0, step + 1)
-    .filter((s) => s.layer)
-    .at(-1)?.key;
-  // Total of the layer beneath the one currently growing – its start diameter.
-  const previousLayerTotal =
-    steps
-      .slice(0, step)
-      .filter((s) => s.layer)
-      .at(-1)?.total ?? 0;
+  // The pinned stage is in the DOM before the reader reaches it, so gate the
+  // reveals on the section actually pinning – otherwise the first layer's
+  // grow animation would have played long before anyone sees it.
+  const sectionStarted = mode !== "before";
 
   // All layer-circles revealed so far, largest drawn first (behind) so each
   // colour shows as a ring around the previous – i.e. the types stacked up.
-  const revealedLayers = steps
-    .slice(0, step + 1)
-    .filter((s) => s.layer)
-    .sort((a, b) => b.total - a.total);
-
-  const showRing = steps.slice(0, step + 1).some((s) => s.ring);
-  const ringStep = steps.find((s) => s.ring);
-  const ringTotal = ringStep?.total ?? current.total;
+  // Each layer springs to full size the moment its step activates (and back
+  // on exit) – one trigger per ring, no partial builds while scrubbing.
+  const revealedLayers = sectionStarted
+    ? steps
+        .slice(0, step + 1)
+        .slice()
+        .sort((a, b) => b.total - a.total)
+    : [];
 
   const diameterFor = (total: number) =>
     Math.sqrt(total / maxTotal) * maxDiameter;
 
-  // Diameter of the circle as currently drawn: lerped while the current
-  // step's layer is growing, full-size otherwise.
-  const currentStartDiameter =
-    previousLayerTotal > 0 ? diameterFor(previousLayerTotal) : 0;
-  const currentDrawnDiameter =
-    current.layer && !reducedMotion
-      ? currentStartDiameter +
-        (diameterFor(current.total) - currentStartDiameter) * stepProgress
-      : diameterFor(current.total);
+  // Area-true diameters, except each layer must grow visibly past the one
+  // beneath it. Without this the e-commerce layer (+0.326 Mton on a ~110 Mton
+  // onion) would add a fraction of a pixel and be invisible.
+  const minRingGrowth = isMobile ? 10 : 14;
+  const layerDiameters = new Map<string, number>();
+  {
+    let previous = 0;
+    for (const s of steps) {
+      const diameter = Math.max(diameterFor(s.total), previous + minRingGrowth);
+      layerDiameters.set(s.key, diameter);
+      previous = diameter;
+    }
+  }
+  const currentDiameter = layerDiameters.get(current.key) ?? 0;
 
   // Distance from the bubble center to just outside the current circle's
-  // edge along the 45° upper-right diagonal (past the dashed ring when shown).
+  // edge along the 45° upper-right diagonal.
   const deltaChipOffset =
-    (currentDrawnDiameter + (current.ring ? (isMobile ? 16 : 26) : 0)) /
-      2 /
-      Math.SQRT2 +
-    (isMobile ? 8 : 12);
+    currentDiameter / 2 / Math.SQRT2 + (isMobile ? 8 : 12);
 
-  // The running total sits on the smallest (innermost) circle – territorial,
-  // which only grows during the first step. Until that circle is big enough
-  // to sit behind the text, render the number white on the dark backdrop.
-  const smallestDrawnDiameter =
-    step === 0 ? currentDrawnDiameter : diameterFor(steps[0].total);
-  const totalOnLayer = smallestDrawnDiameter >= (isMobile ? 64 : 116);
+  // The running total sits on the innermost circle – white on the dark
+  // backdrop until the first layer starts growing behind it.
+  const totalOnLayer = sectionStarted;
 
   // Exit morph (scroll-lerped): captions fade first, then the bubble
   // compresses into a blue droplet that sinks and finally falls off-stage
@@ -304,6 +282,7 @@ export function NationEmissionsJourney({
       data-story-step={step}
       data-story-steps={steps.length}
       data-story-step-vh={JOURNEY_STEP_VH}
+      data-story-exit-vh={JOURNEY_EXIT_VH}
       className="relative"
       style={{ height: `${sectionVh}vh` }}
     >
@@ -317,11 +296,11 @@ export function NationEmissionsJourney({
           className="absolute inset-0 bg-[radial-gradient(ellipse_70%_55%_at_50%_45%,var(--black-2)_0%,var(--black-3)_78%)]"
         />
         <div
-          className="relative grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-12 items-center w-full max-w-5xl mx-auto"
+          className="relative flex h-full flex-col justify-center gap-4 md:grid md:h-auto md:grid-cols-2 md:items-center md:gap-12 w-full max-w-5xl mx-auto"
           style={{ opacity: stageOpacity }}
         >
           {/* Bubble = accumulating colored layers */}
-          <div className="flex flex-col items-center gap-2 md:gap-4 order-1">
+          <div className="flex flex-col items-center gap-2 md:gap-4 py-3 md:py-0 order-1">
             <div
               className="relative"
               style={{
@@ -352,60 +331,44 @@ export function NationEmissionsJourney({
                 />
               </AnimatePresence>
 
-              {revealedLayers.map((layer) => {
-                const fullDiameter = diameterFor(layer.total);
-                // The newest layer grows with scroll (lerp) during its own
-                // step, starting from the previous layer's edge; scrolling
-                // back shrinks it the same way. Older layers stay full-size.
-                const isGrowingLayer =
-                  !reducedMotion &&
-                  current.layer &&
-                  layer.key === newestLayerKey &&
-                  layer.key === current.key;
-                const startDiameter =
-                  previousLayerTotal > 0 ? diameterFor(previousLayerTotal) : 0;
-                const d = isGrowingLayer
-                  ? startDiameter +
-                    (fullDiameter - startDiameter) * stepProgress
-                  : fullDiameter;
-                return (
-                  <motion.div
-                    key={layer.key}
-                    className="absolute left-1/2 top-1/2 rounded-full"
-                    style={{ backgroundColor: layer.color, opacity: 1 }}
-                    initial={false}
-                    animate={{ width: d, height: d, x: "-50%", y: "-50%" }}
-                    transition={
-                      reducedMotion ? { duration: 0 } : LAYER_GROW_TRANSITION
-                    }
-                  />
-                );
-              })}
-
-              {/* Private e-commerce: thin dashed ring around the current total */}
-              {showRing && ringStep && (
-                <div style={{ opacity: exitFade }}>
-                  <motion.span
-                    className="absolute left-1/2 top-1/2 rounded-full border-2 border-dashed"
-                    style={{
-                      width: diameterFor(ringTotal) + (isMobile ? 16 : 26),
-                      height: diameterFor(ringTotal) + (isMobile ? 16 : 26),
-                      x: "-50%",
-                      y: "-50%",
-                      borderColor: NATION_STORY_COLORS.eCommerceRing,
-                    }}
-                    initial={
-                      reducedMotion ? false : { opacity: 0, scale: 0.85 }
-                    }
-                    animate={{ opacity: 1, scale: 1 }}
-                    transition={
-                      reducedMotion
-                        ? { duration: 0 }
-                        : { duration: 0.9, ease: [0.22, 1, 0.36, 1] }
-                    }
-                  />
-                </div>
-              )}
+              <AnimatePresence>
+                {revealedLayers.map((layer) => {
+                  const fullDiameter = layerDiameters.get(layer.key) ?? 0;
+                  // Each ring grows out from the edge of the layer beneath
+                  // it, and shrinks back onto it when scrolled out again.
+                  const layerIndex = steps.findIndex(
+                    (s) => s.key === layer.key,
+                  );
+                  const startDiameter =
+                    layerIndex > 0
+                      ? (layerDiameters.get(steps[layerIndex - 1].key) ?? 0)
+                      : 0;
+                  const collapsed = {
+                    width: startDiameter,
+                    height: startDiameter,
+                    x: "-50%",
+                    y: "-50%",
+                  };
+                  return (
+                    <motion.div
+                      key={layer.key}
+                      className="absolute left-1/2 top-1/2 rounded-full"
+                      style={{ backgroundColor: layer.color, opacity: 1 }}
+                      initial={reducedMotion ? false : collapsed}
+                      animate={{
+                        width: fullDiameter,
+                        height: fullDiameter,
+                        x: "-50%",
+                        y: "-50%",
+                      }}
+                      exit={collapsed}
+                      transition={
+                        reducedMotion ? { duration: 0 } : LAYER_GROW_TRANSITION
+                      }
+                    />
+                  );
+                })}
+              </AnimatePresence>
 
               {/* Exit morph: the stack crossfades to water-blue while it
                   shrinks, so the droplet matches the tub's faucet drip */}
@@ -423,24 +386,46 @@ export function NationEmissionsJourney({
               )}
 
               {/* Running total on top – white on the dark backdrop until the
-                  innermost circle has grown large enough to sit behind it */}
+                  innermost circle has grown large enough to sit behind it.
+                  Before the section pins, a pulsing seed dot waits where the
+                  first layer will grow, instead of a stranded number. */}
               <div
                 className="absolute inset-0 flex items-center justify-center"
                 style={{ opacity: exitFade }}
               >
-                <motion.span
-                  initial={false}
-                  animate={{ color: totalOnLayer ? "#000000" : "#ffffff" }}
-                  transition={{ duration: 0.3 }}
-                  className={`${NATION_STORY_TYPE.stat} font-medium select-none leading-none text-center`}
-                >
-                  {formatMton(current.total, currentLanguage, 0)}
-                  <span
-                    className={`block ${NATION_STORY_TYPE.meta} font-medium mt-0.5 md:mt-1`}
+                {sectionStarted ? (
+                  <motion.span
+                    initial={false}
+                    animate={{ color: totalOnLayer ? "#000000" : "#ffffff" }}
+                    transition={{ duration: 0.3 }}
+                    className={`${NATION_STORY_TYPE.stat} font-medium select-none leading-none text-center`}
                   >
-                    {t("nation.story.unit.mton")}
-                  </span>
-                </motion.span>
+                    {formatMton(current.total, currentLanguage, 0)}
+                    <span
+                      className={`block ${NATION_STORY_TYPE.meta} font-medium mt-0.5 md:mt-1`}
+                    >
+                      {t("nation.story.unit.mton")}
+                    </span>
+                  </motion.span>
+                ) : (
+                  <motion.span
+                    aria-hidden
+                    className="block w-3.5 h-3.5 rounded-full"
+                    style={{
+                      backgroundColor: NATION_STORY_COLORS.territorial,
+                    }}
+                    animate={
+                      reducedMotion
+                        ? undefined
+                        : { scale: [1, 1.35, 1], opacity: [0.7, 1, 0.7] }
+                    }
+                    transition={{
+                      repeat: Infinity,
+                      duration: 1.8,
+                      ease: "easeInOut",
+                    }}
+                  />
+                )}
               </div>
 
               {/* The step's own contribution sits just off the current circle's
@@ -482,11 +467,29 @@ export function NationEmissionsJourney({
               )}
             </div>
 
+            {/* Data note under the bubble: compact on mobile, full sentence
+                on desktop. Appears with the first layer, not before. */}
             <p
               className={`${NATION_STORY_TYPE.meta} ${NATION_STORY_TEXT.secondary} mt-1 md:mt-10`}
               style={{ opacity: exitFade }}
             >
-              {t("nation.story.journey.dataYear", { year: metrics.latestYear })}
+              <motion.span
+                className="block"
+                initial={false}
+                animate={{ opacity: sectionStarted ? 1 : 0 }}
+                transition={{ duration: 0.4 }}
+              >
+                <span className="md:hidden">
+                  {t("nation.story.journey.dataYearShort", {
+                    year: metrics.latestYear,
+                  })}
+                </span>
+                <span className="hidden md:inline">
+                  {t("nation.story.journey.dataYear", {
+                    year: metrics.latestYear,
+                  })}
+                </span>
+              </motion.span>
             </p>
           </div>
 
@@ -495,21 +498,28 @@ export function NationEmissionsJourney({
             className="space-y-2.5 md:space-y-4 order-2 min-h-0"
             style={{ opacity: exitFade }}
           >
+            {/* Hidden (but space-keeping) until the section pins, so the
+                label and copy arrive together with the growing circle */}
             <motion.div
               key={current.key}
               initial={{ opacity: 0, y: 12 }}
-              animate={{ opacity: 1, y: 0 }}
+              animate={{
+                opacity: sectionStarted ? 1 : 0,
+                y: sectionStarted ? 0 : 12,
+              }}
               transition={{ duration: 0.4 }}
               className="space-y-2 md:space-y-3"
             >
               <p
-                className={`${NATION_STORY_TYPE.eyebrow} ${NATION_STORY_TEXT.eyebrow}`}
+                className={`hidden md:block ${NATION_STORY_TYPE.eyebrow} ${NATION_STORY_TEXT.eyebrow}`}
               >
                 {t("nation.story.journey.stepCounter", {
                   current: step + 1,
                   total: steps.length,
                 })}
               </p>
+              {/* Dot + label lead the paragraph they describe – on mobile this
+                  sits right under the onion, on desktop in the caption column */}
               <p
                 className={`flex items-center gap-2.5 md:gap-3 ${NATION_STORY_TYPE.emphasis} text-white`}
               >
@@ -527,42 +537,41 @@ export function NationEmissionsJourney({
             </motion.div>
 
             {/* Running tally: builds up row by row, with a summed total line.
-                Hidden while there is only one layer (it would just repeat the header). */}
+                Desktop only – on mobile the bubble (chip + center total)
+                already carries these numbers. Hidden while there is only one
+                layer (it would just repeat the header). */}
             {revealedLayers.length >= 2 && (
-              <div className="space-y-1 border-t border-white/10 pt-2 md:pt-3">
-                {steps
-                  .slice(0, step + 1)
-                  .filter((s) => s.layer || s.ring)
-                  .map((s, i) => (
-                    <motion.div
-                      key={s.key}
-                      initial={{ opacity: 0, x: -10 }}
-                      animate={{ opacity: 1, x: 0 }}
-                      transition={{ duration: 0.35, delay: 0.1 }}
-                      className={`flex items-center gap-2 md:gap-2.5 ${NATION_STORY_TYPE.meta}`}
+              <div className="hidden md:block space-y-1 border-t border-white/10 pt-2 md:pt-3">
+                {steps.slice(0, step + 1).map((s, i) => (
+                  <motion.div
+                    key={s.key}
+                    initial={{ opacity: 0, x: -10 }}
+                    animate={{ opacity: 1, x: 0 }}
+                    transition={{ duration: 0.35, delay: 0.1 }}
+                    className={`flex items-center gap-2 md:gap-2.5 ${NATION_STORY_TYPE.meta}`}
+                  >
+                    <span
+                      className="w-2.5 h-2.5 md:w-3.5 md:h-3.5 rounded-full shrink-0"
+                      style={{
+                        backgroundColor: s.color,
+                      }}
+                    />
+                    <span className={`${NATION_STORY_TEXT.secondary} flex-1`}>
+                      {t(s.labelKey)}
+                    </span>
+                    <span
+                      className={`${NATION_STORY_TEXT.secondary} tabular-nums shrink-0`}
                     >
-                      <span
-                        className="w-2.5 h-2.5 md:w-3.5 md:h-3.5 rounded-full shrink-0"
-                        style={{
-                          backgroundColor: s.ring ? "#ffffff" : s.color,
-                        }}
-                      />
-                      <span className={`${NATION_STORY_TEXT.secondary} flex-1`}>
-                        {t(s.labelKey)}
-                      </span>
-                      <span
-                        className={`${NATION_STORY_TEXT.secondary} tabular-nums shrink-0`}
-                      >
-                        {i === 0 ? "" : "+"}
-                        {formatMton(
-                          s.delta,
-                          currentLanguage,
-                          deltaDecimals(s.delta),
-                        )}{" "}
-                        {t("nation.story.unit.mton")}
-                      </span>
-                    </motion.div>
-                  ))}
+                      {i === 0 ? "" : "+"}
+                      {formatMton(
+                        s.delta,
+                        currentLanguage,
+                        deltaDecimals(s.delta),
+                      )}{" "}
+                      {t("nation.story.unit.mton")}
+                    </span>
+                  </motion.div>
+                ))}
                 <div
                   className={`flex items-center gap-2 md:gap-2.5 border-t border-white/10 pt-1.5 mt-1.5 ${NATION_STORY_TYPE.meta} text-white font-medium`}
                 >

--- a/src/components/nation/story/NationIntroPunch.tsx
+++ b/src/components/nation/story/NationIntroPunch.tsx
@@ -1,11 +1,6 @@
-import { useId, useRef } from "react";
+import { useId } from "react";
 import { useTranslation } from "react-i18next";
-import {
-  motion,
-  useReducedMotion,
-  useScroll,
-  useTransform,
-} from "framer-motion";
+import { motion, useReducedMotion } from "framer-motion";
 import {
   formatMton,
   type NationStoryMetrics,
@@ -74,11 +69,13 @@ function StatCallout({
       </p>
       <p className={`${NATION_STORY_TYPE.display} ${colorClass}`}>
         {value}{" "}
+        {/* Unit below the number on mobile (symmetric columns, same format
+            as the onion total), inline written-out on desktop */}
         <span
-          className={`${NATION_STORY_TYPE.meta} ${NATION_STORY_TEXT.secondary} font-normal align-baseline`}
+          className={`block mt-1 md:mt-0 md:inline ${NATION_STORY_TYPE.meta} ${NATION_STORY_TEXT.secondary} font-normal align-baseline`}
         >
-          <span className="md:hidden">{unitShort}</span>
-          <span className="hidden md:inline">{unitLong}</span>
+          <span className="md:hidden whitespace-nowrap">{unitShort}</span>
+          <span className="hidden md:inline whitespace-nowrap">{unitLong}</span>
         </span>
       </p>
     </motion.div>
@@ -97,7 +94,6 @@ export function NationIntroPunch({ metrics }: NationIntroPunchProps) {
   const { t } = useTranslation();
   const { currentLanguage } = useLanguage();
   const reducedMotion = useReducedMotion();
-  const rootRef = useRef<HTMLDivElement>(null);
   const clipId = `sweden-fill-clip-${useId().replace(/:/g, "")}`;
 
   const reportedValue = metrics.territorialLatestMton;
@@ -109,33 +105,15 @@ export function NationIntroPunch({ metrics }: NationIntroPunchProps) {
   const unitShort = t("nation.story.unit.mtonCo2e");
   const unitLong = t("nation.story.unit.millionTco2e");
 
-  // Scroll-lerped drain: as the hero scrolls out, the orange fill sinks back
-  // down and empties – one scroll later the onion's first orange circle grows
-  // from zero, so the reported share visually pours from the map into it.
-  // Pushing the clipped fill group down reads as the level draining; it
-  // composes with the one-shot rise (attribute animation vs transform) and
-  // refills when scrolling back up.
-  const { scrollYProgress: drainProgress } = useScroll({
-    target: rootRef,
-    offset: ["end 85%", "end 25%"],
-  });
-  const drainDistance = OUTLINE_BOTTOM - fillTop + 6;
-  const drainY = useTransform(
-    drainProgress,
-    [0, 1],
-    reducedMotion ? [0, 0] : [0, drainDistance],
-  );
-
   return (
     <motion.div
-      ref={rootRef}
       initial={{ opacity: 0, y: 12 }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true, amount: 0.35 }}
       transition={{ duration: 0.45 }}
       className="flex flex-col md:flex-row items-center justify-center gap-5 md:gap-10 lg:gap-14"
     >
-      <div className="relative h-[clamp(180px,32svh,300px)] md:h-[clamp(240px,40svh,420px)] aspect-[100/220]">
+      <div className="relative h-[clamp(220px,41svh,400px)] md:h-[clamp(260px,44svh,460px)] aspect-[100/220]">
         <svg
           viewBox={SWEDEN_OUTLINE_VIEWBOX}
           className="h-full w-auto max-w-full mx-auto"
@@ -159,47 +137,45 @@ export function NationIntroPunch({ metrics }: NationIntroPunchProps) {
 
           {/* Reported share rises like water inside the silhouette */}
           <g clipPath={svgLocalUrl(clipId)}>
-            <motion.g style={{ y: drainY }}>
-              <motion.rect
-                x={0}
-                width={100}
-                fill={NATION_STORY_COLORS.territorial}
-                initial={
-                  reducedMotion
-                    ? { y: fillTop, height: OUTLINE_BOTTOM - fillTop + 6 }
-                    : { y: OUTLINE_BOTTOM, height: 0 }
-                }
-                whileInView={{
-                  y: fillTop,
-                  height: OUTLINE_BOTTOM - fillTop + 6,
-                }}
-                viewport={{ once: true, amount: 0.35 }}
-                transition={
-                  reducedMotion
-                    ? { duration: 0 }
-                    : { ...FILL_SPRING, delay: 0.35 }
-                }
-              />
-              <motion.line
-                x1={0}
-                x2={100}
-                stroke="var(--orange-1)"
-                strokeWidth="1"
-                strokeOpacity="0.8"
-                initial={
-                  reducedMotion
-                    ? { y1: fillTop, y2: fillTop, opacity: 1 }
-                    : { y1: OUTLINE_BOTTOM, y2: OUTLINE_BOTTOM, opacity: 0 }
-                }
-                whileInView={{ y1: fillTop, y2: fillTop, opacity: 1 }}
-                viewport={{ once: true, amount: 0.35 }}
-                transition={
-                  reducedMotion
-                    ? { duration: 0 }
-                    : { ...FILL_SPRING, delay: 0.35 }
-                }
-              />
-            </motion.g>
+            <motion.rect
+              x={0}
+              width={100}
+              fill={NATION_STORY_COLORS.territorial}
+              initial={
+                reducedMotion
+                  ? { y: fillTop, height: OUTLINE_BOTTOM - fillTop + 6 }
+                  : { y: OUTLINE_BOTTOM, height: 0 }
+              }
+              whileInView={{
+                y: fillTop,
+                height: OUTLINE_BOTTOM - fillTop + 6,
+              }}
+              viewport={{ once: true, amount: 0.35 }}
+              transition={
+                reducedMotion
+                  ? { duration: 0 }
+                  : { ...FILL_SPRING, delay: 0.35 }
+              }
+            />
+            <motion.line
+              x1={0}
+              x2={100}
+              stroke="var(--orange-1)"
+              strokeWidth="1"
+              strokeOpacity="0.8"
+              initial={
+                reducedMotion
+                  ? { y1: fillTop, y2: fillTop, opacity: 1 }
+                  : { y1: OUTLINE_BOTTOM, y2: OUTLINE_BOTTOM, opacity: 0 }
+              }
+              whileInView={{ y1: fillTop, y2: fillTop, opacity: 1 }}
+              viewport={{ once: true, amount: 0.35 }}
+              transition={
+                reducedMotion
+                  ? { duration: 0 }
+                  : { ...FILL_SPRING, delay: 0.35 }
+              }
+            />
           </g>
         </svg>
       </div>
@@ -207,7 +183,7 @@ export function NationIntroPunch({ metrics }: NationIntroPunchProps) {
       {/* Full/pink callout beside the upper region, reported/orange beside the fill */}
       <div className="flex flex-row md:flex-col items-center md:items-start justify-center gap-8 md:gap-10">
         <StatCallout
-          label={t("nation.story.conclusion.fullLabel")}
+          label={t("nation.story.intro.fullLabel")}
           value={full}
           unitShort={unitShort}
           unitLong={unitLong}
@@ -216,7 +192,7 @@ export function NationIntroPunch({ metrics }: NationIntroPunchProps) {
           className="order-2 md:order-1"
         />
         <StatCallout
-          label={t("nation.story.conclusion.usualLabel")}
+          label={t("nation.story.intro.usualLabel")}
           value={reported}
           unitShort={unitShort}
           unitLong={unitLong}

--- a/src/components/nation/story/NationStackedChart.tsx
+++ b/src/components/nation/story/NationStackedChart.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo } from "react";
+import { FC, useEffect, useMemo, useRef, useState } from "react";
 import {
   Area,
   AreaChart,
@@ -8,7 +8,7 @@ import {
   YAxis,
 } from "recharts";
 import { useTranslation } from "react-i18next";
-import { motion } from "framer-motion";
+import { AnimatePresence, motion } from "framer-motion";
 import {
   formatMton,
   NATION_BASELINE_YEAR,
@@ -25,12 +25,16 @@ import {
 } from "@/components/nation/story/nationStoryColors";
 import { usePinnedSteps } from "@/components/nation/story/usePinnedSteps";
 
-/** Story chart needs room for Y ticks; shared chart margins are negative and clip them. */
+/**
+ * Mobile runs the plot edge-to-edge so it lines up with the heading and copy
+ * (the Y labels mirror inside the plot instead of reserving a gutter).
+ * Desktop keeps room for the outside axis + rotated unit label.
+ */
 function getStoryChartMargin(isMobile: boolean) {
   return {
     top: 8,
-    right: isMobile ? 4 : 12,
-    left: isMobile ? 4 : 20,
+    right: isMobile ? 0 : 12,
+    left: isMobile ? 0 : 20,
     bottom: 0,
   };
 }
@@ -62,6 +66,9 @@ const LAYERS = [
   },
 ];
 
+/** Shorter than the 90vh default so the reveal is quicker to scroll through. */
+const STACKED_STEP_VH = 70;
+
 interface NationStackedChartProps {
   data: NationStackDataPoint[];
   className?: string;
@@ -75,18 +82,111 @@ export const NationStackedChart: FC<NationStackedChartProps> = ({
   const { currentLanguage } = useLanguage();
   const { isMobile } = useScreenSize();
   const latestYear = data.at(-1)?.year ?? NATION_BASELINE_YEAR;
+  // Mobile skips 2020: it sits so close to the latest year that recharts
+  // drops one of the colliding labels, leaving uneven spacing.
   const xAxisTicks = useMemo(() => {
-    const ticks = [1990, 2000, 2010, 2020];
+    const ticks = isMobile ? [1990, 2000, 2010] : [1990, 2000, 2010, 2020];
     if (latestYear > 2020) ticks.push(latestYear);
     return ticks;
-  }, [latestYear]);
+  }, [latestYear, isMobile]);
 
   // Scroll-driven: each step reveals one more area layer.
-  const { ref, step, sectionVh, stageStyle } = usePinnedSteps(LAYERS.length);
+  const { ref, step, sectionVh, stageStyle } = usePinnedSteps(
+    LAYERS.length,
+    STACKED_STEP_VH,
+  );
   const visibleLayers = step + 1;
 
+  // Mobile has no floating tooltip (it covers the chart); instead the legend
+  // becomes a readout while the reader scrubs a finger across the chart,
+  // showing that year's stacking arithmetic (47, +4, +60, +48 = total). It
+  // lingers briefly after the finger lifts, then returns to names-only.
+  const [scrubYear, setScrubYear] = useState<number | null>(null);
+  const scrubClearRef = useRef<number | null>(null);
   const latestPoint = data.at(-1);
-  const chartHeight = isMobile ? 190 : 330;
+  const scrubbing = isMobile && scrubYear !== null;
+  const readoutYear = scrubYear ?? latestYear;
+  const readoutPoint =
+    data.find((point) => point.year === readoutYear) ?? latestPoint;
+  const readoutTotal = LAYERS.slice(0, visibleLayers).reduce(
+    (sum, layer) => sum + (readoutPoint?.[layer.dataKey] ?? 0),
+    0,
+  );
+  const handleScrub = ({ activeLabel }: { activeLabel?: string | number }) => {
+    const year = Number(activeLabel);
+    if (!Number.isFinite(year)) return;
+    setScrubYear(year);
+    if (scrubClearRef.current) window.clearTimeout(scrubClearRef.current);
+    scrubClearRef.current = window.setTimeout(() => setScrubYear(null), 2500);
+  };
+  useEffect(
+    () => () => {
+      if (scrubClearRef.current) window.clearTimeout(scrubClearRef.current);
+    },
+    [],
+  );
+
+  // Height caps at 32svh so short phones (~570-670px tall) still fit the
+  // title, caption, chart and legend inside the pinned stage.
+  const chartHeight = isMobile ? "min(240px, 32svh)" : 330;
+  const activeLayer = LAYERS[visibleLayers - 1];
+
+  // Full-bleed mobile plot: the edge ticks anchor inward so "1990" and the
+  // latest year don't clip at the svg boundary.
+  const edgeAwareTick = ({
+    x,
+    y,
+    payload,
+  }: {
+    x: number;
+    y: number;
+    payload: { value: number };
+  }) => {
+    const anchor =
+      payload.value === NATION_BASELINE_YEAR
+        ? "start"
+        : payload.value === latestYear
+          ? "end"
+          : "middle";
+    return (
+      <text
+        x={x}
+        y={y + 10}
+        textAnchor={anchor}
+        fontSize={10}
+        fill="var(--grey)"
+      >
+        {payload.value}
+      </text>
+    );
+  };
+
+  // Mirrored Y labels paint above the fills (the axis is declared after the
+  // areas), so plain sharp white text is enough. The 0 tick is skipped – the
+  // baseline explains itself.
+  const mirroredYAxisTick = ({
+    x,
+    y,
+    payload,
+  }: {
+    x: number;
+    y: number;
+    payload: { value: number };
+  }) => {
+    if (payload.value === 0) return <g />;
+    return (
+      <text
+        x={x + 2}
+        y={y + 4}
+        textAnchor="start"
+        fontSize={11}
+        fontWeight={600}
+        fill="#ffffff"
+      >
+        {formatMton(payload.value, currentLanguage, 0)}
+      </text>
+    );
+  };
 
   return (
     <section
@@ -94,7 +194,7 @@ export const NationStackedChart: FC<NationStackedChartProps> = ({
       data-story-section
       data-story-step={step}
       data-story-steps={LAYERS.length}
-      data-story-step-vh={90}
+      data-story-step-vh={STACKED_STEP_VH}
       className="relative"
       style={{ height: `${sectionVh}vh` }}
     >
@@ -108,8 +208,9 @@ export const NationStackedChart: FC<NationStackedChartProps> = ({
           className="absolute inset-0 bg-[radial-gradient(ellipse_70%_55%_at_50%_45%,var(--black-2)_0%,var(--black-3)_78%)]"
         />
         <div className={`relative w-full max-w-4xl mx-auto ${className ?? ""}`}>
+          {/* Mobile relies on the step dots for progress instead */}
           <p
-            className={`${NATION_STORY_TYPE.eyebrow} ${NATION_STORY_TEXT.eyebrow} mb-2 md:mb-3`}
+            className={`hidden md:block ${NATION_STORY_TYPE.eyebrow} ${NATION_STORY_TEXT.eyebrow} mb-2 md:mb-3`}
           >
             {t("nation.story.stacked.layerCounter", {
               current: visibleLayers,
@@ -120,39 +221,128 @@ export const NationStackedChart: FC<NationStackedChartProps> = ({
             {t("nation.story.stacked.title")}
           </h2>
 
-          {/* Caption explaining the layer currently being drawn */}
-          <div className="min-h-[2rem] md:min-h-[2.5rem] mb-2 md:mb-4">
+          {/* Caption explaining the layer currently being drawn – meta scale
+              like the legend rows (it runs several lines on mobile, where the
+              step-header emphasis style reads too heavy), dot on line one */}
+          {/* Sized for the longest caption (3 lines mobile) so the chart
+              below doesn't shift vertically as the step captions swap */}
+          <div className="min-h-[3.75rem] md:min-h-[2.5rem] mb-2 md:mb-4">
             <motion.p
               key={visibleLayers}
               initial={{ opacity: 0, y: 6 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.4 }}
-              className={`flex items-center gap-2 md:gap-3 ${NATION_STORY_TYPE.emphasis} text-white`}
+              className={`flex items-start gap-2 md:gap-3 ${NATION_STORY_TYPE.meta} text-white`}
             >
               <span
-                className="w-3 h-3 md:w-4 md:h-4 rounded-full shrink-0"
+                className="w-2.5 h-2.5 md:w-3.5 md:h-3.5 rounded-full shrink-0 mt-1 md:mt-1.5"
                 style={{ backgroundColor: LAYERS[visibleLayers - 1].color }}
               />
               {t(LAYERS[visibleLayers - 1].captionKey)}
             </motion.p>
           </div>
 
-          <div style={{ width: "100%", height: chartHeight }}>
+          {/* Mobile has no rotated axis label, so state the unit here */}
+          {isMobile && (
+            <p
+              className={`${NATION_STORY_TYPE.meta} ${NATION_STORY_TEXT.secondary} mb-1`}
+            >
+              {t("nation.story.unit.mtonCo2e")}
+            </p>
+          )}
+          <div
+            className="relative"
+            style={{ width: "100%", height: chartHeight }}
+          >
+            {/* Soft glow behind the chart in the active layer's color – the
+                same cue the onion scene uses when a new layer grows */}
+            <AnimatePresence>
+              <motion.div
+                key={`glow-${activeLayer.color}`}
+                aria-hidden
+                className="absolute inset-x-6 inset-y-2 rounded-full blur-3xl pointer-events-none"
+                style={{ backgroundColor: activeLayer.color }}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 0.12 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.8 }}
+              />
+            </AnimatePresence>
             <ResponsiveContainer width="100%" height="100%">
-              <AreaChart data={data} margin={getStoryChartMargin(isMobile)}>
+              <AreaChart
+                data={data}
+                margin={getStoryChartMargin(isMobile)}
+                {...(isMobile
+                  ? { onMouseMove: handleScrub, onTouchMove: handleScrub }
+                  : {})}
+              >
                 <XAxis
                   {...getXAxisProps(
                     "year",
                     [NATION_BASELINE_YEAR, latestYear],
                     xAxisTicks,
+                    isMobile ? edgeAwareTick : undefined,
                   )}
+                  // Render every hand-picked tick: recharts' collision culling
+                  // assumes centered labels and drops the edge-anchored 1990
+                  interval={0}
                 />
+                {/* Mobile keeps the vertical cursor line for scrub feedback but
+                    renders no tooltip box – the legend below is the readout. */}
+                <Tooltip
+                  content={
+                    isMobile ? (
+                      () => null
+                    ) : (
+                      <ChartTooltip
+                        unit={t("nation.story.unit.mton")}
+                        customFormatter={(value) =>
+                          formatMton(value, currentLanguage, 1)
+                        }
+                      />
+                    )
+                  }
+                  cursor={{ stroke: "var(--grey)", strokeDasharray: "4 4" }}
+                  wrapperStyle={{ outline: "none", zIndex: 60 }}
+                />
+                {LAYERS.slice(0, visibleLayers).map((layer, index) => (
+                  <Area
+                    key={layer.dataKey}
+                    type="monotone"
+                    dataKey={layer.dataKey}
+                    stackId="emissions"
+                    stroke={layer.color}
+                    strokeWidth={NATION_STORY_CHART.strokeWidth}
+                    fill={layer.color}
+                    // Newest layer carries the emphasis; earlier ones recede
+                    fillOpacity={
+                      index === visibleLayers - 1
+                        ? NATION_STORY_CHART.fillOpacity
+                        : NATION_STORY_CHART.fillOpacity * 0.8
+                    }
+                    name={t(layer.translationKey)}
+                    connectNulls={false}
+                    isAnimationActive
+                    animationDuration={1000}
+                    animationEasing="ease-out"
+                  />
+                ))}
+                {/* Declared after the areas: recharts paints children in
+                    order, and the mirrored mobile labels sit inside the plot
+                    – earlier in the tree they'd be buried under the fills. */}
                 <YAxis
                   stroke="var(--grey)"
                   tickLine={false}
                   axisLine={false}
+                  // Mirrored on mobile: labels sit inside the plot, so the
+                  // chart spans the full text column width without a gutter
+                  mirror={isMobile}
                   width={isMobile ? 36 : 56}
-                  tick={{ fill: "var(--grey)", fontSize: isMobile ? 10 : 12 }}
+                  tick={
+                    isMobile
+                      ? mirroredYAxisTick
+                      : { fill: "var(--grey)", fontSize: 12 }
+                  }
                   tickFormatter={(value: number) =>
                     formatMton(value, currentLanguage, 0)
                   }
@@ -172,43 +362,33 @@ export const NationStackedChart: FC<NationStackedChartProps> = ({
                       }
                     : {})}
                 />
-                <Tooltip
-                  content={
-                    <ChartTooltip
-                      unit={t("nation.story.unit.mton")}
-                      customFormatter={(value) =>
-                        formatMton(value, currentLanguage, 1)
-                      }
-                    />
-                  }
-                  wrapperStyle={{ outline: "none", zIndex: 60 }}
-                />
-                {LAYERS.slice(0, visibleLayers).map((layer) => (
-                  <Area
-                    key={layer.dataKey}
-                    type="monotone"
-                    dataKey={layer.dataKey}
-                    stackId="emissions"
-                    stroke={layer.color}
-                    strokeWidth={NATION_STORY_CHART.strokeWidth}
-                    fill={layer.color}
-                    fillOpacity={NATION_STORY_CHART.fillOpacity}
-                    name={t(layer.translationKey)}
-                    connectNulls={false}
-                    isAnimationActive
-                    animationDuration={1000}
-                    animationEasing="ease-out"
-                  />
-                ))}
               </AreaChart>
             </ResponsiveContainer>
           </div>
 
-          {/* Legend in the story's own styling: revealed layers inline,
-              each with its latest-year contribution */}
+          {/* Legend in the story's own styling. At rest it is names only; on
+              mobile, scrubbing the chart turns it into a readout showing the
+              scrubbed year's stacking arithmetic with a summed total. Desktop
+              keeps the hover tooltip for values. */}
           <div className="mt-3 md:mt-5 border-t border-white/10 pt-2.5 md:pt-3 space-y-1.5 md:space-y-2">
-            <div className="flex flex-wrap items-center gap-x-5 md:gap-x-8 gap-y-1.5">
-              {LAYERS.slice(0, visibleLayers).map((layer) => (
+            {/* Same slot: an invitation to scrub at rest, the scrubbed year
+                while the finger is on the chart */}
+            {isMobile &&
+              (scrubbing ? (
+                <p className={`${NATION_STORY_TYPE.meta}`}>
+                  <span className="text-white tabular-nums font-medium">
+                    {readoutYear}
+                  </span>
+                </p>
+              ) : (
+                <p
+                  className={`${NATION_STORY_TYPE.meta} ${NATION_STORY_TEXT.secondary}`}
+                >
+                  {t("nation.story.stacked.scrubHint")}
+                </p>
+              ))}
+            <div className="flex flex-col gap-y-1.5 md:flex-row md:flex-wrap md:items-center md:gap-x-8">
+              {LAYERS.slice(0, visibleLayers).map((layer, index) => (
                 <motion.span
                   key={layer.dataKey}
                   initial={{ opacity: 0, y: 6 }}
@@ -223,17 +403,29 @@ export const NationStackedChart: FC<NationStackedChartProps> = ({
                   <span className={NATION_STORY_TEXT.secondary}>
                     {t(layer.translationKey)}
                   </span>
-                  <span className="text-white tabular-nums">
-                    {formatMton(
-                      latestPoint?.[layer.dataKey] ?? 0,
-                      currentLanguage,
-                      0,
-                    )}{" "}
-                    {t("nation.story.unit.mton")}
-                  </span>
+                  {scrubbing && (
+                    <span className="ml-auto text-white tabular-nums">
+                      {index === 0 ? "" : "+"}
+                      {formatMton(
+                        readoutPoint?.[layer.dataKey] ?? 0,
+                        currentLanguage,
+                        0,
+                      )}
+                    </span>
+                  )}
                 </motion.span>
               ))}
             </div>
+            {scrubbing && visibleLayers > 1 && (
+              <p
+                className={`flex items-center justify-between border-t border-white/10 pt-1.5 ${NATION_STORY_TYPE.meta} text-white font-medium`}
+              >
+                <span>{t("nation.story.journey.totalLabel")}</span>
+                <span className="tabular-nums">
+                  {formatMton(readoutTotal, currentLanguage, 0)}
+                </span>
+              </p>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/nation/story/NationStoryPage.tsx
+++ b/src/components/nation/story/NationStoryPage.tsx
@@ -160,22 +160,18 @@ export function NationStoryPage({
     <div className="bg-black text-white pb-10 md:pb-24">
       <StoryProgressBar />
 
-      {/* Intro hero – exactly one viewport: eyebrow, headline, lede, silhouette */}
+      {/* Intro hero – one landing view: eyebrow, headline and lede up top,
+          then the silhouette with callouts, then the explanation paragraphs. */}
       <section
         data-story-section
-        className="relative min-h-[100svh] md:h-[100svh] flex flex-col items-center justify-center px-4 md:px-8 pt-6 md:pt-10 pb-28 md:pb-20 overflow-hidden"
+        className="relative min-h-[100svh] flex flex-col items-center justify-start px-4 md:px-8 pt-[clamp(4.5rem,17svh,9rem)] md:pt-44 pb-28 md:pb-20 overflow-hidden"
       >
         {/* Subtle depth behind the hero, using existing surface colors only */}
         <div
           aria-hidden
           className="absolute inset-0 bg-[radial-gradient(ellipse_70%_55%_at_50%_38%,var(--black-2)_0%,var(--black-3)_78%)]"
         />
-        <div className="relative max-w-5xl mx-auto text-center space-y-4 md:space-y-6">
-          <p
-            className={`${NATION_STORY_TYPE.eyebrow} ${NATION_STORY_TEXT.eyebrow}`}
-          >
-            {t("nation.story.intro.eyebrow")}
-          </p>
+        <div className="relative max-w-5xl mx-auto text-center space-y-2.5 md:space-y-4">
           <h1 className="text-4xl md:text-6xl font-light tracking-tight text-white">
             {t("nation.story.intro.title")}
           </h1>
@@ -184,35 +180,10 @@ export function NationStoryPage({
           >
             {t("nation.story.intro.paragraph1")}
           </p>
-          <NationIntroPunch metrics={metrics} />
-        </div>
-      </section>
-
-      {/* Short transition: the explanation that follows the hero's punch.
-          Mobile keeps this tight – big min-heights read as empty black. */}
-      <section
-        data-story-section
-        className="relative min-h-[35vh] md:min-h-[70vh] flex items-center justify-center px-4 md:px-8 py-12 md:py-16"
-      >
-        <div className="max-w-2xl mx-auto text-center space-y-5 md:space-y-6">
-          <motion.p
-            initial={{ opacity: 0, y: 16 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true, amount: 0.5 }}
-            transition={{ duration: 0.5 }}
-            className={`${NATION_STORY_TYPE.body} ${NATION_STORY_TEXT.body}`}
-          >
-            {t("nation.story.intro.paragraph2")}
-          </motion.p>
-          <motion.p
-            initial={{ opacity: 0, y: 16 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true, amount: 0.5 }}
-            transition={{ duration: 0.5, delay: 0.1 }}
-            className={`${NATION_STORY_TYPE.emphasis} text-white`}
-          >
-            {t("nation.story.intro.paragraph3")}
-          </motion.p>
+          {/* Extra breathing room between the copy and the map */}
+          <div className="pt-6 md:pt-10">
+            <NationIntroPunch metrics={metrics} />
+          </div>
         </div>
       </section>
 
@@ -225,21 +196,12 @@ export function NationStoryPage({
       {/* Mid-story conclusion before the stacked historic chart */}
       <FullScreenSection>
         <div className="max-w-2xl mx-auto text-center space-y-6">
-          <motion.p
-            initial={{ opacity: 0, y: 12 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true, amount: 0.5 }}
-            transition={{ duration: 0.4 }}
-            className={`${NATION_STORY_TYPE.eyebrow} ${NATION_STORY_TEXT.eyebrow}`}
-          >
-            {t("nation.story.interlude.eyebrow")}
-          </motion.p>
           <motion.h2
             initial={{ opacity: 0, y: 16 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true, amount: 0.5 }}
             transition={{ duration: 0.45, delay: 0.05 }}
-            className={`${NATION_STORY_TYPE.title} leading-tight`}
+            className={NATION_STORY_TYPE.title}
           >
             {t("nation.story.interlude.title")}
           </motion.h2>

--- a/src/components/nation/story/StoryScrollHint.tsx
+++ b/src/components/nation/story/StoryScrollHint.tsx
@@ -1,4 +1,4 @@
-import { useRef, type RefObject } from "react";
+import { useEffect, useRef, useState, type RefObject } from "react";
 import { ChevronDown } from "lucide-react";
 import { motion } from "framer-motion";
 import { useTranslation } from "react-i18next";
@@ -53,11 +53,28 @@ function scrollToNextStoryBeat() {
     const current = sections[currentIndex];
     const step = Number(current.dataset.storyStep ?? "0");
     const stepCount = Number(current.dataset.storySteps ?? "1");
-    const stepVh = Number(current.dataset.storyStepVh ?? "100");
+    // "floor" sections activate step n across [n, n+1) of the steps span;
+    // "round" sections (the bathtub) flip at segment midpoints.
+    const snap = current.dataset.storySnap ?? "floor";
 
     if (stepCount > 1 && step < stepCount - 1) {
-      window.scrollBy({
-        top: (stepVh / 100) * window.innerHeight,
+      // Compute the next step's position in the pinned hook's own
+      // coordinates (the pin distance loses one viewport height, so a
+      // relative scrollBy of the nominal step-vh overshoots – drifting
+      // toward span edges and even into exit-morph zones). Land mid-span
+      // for floor sections, on the exact milestone for round ones.
+      const rect = current.getBoundingClientRect();
+      const viewport = window.innerHeight;
+      const enterPx =
+        (Number(current.dataset.storyEnterVh ?? "0") / 100) * viewport;
+      const exitPx =
+        (Number(current.dataset.storyExitVh ?? "0") / 100) * viewport;
+      const stepsPx = Math.max(rect.height - viewport - enterPx - exitPx, 0);
+      const segments = snap === "round" ? stepCount - 1 : stepCount;
+      const stepPos = snap === "round" ? step + 1 : step + 1.5;
+      window.scrollTo({
+        top:
+          window.scrollY + rect.top + enterPx + (stepPos / segments) * stepsPx,
         behavior: "smooth",
       });
       return;
@@ -81,12 +98,37 @@ function scrollToNextStoryBeat() {
   window.scrollBy({ top: window.innerHeight * 0.85, behavior: "smooth" });
 }
 
-/** Fixed bounce chevron shown through the story until the conclusion. */
+/** Fixed pulsing chevron shown through the story until the conclusion. */
 export function StoryScrollHint({ endRef }: StoryScrollHintProps) {
   const { t } = useTranslation();
   const ref = useRef<HTMLButtonElement>(null);
   const endReached = useStoryEndReached(endRef);
-  const visible = !endReached;
+
+  // Hidden while the reader is actively scrolling/swiping – the hint is an
+  // idle-state affordance. Reappears shortly after the page settles.
+  const [scrolling, setScrolling] = useState(false);
+  const settleTimeoutRef = useRef<number | null>(null);
+  useEffect(() => {
+    const onScroll = () => {
+      setScrolling(true);
+      if (settleTimeoutRef.current) {
+        window.clearTimeout(settleTimeoutRef.current);
+      }
+      settleTimeoutRef.current = window.setTimeout(
+        () => setScrolling(false),
+        650,
+      );
+    };
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      if (settleTimeoutRef.current) {
+        window.clearTimeout(settleTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const visible = !endReached && !scrolling;
 
   return (
     <motion.button
@@ -97,26 +139,27 @@ export function StoryScrollHint({ endRef }: StoryScrollHintProps) {
       aria-hidden={!visible}
       tabIndex={visible ? 0 : -1}
       initial={false}
-      animate={
-        visible
-          ? { opacity: [0.4, 1, 0.4], y: [0, 12, 0] }
-          : { opacity: 0, y: 0 }
-      }
+      animate={visible ? { opacity: [0.35, 1, 0.35] } : { opacity: 0 }}
       transition={
         visible
           ? {
-              opacity: { repeat: Infinity, duration: 1.2, ease: "easeInOut" },
-              y: { repeat: Infinity, duration: 1.2, ease: "easeInOut" },
+              opacity: { repeat: Infinity, duration: 1.8, ease: "easeInOut" },
             }
           : { duration: 0.35 }
       }
-      className={`fixed inset-x-0 bottom-5 md:bottom-8 z-50 mx-auto flex w-fit items-center justify-center text-white drop-shadow-[0_2px_8px_rgba(0,0,0,0.9)] transition-colors hover:text-blue-2 ${visible ? "" : "pointer-events-none"}`}
+      className={`fixed inset-x-0 bottom-4 md:bottom-6 z-50 mx-auto flex w-fit flex-col items-center justify-center gap-0 text-white drop-shadow-[0_2px_8px_rgba(0,0,0,0.9)] transition-colors hover:text-blue-2 ${visible ? "" : "pointer-events-none"}`}
     >
       <ChevronDown
-        className="h-10 w-10 md:h-11 md:w-11"
-        strokeWidth={2.5}
+        className="h-6 w-6 md:h-7 md:w-7"
+        strokeWidth={2}
         aria-hidden
       />
+      <span className="text-[11px] md:text-xs font-medium tracking-wide">
+        <span className="md:hidden">{t("nation.story.scrollHint.swipe")}</span>
+        <span className="hidden md:inline">
+          {t("nation.story.scrollHint.scroll")}
+        </span>
+      </span>
     </motion.button>
   );
 }

--- a/src/components/nation/story/nationStoryColors.ts
+++ b/src/components/nation/story/nationStoryColors.ts
@@ -3,7 +3,7 @@ export const NATION_STORY_COLORS = {
   territorial: "var(--orange-3)",
   production: "var(--blue-2)",
   consumption: "var(--pink-3)",
-  eCommerceRing: "var(--pink-1)",
+  eCommerce: "#ffffff",
   biogenic: "var(--green-2)",
 } as const;
 
@@ -29,9 +29,9 @@ export const NATION_STORY_TEXT = {
  */
 export const NATION_STORY_TYPE = {
   /** Section titles (intro, interlude, conclusion, stacked chart) */
-  title: "text-3xl md:text-5xl font-light tracking-tight",
+  title: "text-3xl md:text-5xl font-light tracking-tight leading-tight",
   /** Narrative paragraphs and step body copy */
-  body: "text-base md:text-lg leading-relaxed",
+  body: "text-base md:text-lg leading-snug",
   /** Step/layer headers with color dots – same size as body, heavier weight */
   emphasis: "text-base md:text-lg font-medium",
   /** Eyebrows like “Conclusion” */

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1539,30 +1539,32 @@
       "intro": {
         "eyebrow": "Election 2026",
         "title": "Sweden's emissions",
-        "paragraph1": "We often hear that Sweden's emissions have fallen by a third while the economy has doubled. But is that really true?",
-        "paragraph2": "What we usually hear about are territorial emissions – fossil greenhouse gas emissions within Sweden's borders. It is the measure used to track Sweden's climate goals.",
-        "paragraph3": "But Sweden's emissions are actually larger than that. Let's look at it, step by step.",
+        "paragraph1": "We often hear that Sweden's emissions are small and that they have fallen by a third while the economy has doubled. But is that really true? Let's look at it, step by step.",
+        "usualLabel": "What we often hear about",
+        "fullLabel": "Sweden's actual emissions",
         "previewRatio": "larger than what we usually talk about"
       },
       "scrollHint": {
-        "text": "Scroll for more",
+        "scroll": "Scroll",
+        "swipe": "Swipe",
         "label": "Scroll down to the next part of the story"
       },
       "journey": {
-        "dataYear": "Figures refer to CO₂e and year {{year}}.",
+        "dataYear": "The figure refers to CO₂e and {{year}}.",
+        "dataYearShort": "CO₂e, year {{year}}",
         "stepCounter": "Step {{current}} of {{total}}",
         "totalLabel": "Total",
         "step1": {
           "label": "Territorial emissions",
-          "text": "First, we have emissions within Sweden's borders. This includes emissions from industry, domestic transport, agriculture, heating and waste, among other sources."
+          "text": "We start with the figure we hear about most often: territorial emissions – fossil emissions within Sweden's borders. This includes emissions from industry, transport, agriculture, heating and waste, among other sources. This measure is used to track our climate goals."
         },
         "step2": {
           "label": "Production-based emissions",
-          "text": "Production-based emissions are emissions from the Swedish economy. They are roughly equivalent to territorial emissions, but also include emissions from Swedish shipping in international waters and Swedish airlines in international airspace."
+          "text": "Production-based emissions are emissions from the Swedish economy. They are roughly equivalent to territorial emissions, but also include emissions from Swedish shipping companies and airlines abroad."
         },
         "step3": {
-          "label": "Consumption abroad",
-          "text": "But Swedes also cause emissions through our consumption abroad. This includes emissions from manufacturing and transport of imported goods for Swedish household consumption, public services and investments. Swedes' international flights are included here, but emissions from goods produced in Sweden and exported to other countries are excluded."
+          "label": "Consumption-based emissions abroad",
+          "text": "Swedes also cause emissions abroad through our consumption. This includes emissions from manufacturing and transport of imported goods for Swedish household consumption, public services and investments. Emissions from goods produced in Sweden and exported to other countries are excluded."
         },
         "step4": {
           "label": "Private e-commerce",
@@ -1570,27 +1572,25 @@
         },
         "step5": {
           "label": "Biogenic emissions",
-          "text": "Finally, there are biogenic carbon dioxide emissions released when wood and other biological material is burned – for example in district heating, the paper industry and cars using biofuels. Biogenic emissions are part of the natural cycle. However, it can take decades for new forest to absorb the same amount of carbon dioxide, which is why biogenic emissions also affect the climate here and now."
+          "text": "Finally, we have biogenic carbon dioxide emissions released when wood and other biological material is burned. In theory the carbon dioxide can be reabsorbed, for example when new trees are planted. However, it can take several decades for new forest to bind the same amount of carbon dioxide. That is why biogenic emissions also have a climate impact here and now."
         }
       },
       "bathtub": {
         "eyebrow": "The bathtub effect",
-        "text": "The atmosphere responds to the total amount of greenhouse gases – and they stay and accumulate over time. A bit like a bathtub with the tap running: until the tap is fully closed, the water level will keep rising. And the atmosphere has already passed the threshold for 1.5°C of warming. That is why it is crucially important how quickly we cut emissions toward zero.",
-        "question": "How has that gone since 1990?",
-        "waterCaptionPrefix": "Sweden has emitted a total of",
-        "waterCaptionSuffix": "since 1990",
+        "text": "The atmosphere responds to the amount of greenhouse gases – which stay and accumulate over time. Like a bathtub with the tap running: until the tap is turned off, the water level will keep rising. We have already passed 1.5°C of warming, and Sweden is approaching the point where we have emitted more than our commitment under the Paris Agreement. That is why how quickly we cut emissions is decisive.",
+        "question": "How has it gone since 1990?",
+        "waterCaptionPrefix": "Sweden has since 1990 emitted",
         "chunkCaptionSingleYear": "+{{value}} Mt CO₂e added in {{year}}",
         "chunkCaptionYearRange": "+{{value}} Mt CO₂e added {{fromYear}}–{{toYear}}"
       },
       "graph": {
-        "territorialFossil": "Territorial emissions",
+        "territorialFossil": "Territorial",
         "productionBased": "Production-based emissions",
-        "productionBeyondTerritorial": "Swedish shipping and aviation abroad",
-        "biogenic": "Biogenic emissions",
-        "consumptionAbroad": "Consumption-based emissions abroad"
+        "productionBeyondTerritorial": "Production-based",
+        "biogenic": "Biogenic",
+        "consumptionAbroad": "Consumption-based abroad"
       },
       "interlude": {
-        "eyebrow": "Insight",
         "title": "We only discuss part of Sweden's emissions",
         "body": "The usual figure we hear about gives an overly positive picture. When we also include other emissions that Sweden can influence, we get a more complete picture – one that tells a different story."
       },
@@ -1598,12 +1598,12 @@
         "layerCounter": "Layer {{current}} of {{total}}",
         "title": "Sweden's emissions since 1990",
         "layerCaption1": "First we have territorial emissions – fossil emissions within Sweden's borders.",
-        "layerCaption2": "Now we add emissions from Swedish shipping and aviation abroad – together with the territorial emissions, this makes up the production-based emissions.",
+        "layerCaption2": "Now we add emissions from Swedish shipping companies and airlines abroad – together with the territorial emissions, this gives us the production-based emissions.",
         "layerCaption3": "Then we add consumption-based emissions abroad, including private e-commerce imports.",
-        "layerCaption4": "And finally the biogenic emissions to show the full picture."
+        "layerCaption4": "And finally the biogenic emissions to show the full picture.",
+        "scrubHint": "Swipe across the chart to see values by year"
       },
       "conclusion": {
-        "eyebrow": "Conclusion",
         "title": "Sweden's emissions are larger than we think and have not fallen as much as we think",
         "usualLabel": "What we usually discuss",
         "fullLabel": "Sweden's actual emissions",

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -1589,30 +1589,32 @@
       "intro": {
         "eyebrow": "Valet 2026",
         "title": "Sveriges utsläpp",
-        "paragraph1": "Vi får ofta höra att Sveriges utsläpp minskat med en tredjedel samtidigt som ekonomin har fördubblats. Men stämmer det verkligen?",
-        "paragraph2": "Det vi oftast hör om är territoriella utsläpp, det vill säga fossila växthusgasutsläpp inom Sveriges gränser. Det är det måttet som används för att följa upp Sveriges klimatmål.",
-        "paragraph3": "Men Sveriges utsläpp är egentligen större än så. Låt oss titta på det, steg för steg.",
+        "paragraph1": "Vi får ofta höra att Sveriges utsläpp är små och att de minskat med en tredjedel samtidigt som ekonomin har fördubblats. Men stämmer det verkligen? Låt oss titta på det, steg för steg.",
+        "usualLabel": "Det vi ofta hör om",
+        "fullLabel": "Sveriges egentliga utsläpp",
         "previewRatio": "större än det vi brukar prata om"
       },
       "scrollHint": {
-        "text": "Scrolla för mer",
+        "scroll": "Scrolla",
+        "swipe": "Svep",
         "label": "Scrolla nedåt till nästa del av berättelsen"
       },
       "journey": {
-        "dataYear": "Siffrorna avser CO₂e och år {{year}}.",
+        "dataYear": "Siffran avser CO₂e och {{year}}.",
+        "dataYearShort": "CO₂e, år {{year}}",
         "stepCounter": "Steg {{current}} av {{total}}",
         "totalLabel": "Totalt",
         "step1": {
           "label": "Territoriella utsläpp",
-          "text": "Först har vi alltså utsläpp innanför Sveriges gränser. Här ingår bland annat utsläpp från industrin, inrikestransporter, jordbruk, uppvärmning och avfall."
+          "text": "Vi börjar med siffran vi oftast hör om: de territoriella utsläppen, fossila utsläpp inom Sveriges gränser. Här ingår bland annat utsläpp från industrin, transporter, jordbruk, uppvärmning och avfall. Detta mått används för att följa upp våra klimatmål."
         },
         "step2": {
           "label": "Produktionsbaserade utsläpp",
-          "text": "Med produktionsbaserade utsläpp menas utsläpp från den svenska ekonomin. Det är ungefär likvärdigt med de territoriella utsläppen, men omfattar också utsläpp från svenska rederier på internationellt vatten och svenska flygbolag i internationellt luftrum."
+          "text": "Med produktionsbaserade utsläpp menas utsläpp från den svenska ekonomin. Det är ungefär likvärdigt med de territoriella utsläppen, men omfattar också utsläpp från svenska rederier och flygbolag utomlands."
         },
         "step3": {
-          "label": "Konsumtion utomlands",
-          "text": "Men svenskar orsakar också utsläpp genom vår konsumtion utomlands. Här inkluderas utsläpp från tillverkning och transport av importerade varor till svensk hushållskonsumtion, offentlig verksamhet och investeringar. Svenskarnas utrikesflyg ingår här, men utsläpp från varor som produceras i Sverige men exporteras till andra länder räknas bort."
+          "label": "Konsumtionsbaserade utsläpp utomlands",
+          "text": "Svenskar orsakar också utsläpp utomlands genom vår konsumtion. Här inkluderas utsläpp från tillverkning och transport av importerade varor till svensk hushållskonsumtion, offentlig verksamhet och investeringar. Utsläpp från varor som produceras i Sverige och exporteras till andra länder räknas bort."
         },
         "step4": {
           "label": "Privat e-handel",
@@ -1620,27 +1622,25 @@
         },
         "step5": {
           "label": "Biogena utsläpp",
-          "text": "Till sist har vi biogena koldioxidutsläpp som frigörs när trä och annat biologiskt material förbränns, exempelvis i fjärrvärmen, i pappersindustrin och från bilar med biodrivmedel. Biogena utsläpp ingår i det naturliga kretsloppet. Det kan dock ta decennier för ny skog att binda samma mängd koldioxid, därför har även biogena utsläpp klimatpåverkan här och nu."
+          "text": "Till sist har vi biogena koldioxidutsläpp som frigörs när trä och annat biologiskt material förbränns. I teorin kan koldioxiden tas upp igen, exempelvis när nya träd planteras. Det kan dock ta flera decennier för ny skog att binda samma mängd koldioxid. Därför har även biogena utsläpp klimatpåverkan här och nu."
         }
       },
       "bathtub": {
         "eyebrow": "Badkarseffekten",
-        "text": "Atmosfären reagerar på mängden växthusgaser totalt – och de stannar kvar och ansamlas över tid. Lite som ett badkar, där kranen står på. Innan kranen dras åt helt, kommer vattennivån att fortsätta stiga. Och atmosfären har redan passerat gränsen för 1,5 graders uppvärmning. Därför är det avgörande viktigt hur snabbt vi minskar utsläppen ner mot noll.",
-        "question": "Hur har det gått med det sedan 1990?",
-        "waterCaptionPrefix": "Sverige har totalt släppt ut",
-        "waterCaptionSuffix": "sedan 1990",
+        "text": "Atmosfären reagerar på mängden växthusgaser – som stannar kvar och ansamlas över tid. Som ett badkar, där kranen står på. Tills kranen dras åt, kommer vattennivån att fortsätta stiga. Vi har redan passerat 1,5 graders uppvärmning och Sverige närmar oss gränsen då vi släppt ut mer än vårt åtagande enligt Parisavtalet. Därför är det avgörande hur snabbt vi minskar utsläppen.",
+        "question": "Hur har det gått sedan 1990?",
+        "waterCaptionPrefix": "Sverige har sedan 1990 släppt ut",
         "chunkCaptionSingleYear": "+{{value}} Mton CO₂e tillkom {{year}}",
         "chunkCaptionYearRange": "+{{value}} Mton CO₂e tillkom {{fromYear}}–{{toYear}}"
       },
       "graph": {
-        "territorialFossil": "Territoriella utsläpp",
+        "territorialFossil": "Territoriella",
         "productionBased": "Produktionsbaserade utsläpp",
-        "productionBeyondTerritorial": "Svensk sjöfart och flyg utomlands",
-        "biogenic": "Biogena utsläpp",
+        "productionBeyondTerritorial": "Produktionsbaserade",
+        "biogenic": "Biogena",
         "consumptionAbroad": "Konsumtionsbaserade utomlands"
       },
       "interlude": {
-        "eyebrow": "Insikt",
         "title": "Vi diskuterar bara en del av Sveriges utsläpp",
         "body": "Den vanliga siffran vi hör om ger en överdrivet positiv bild. Om vi räknar in även andra utsläpp som Sverige kan påverka får vi en mer heltäckande bild – som berättar en annan historia."
       },
@@ -1648,12 +1648,12 @@
         "layerCounter": "Lager {{current}} av {{total}}",
         "title": "Sveriges utsläpp sedan 1990",
         "layerCaption1": "Först har vi de territoriella utsläppen – fossila utsläpp inom Sveriges gränser.",
-        "layerCaption2": "Nu lägger vi till utsläpp från svensk sjöfart och flyg utomlands – tillsammans med de territoriella blir det de produktionsbaserade utsläppen.",
+        "layerCaption2": "Nu lägger vi till utsläpp från svenska rederier och flygbolag utomlands, tillsammans med de territoriella får vi då de produktionsbaserade utsläppen.",
         "layerCaption3": "Sedan lägger vi till de konsumtionsbaserade utsläppen utomlands, inklusive privat e-handelsimport.",
-        "layerCaption4": "Och slutligen de biogena utsläppen för att ge hela bilden."
+        "layerCaption4": "Och slutligen de biogena utsläppen för att ge hela bilden.",
+        "scrubHint": "Svep över grafen för att se värden per år"
       },
       "conclusion": {
-        "eyebrow": "Slutsats",
         "title": "Sveriges utsläpp är större än vad vi tror och har inte minskat så mycket som vi tror",
         "usualLabel": "Det vi vanligtvis diskuterar",
         "fullLabel": "Sveriges egentliga utsläpp",


### PR DESCRIPTION
## Summary

Mobile-focused polish pass on the Valet 2026 story page (`/sverige/valet-2026`), with several cross-cutting UX and copy improvements from founder feedback.

### Intro / hero
- Orange map fill now stays colored after the initial mount (removed the scroll-linked drain)
- Bigger silhouette on mobile; top padding scales with viewport height so short phones fit the whole hero
- Callout units stack below the numbers on mobile for symmetric columns
- Step 1 copy now opens with a bridge back to the hero figure ("Vi börjar med siffran vi oftast hör om…")

### Onion (emissions journey)
- Private e-commerce is now a real white layer included in the running total (previously a dashed decorative ring outside the sum), with a minimum visible ring width since 0.326 Mton would otherwise be sub-pixel
- Step label + copy moved below the onion on mobile, directly above the paragraph they describe
- Before the section pins, a pulsing seed dot waits where the first circle grows (was a stranded white "47 Mton"); label, copy and data note appear together with the first layer

### Stacked chart
- Mobile: full-bleed plot aligned with the text column (mirrored Y-axis labels painted above the fills), unit label above the chart, edge-anchored X ticks so 1990 renders, 0-tick dropped
- Mobile: no floating tooltip – the legend becomes a scrub readout (year, per-layer additions, total) with an at-rest "swipe to explore" hint
- Color glow behind the chart follows the layer being added; newest layer carries fill emphasis
- Chart height caps at 32svh for short phones

### Bathtub
- Two-row caption inside the water ("Sverige har sedan 1990 släppt" + value)
- Tub artwork scaled up around the caption text; height-capped per viewport so it fits all screens
- Section heading now uses the shared title token; more vertical breathing room
- Updated founder copy for the bathtub paragraph and question

### Page-wide
- "Slutsats"/"Insikt" eyebrows removed
- Unified line-height via type tokens (snug body, tight titles)
- Chevron hint: smaller, pulses instead of bouncing, "Svep"/"Scrolla" label, hides while actively scrolling and reappears when the page settles

## Test plan
- [ ] Walk the full story on mobile (~390px) and desktop widths
- [ ] Scrub the stacked chart on mobile; verify readout and 2.5s linger
- [ ] Verify onion step 4 shows the white ring and the tally sums to the final total
- [ ] Check hero, onion, chart and bathtub on a short viewport (iPhone SE 375x667)
- [ ] Verify chevron hides while scrolling and advances correctly through pinned scenes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches presentation of official vs full emissions (e-commerce in the onion total), many scroll-pin and auto-scroll behaviors, and public-facing election copy—not auth or backend, but UX regressions or narrative misreadings are the main risk.
> 
> **Overview**
> Polishes the Valet 2026 nation story (`/valet-2026`) for mobile and tightens scroll-driven scenes, copy, and how emissions layers are presented.
> 
> **Layout & page structure** — The story route now uses the same full-bleed main layout as the landing page (no container padding). The hero folds the former follow-up section into one viewport: larger map, intro-specific stat labels, and no scroll-linked drain on the orange fill. Section eyebrows are dropped in several places.
> 
> **Onion journey** — Private e-commerce becomes a **white ring layer counted in the running total** (replacing a dashed ring outside the sum), with a minimum ring width so tiny values stay visible. Layers **snap per scroll step** instead of scrubbing; totals animate with `AnimatedTotal`. Content is gated until the section pins (pulsing seed dot before the first layer). Mobile layout and tally visibility are adjusted; pinned scroll distances are shortened.
> 
> **Bathtub** — Water level **snaps to decade milestones** (1990 as baseline, `data-story-snap="round"`) instead of interpolating between steps. In-basin copy is two lines; tub art is zoomed with height caps. Scroll segment vh is reduced.
> 
> **Stacked chart** — On mobile: edge-to-edge plot, mirrored in-chart Y labels, scrub-driven **legend readout** (year, per-layer values, total) with a hint and 2.5s linger; no floating tooltip. Layer glow, shorter pin steps, and caption/height tweaks for small screens.
> 
> **Scroll hint** — Chevron advances using enter/exit vh and floor vs round snap so clicks don’t overshoot pinned zones. Smaller UI, pulse-only animation, “Svep”/“Scrolla” labels, hides while scrolling.
> 
> **Copy** — EN/SV strings updated across intro, journey, bathtub, graph labels, stacked scrub hint, and scroll hints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f9196191293fb22ba1d6ea2022d8cc10145968c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->